### PR TITLE
allow `v22.3.x.y-altinitystable` git tags

### DIFF
--- a/tests/ci/git_helper.py
+++ b/tests/ci/git_helper.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 # \A and \Z match only start and end of the whole string
 RELEASE_BRANCH_REGEXP = r"\A\d+[.]\d+\Z"
 TAG_REGEXP = (
-    r"\Av\d{2}[.][1-9]\d*[.][1-9]\d*[.][1-9]\d*-(testing|prestable|stable|lts)\Z"
+    r"\Av\d{2}[.][1-9]\d*[.][1-9]\d*[.][1-9]\d*-(testing|prestable|stable|lts|altinitystable)\Z"
 )
 SHA_REGEXP = r"\A([0-9]|[a-f]){40}\Z"
 

--- a/tests/ci/git_test.py
+++ b/tests/ci/git_test.py
@@ -57,6 +57,9 @@ class TestGit(unittest.TestCase):
                 with self.assertRaises(Exception):
                     setattr(self.git, tag_attr, tag)
 
+    def check_tag(self):
+        self.git.check_tag("v21.12.333.4567-altinitystable")
+
     def test_tweak(self):
         self.git.commits_since_tag = 0
         self.assertEqual(self.git.tweak, 1)
@@ -66,3 +69,6 @@ class TestGit(unittest.TestCase):
         self.assertEqual(self.git.tweak, 22224)
         self.git.commits_since_tag = 0
         self.assertEqual(self.git.tweak, 22222)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
allow `v22.3.x.y-altinitystable` git tags
...