### PR TITLE
Config merge fix

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -230,8 +230,19 @@ void ConfigProcessor::merge(XMLDocumentPtr config, XMLDocumentPtr with)
     Node * config_root = getRootNode(config.get());
     Node * with_root = getRootNode(with.get());
 
-    if (config_root->nodeName() != with_root->nodeName())
-        throw Poco::Exception("Root element doesn't have the corresponding root element as the config file. It must be <" + config_root->nodeName() + ">");
+    std::string config_root_node_name = config_root->nodeName();
+    std::string merged_root_node_name = with_root->nodeName();
+
+    /// For compatibility, we treat 'yandex' and 'clickhouse' equivalent.
+    /// See https://clickhouse.com/blog/en/2021/clickhouse-inc/
+
+    if (config_root_node_name == merged_root_node_name
+        || ((config_root_node_name == "yandex" || config_root_node_name == "clickhouse")
+            && (merged_root_node_name == "yandex" || merged_root_node_name == "clickhouse")))
+    {
+        throw Poco::Exception("Root element doesn't have the corresponding root element as the config file."
+            " It must be <" + config_root->nodeName() + ">");
+    }
 
     mergeRecursive(config, config_root, with_root);
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed issue with merging configs that have `<yandex>` and `<clickhouse>` root XML tags. (backport of https://github.com/ClickHouse/ClickHouse/commit/213ecaedde9c5e5961ef6d809914efae241698f0)
