### PR TITLE
Attempt to fix integration tests

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -74,7 +74,7 @@ RUN python3 -m pip install \
     kazoo \
     lz4 \
     minio \
-    protobuf \
+    protobuf==3.20 \
     psycopg2-binary==2.8.6 \
     pymongo==3.11.0 \
     pytest \

--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -74,7 +74,7 @@ RUN python3 -m pip install \
     kazoo \
     lz4 \
     minio \
-    protobuf==3.20 \
+    protobuf==3.19 \
     psycopg2-binary==2.8.6 \
     pymongo==3.11.0 \
     pytest \

--- a/docker/test/stateful/Dockerfile
+++ b/docker/test/stateful/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update -y \
     && env DEBIAN_FRONTEND=noninteractive \
         apt-get install --yes --no-install-recommends \
         python3-requests \
-        llvm-9
+        llvm-9 \
+        rpm2cpio \
+        cpio
 
 COPY s3downloader /s3downloader
 

--- a/tests/ci/compatibility_check.py
+++ b/tests/ci/compatibility_check.py
@@ -24,8 +24,8 @@ from clickhouse_helper import (
 from stopwatch import Stopwatch
 from rerun_helper import RerunHelper
 
-IMAGE_UBUNTU = "clickhouse/test-old-ubuntu"
-IMAGE_CENTOS = "clickhouse/test-old-centos"
+IMAGE_UBUNTU = "altinityinfra/test-old-ubuntu"
+IMAGE_CENTOS = "altinityinfra/test-old-centos"
 MAX_GLIBC_VERSION = "2.4"
 DOWNLOAD_RETRIES_COUNT = 5
 CHECK_NAME = "Compatibility check (actions)"

--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -30,17 +30,17 @@ from tee_popen import TeePopen
 # When update, update
 # integration/ci-runner.py:ClickhouseIntegrationTestsRunner.get_images_names too
 IMAGES = [
-    "clickhouse/integration-tests-runner",
-    "clickhouse/mysql-golang-client",
-    "clickhouse/mysql-java-client",
-    "clickhouse/mysql-js-client",
-    "clickhouse/mysql-php-client",
-    "clickhouse/postgresql-java-client",
-    "clickhouse/integration-test",
-    "clickhouse/kerberos-kdc",
-    "clickhouse/kerberized-hadoop",
-    "clickhouse/integration-helper",
-    "clickhouse/dotnet-client",
+    "altinityinfra/integration-tests-runner",
+    "altinityinfra/mysql-golang-client",
+    "altinityinfra/mysql-java-client",
+    "altinityinfra/mysql-js-client",
+    "altinityinfra/mysql-php-client",
+    "altinityinfra/postgresql-java-client",
+    "altinityinfra/integration-test",
+    "altinityinfra/kerberos-kdc",
+    "altinityinfra/kerberized-hadoop",
+    "altinityinfra/integration-helper",
+    "altinityinfra/dotnet-client",
 ]
 
 

--- a/tests/ci/unit_tests_check.py
+++ b/tests/ci/unit_tests_check.py
@@ -25,7 +25,7 @@ from rerun_helper import RerunHelper
 from tee_popen import TeePopen
 
 
-IMAGE_NAME = "clickhouse/unit-test"
+IMAGE_NAME = "altinityinfra/unit-test"
 
 
 def get_test_name(line):

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -256,17 +256,17 @@ class ClickhouseIntegrationTestsRunner:
     @staticmethod
     def get_images_names():
         return [
-            "clickhouse/dotnet-client",
-            "clickhouse/integration-helper",
-            "clickhouse/integration-test",
-            "clickhouse/integration-tests-runner",
-            "clickhouse/kerberized-hadoop",
-            "clickhouse/kerberos-kdc",
-            "clickhouse/mysql-golang-client",
-            "clickhouse/mysql-java-client",
-            "clickhouse/mysql-js-client",
-            "clickhouse/mysql-php-client",
-            "clickhouse/postgresql-java-client",
+            "altinityinfra/dotnet-client",
+            "altinityinfra/integration-helper",
+            "altinityinfra/integration-test",
+            "altinityinfra/integration-tests-runner",
+            "altinityinfra/kerberized-hadoop",
+            "altinityinfra/kerberos-kdc",
+            "altinityinfra/mysql-golang-client",
+            "altinityinfra/mysql-java-client",
+            "altinityinfra/mysql-js-client",
+            "altinityinfra/mysql-php-client",
+            "altinityinfra/postgresql-java-client",
         ]
 
     def _can_run_with(self, path, opt):
@@ -463,7 +463,7 @@ class ClickhouseIntegrationTestsRunner:
             "--docker-image-version",
         ):
             for img in self.get_images_names():
