### PR TITLE
Remove rerun helper from integ tests as well

### DIFF
--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -146,10 +146,12 @@ if __name__ == "__main__":
 
     gh = Github(get_best_robot_token())
 
-    rerun_helper = RerunHelper(gh, pr_info, check_name_with_group)
-    if rerun_helper.is_already_finished_by_status():
-        logging.info("Check is already finished according to github status, exiting")
-        sys.exit(0)
+    # Always re-run, even if it finished in previous run.
+    # gh = Github(get_best_robot_token())
+    # rerun_helper = RerunHelper(gh, pr_info, check_name_with_group)
+    # if rerun_helper.is_already_finished_by_status():
+    #     logging.info("Check is already finished according to github status, exiting")
+    #     sys.exit(0)
 
     images = get_images_with_versions(reports_path, IMAGES)
     images_with_versions = {i.name: i.version for i in images}


### PR DESCRIPTION
Changelog category (leave one):
- New Feature
- Improvement
- Bug Fix (user-visible misbehaviour in official stable or prestable release)
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
