### PR TITLE
Use gh-data.checks table instead of default.checks for docker_server

### DIFF
--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -357,7 +357,7 @@ def main():
         NAME,
     )
     ch_helper = ClickHouseHelper()
-    ch_helper.insert_events_into(db="default", table="checks", events=prepared_events)
+    ch_helper.insert_events_into(db="gh-data", table="checks", events=prepared_events)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
IIRC, DockerServerImages wasn't in the pipeline before. For some reason, it's being run now. Since it was not being executed, we never paid attention to the table it was trying to insert events into. This PR sets the proper table.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