-                if img == "clickhouse/integration-tests-runner":
+                if img == "altinityinfra/integration-tests-runner":
                     runner_version = self.get_single_image_version()
                     logging.info(
                         "Can run with custom docker image version %s", runner_version

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -689,7 +689,7 @@ class ClickHouseCluster:
             binary_path = binary_path[: -len("-server")]
 
         env_variables["keeper_binary"] = binary_path
-        env_variables["image"] = "clickhouse/integration-test:" + self.docker_base_tag
+        env_variables["image"] = "altinityinfra/integration-test:" + self.docker_base_tag
         env_variables["user"] = str(os.getuid())
         env_variables["keeper_fs"] = "bind"
         for i in range(1, 4):
@@ -1169,7 +1169,7 @@ class ClickHouseCluster:
         with_hive=False,
         hostname=None,
         env_variables=None,
-        image="clickhouse/integration-test",
+        image="altinityinfra/integration-test",
         tag=None,
         stay_alive=False,
         ipv4_address=None,
@@ -2643,7 +2643,7 @@ class ClickHouseInstance:
         copy_common_configs=True,
         hostname=None,
         env_variables=None,
-        image="clickhouse/integration-test",
+        image="altinityinfra/integration-test",
         tag="latest",
         stay_alive=False,
         ipv4_address=None,

--- a/tests/integration/runner
+++ b/tests/integration/runner
@@ -19,7 +19,7 @@ CONFIG_DIR_IN_REPO = "programs/server"
 INTERGATION_DIR_IN_REPO = "tests/integration"
 SRC_DIR_IN_REPO = "src"
 
-DIND_INTEGRATION_TESTS_IMAGE_NAME = "clickhouse/integration-tests-runner"
+DIND_INTEGRATION_TESTS_IMAGE_NAME = "altinityinfra/integration-tests-runner"
 
 def check_args_and_update_paths(args):
     if args.clickhouse_root:
@@ -224,23 +224,23 @@ if __name__ == "__main__":
     if args.docker_compose_images_tags is not None:
         for img_tag in args.docker_compose_images_tags:
             [image, tag] = img_tag.split(":")
-            if image == "clickhouse/mysql-golang-client":
+            if image == "altinityinfra/mysql-golang-client":
                 env_tags += "-e {}={} ".format("DOCKER_MYSQL_GOLANG_CLIENT_TAG", tag)
-            elif image == "clickhouse/dotnet-client":
+            elif image == "altinityinfra/dotnet-client":
                 env_tags += "-e {}={} ".format("DOCKER_DOTNET_CLIENT_TAG", tag)
-            elif image == "clickhouse/mysql-java-client":
+            elif image == "altinityinfra/mysql-java-client":
                 env_tags += "-e {}={} ".format("DOCKER_MYSQL_JAVA_CLIENT_TAG", tag)
-            elif image == "clickhouse/mysql-js-client":
+            elif image == "altinityinfra/mysql-js-client":
                 env_tags += "-e {}={} ".format("DOCKER_MYSQL_JS_CLIENT_TAG", tag)
-            elif image == "clickhouse/mysql-php-client":
+            elif image == "altinityinfra/mysql-php-client":
                 env_tags += "-e {}={} ".format("DOCKER_MYSQL_PHP_CLIENT_TAG", tag)
-            elif image == "clickhouse/postgresql-java-client":
+            elif image == "altinityinfra/postgresql-java-client":
                 env_tags += "-e {}={} ".format("DOCKER_POSTGRESQL_JAVA_CLIENT_TAG", tag)
-            elif image == "clickhouse/integration-test":
+            elif image == "altinityinfra/integration-test":
                 env_tags += "-e {}={} ".format("DOCKER_BASE_TAG", tag)
-            elif image == "clickhouse/kerberized-hadoop":
+            elif image == "altinityinfra/kerberized-hadoop":
                 env_tags += "-e {}={} ".format("DOCKER_KERBERIZED_HADOOP_TAG", tag)
-            elif image == "clickhouse/kerberos-kdc":
+            elif image == "altinityinfra/kerberos-kdc":
                 env_tags += "-e {}={} ".format("DOCKER_KERBEROS_KDC_TAG", tag)
             else:
                 logging.info("Unknown image %s" % (image))

--- a/tests/integration/test_storage_kafka/test.py
+++ b/tests/integration/test_storage_kafka/test.py
@@ -30,11 +30,23 @@ from kafka.protocol.admin import DescribeGroupsRequest_v1
 from kafka.protocol.group import MemberAssignment
 from kafka.admin import NewTopic
 
+from pathlib import Path
+from helpers.cluster import run_and_check
 
 # protoc --version
 # libprotoc 3.0.0
 # # to create kafka_pb2.py
 # protoc --python_out=. kafka.proto
+
+# Regenerate _pb2 files on each run, to make sure test doesn't depend installed protobuf version
+proto_dir = Path(__file__).parent / "clickhouse_path/format_schemas"
+gen_dir = Path(__file__).parent
+gen_dir.mkdir(exist_ok=True)
+run_and_check(
+    f"python3 -m grpc_tools.protoc -I{proto_dir!s} --python_out={gen_dir!s} --grpc_python_out={gen_dir!s} \
+    {proto_dir!s}/kafka.proto",
+    shell=True,
+)
 
 from . import kafka_pb2
 from . import social_pb2


### PR DESCRIPTION
Changelog category (leave one):
- Build/Testing/Packaging Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Pinned protobuf version in Dockerfile of integration tests runner


This is for compatibility with existing generated files, currently integration stage fails with:
```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```
https://s3.amazonaws.com/altinity-build-artifacts/142/5b2ab8fe52ea5dc300ced61fb92bea474b133ff2/integration_tests__release__actions__[1/2]/main_script_log.txt