### PR TITLE
Fixed default root tag from <clickhouse> back to <yandex>

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -495,12 +495,12 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                 {
                     std::string data_file = config_d / "data-paths.xml";
                     WriteBufferFromFile out(data_file);
-                    out << "<clickhouse>\n"
+                    out << "<yandex>\n"
                     "    <path>" << data_path.string() << "</path>\n"
                     "    <tmp_path>" << (data_path / "tmp").string() << "</tmp_path>\n"
                     "    <user_files_path>" << (data_path / "user_files").string() << "</user_files_path>\n"
                     "    <format_schema_path>" << (data_path / "format_schemas").string() << "</format_schema_path>\n"
-                    "</clickhouse>\n";
+                    "</yandex>\n";
                     out.sync();
                     out.finalize();
                     fmt::print("Data path configuration override is saved to file {}.\n", data_file);
@@ -510,12 +510,12 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                 {
                     std::string logger_file = config_d / "logger.xml";
                     WriteBufferFromFile out(logger_file);
-                    out << "<clickhouse>\n"
+                    out << "<yandex>\n"
                     "    <logger>\n"
                     "        <log>" << (log_path / "clickhouse-server.log").string() << "</log>\n"
                     "        <errorlog>" << (log_path / "clickhouse-server.err.log").string() << "</errorlog>\n"
                     "    </logger>\n"
-                    "</clickhouse>\n";
+                    "</yandex>\n";
                     out.sync();
                     out.finalize();
                     fmt::print("Log path configuration override is saved to file {}.\n", logger_file);
@@ -525,13 +525,13 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                 {
                     std::string user_directories_file = config_d / "user-directories.xml";
                     WriteBufferFromFile out(user_directories_file);
-                    out << "<clickhouse>\n"
+                    out << "<yandex>\n"
                     "    <user_directories>\n"
                     "        <local_directory>\n"
                     "            <path>" << (data_path / "access").string() << "</path>\n"
                     "        </local_directory>\n"
                     "    </user_directories>\n"
-                    "</clickhouse>\n";
+                    "</yandex>\n";
                     out.sync();
                     out.finalize();
                     fmt::print("User directory path configuration override is saved to file {}.\n", user_directories_file);
@@ -541,7 +541,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                 {
                     std::string openssl_file = config_d / "openssl.xml";
                     WriteBufferFromFile out(openssl_file);
-                    out << "<clickhouse>\n"
+                    out << "<yandex>\n"
                     "    <openSSL>\n"
                     "        <server>\n"
                     "            <certificateFile>" << (config_dir / "server.crt").string() << "</certificateFile>\n"
@@ -549,7 +549,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                     "            <dhParamsFile>" << (config_dir / "dhparam.pem").string() << "</dhParamsFile>\n"
                     "        </server>\n"
                     "    </openSSL>\n"
-                    "</clickhouse>\n";
+                    "</yandex>\n";
                     out.sync();
                     out.finalize();
                     fmt::print("OpenSSL path configuration override is saved to file {}.\n", openssl_file);
@@ -716,25 +716,25 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
                 hash_hex.resize(64);
                 for (size_t i = 0; i < 32; ++i)
                     writeHexByteLowercase(hash[i], &hash_hex[2 * i]);
-                out << "<clickhouse>\n"
+                out << "<yandex>\n"
                     "    <users>\n"
                     "        <default>\n"
                     "            <password remove='1' />\n"
                     "            <password_sha256_hex>" << hash_hex << "</password_sha256_hex>\n"
                     "        </default>\n"
                     "    </users>\n"
-                    "</clickhouse>\n";
+                    "</yandex>\n";
                 out.sync();
                 out.finalize();
                 fmt::print(HILITE "Password for default user is saved in file {}." END_HILITE "\n", password_file);
 #else
-                out << "<clickhouse>\n"
+                out << "<yandex>\n"
                     "    <users>\n"
                     "        <default>\n"
                     "            <password><![CDATA[" << password << "]]></password>\n"
                     "        </default>\n"
                     "    </users>\n"
-                    "</clickhouse>\n";
+                    "</yandex>\n";
                 out.sync();
                 out.finalize();
                 fmt::print(HILITE "Password for default user is saved in plaintext in file {}." END_HILITE "\n", password_file);
@@ -778,9 +778,9 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
             {
                 std::string listen_file = config_d / "listen.xml";
                 WriteBufferFromFile out(listen_file);
-                out << "<clickhouse>\n"
+                out << "<yandex>\n"
                     "    <listen_host>::</listen_host>\n"
-                    "</clickhouse>\n";
+                    "</yandex>\n";
                 out.sync();
                 out.finalize();
                 fmt::print("The choice is saved in file {}.\n", listen_file);

--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -230,8 +230,19 @@ void ConfigProcessor::merge(XMLDocumentPtr config, XMLDocumentPtr with)
     Node * config_root = getRootNode(config.get());
     Node * with_root = getRootNode(with.get());
 
-    if (config_root->nodeName() != with_root->nodeName())
-        throw Poco::Exception("Root element doesn't have the corresponding root element as the config file. It must be <" + config_root->nodeName() + ">");
+    std::string config_root_node_name = config_root->nodeName();
+    std::string merged_root_node_name = with_root->nodeName();
+
+    /// For compatibility, we treat 'yandex' and 'clickhouse' equivalent.
+    /// See https://clickhouse.com/blog/en/2021/clickhouse-inc/
+
+    if (config_root_node_name != merged_root_node_name
+        && !((config_root_node_name == "yandex" || config_root_node_name == "clickhouse")
+            && (merged_root_node_name == "yandex" || merged_root_node_name == "clickhouse")))
+    {
+        throw Poco::Exception("Root element doesn't have the corresponding root element as the config file."
+            " It must be <" + config_root->nodeName() + ">");
+    }
 
     mergeRecursive(config, config_root, with_root);
 }


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed default root tag from `<clickhouse>` back to `<yandex>` for configs generated on installation.
...
