### PR TITLE
Tuned CI/CD for FIPs build

### DIFF
--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -3,26 +3,6 @@
 ARG FROM_TAG=latest
 FROM altinityinfra/test-util:$FROM_TAG
 
-# Rust toolchain and libraries
-ENV RUSTUP_HOME=/rust/rustup
-ENV CARGO_HOME=/rust/cargo
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-RUN chmod 777 -R /rust
-ENV PATH="/rust/cargo/env:${PATH}"
-ENV PATH="/rust/cargo/bin:${PATH}"
-RUN rustup target add aarch64-unknown-linux-gnu && \
-        rustup target add x86_64-apple-darwin && \
-        rustup target add x86_64-unknown-freebsd && \
-        rustup target add aarch64-apple-darwin && \
-        rustup target add powerpc64le-unknown-linux-gnu
-RUN apt-get install \
-        gcc-aarch64-linux-gnu \
-        build-essential \
-        libc6 \
-        libc6-dev \
-        libc6-dev-arm64-cross \
-        --yes
-
 # Install CMake 3.20+ for Rust compilation
 # Used https://askubuntu.com/a/1157132 as reference
 RUN apt purge cmake --yes

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -3,6 +3,53 @@
 ARG FROM_TAG=latest
 FROM altinityinfra/test-util:$FROM_TAG
 
+# Rust toolchain and libraries
+ENV RUSTUP_HOME=/rust/rustup
+ENV CARGO_HOME=/rust/cargo
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN chmod 777 -R /rust
+ENV PATH="/rust/cargo/env:${PATH}"
+ENV PATH="/rust/cargo/bin:${PATH}"
+RUN rustup target add aarch64-unknown-linux-gnu && \
+        rustup target add x86_64-apple-darwin && \
+        rustup target add x86_64-unknown-freebsd && \
+        rustup target add aarch64-apple-darwin && \
+        rustup target add powerpc64le-unknown-linux-gnu
+RUN apt-get install \
+        gcc-aarch64-linux-gnu \
+        build-essential \
+        libc6 \
+        libc6-dev \
+        libc6-dev-arm64-cross \
+        --yes
+
+# Install CMake 3.20+ for Rust compilation
+# Used https://askubuntu.com/a/1157132 as reference
+RUN apt purge cmake --yes
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
+RUN apt update && apt install cmake --yes
+RUN wget https://apt.llvm.org/llvm.sh \
+    && chmod +x llvm.sh \
+    && ./llvm.sh 14
+
+
+# Install Docker
+ENV DOCKER_CHANNEL stable
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -c -s) ${DOCKER_CHANNEL}"
+
+RUN apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+        docker-ce \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /var/cache/debconf \
+        /tmp/* \
+    && apt-get clean
+
+RUN dockerd --version; docker --version
+
 ENV CC=clang-${LLVM_VERSION}
 ENV CXX=clang++-${LLVM_VERSION}
 
@@ -46,7 +93,7 @@ RUN apt-get install binutils-riscv64-linux-gnu
 
 # Architecture of the image when BuildKit/buildx is used
 ARG TARGETARCH
-ARG NFPM_VERSION=2.18.1
+ARG NFPM_VERSION=2.20.0
 
 RUN arch=${TARGETARCH:-amd64} \
   && curl -Lo /tmp/nfpm.deb "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${arch}.deb" \
@@ -64,23 +111,12 @@ ENV PATH="$PATH:/usr/local/go/bin"
 ENV GOPATH=/workdir/go
 ENV GOCACHE=/workdir/
 
+RUN curl https://raw.githubusercontent.com/matus-chochlik/ctcache/7fd516e91c17779cbc6fc18bd119313d9532dd90/clang-tidy-cache -Lo /usr/bin/clang-tidy-cache \
+  && chmod +x /usr/bin/clang-tidy-cache
+
 RUN mkdir /workdir && chmod 777 /workdir
 WORKDIR /workdir
 
-# NOTE: thread sanitizer is broken in clang-14, we have to build it with clang-15
-# https://github.com/ClickHouse/ClickHouse/pull/39450
-# https://github.com/google/sanitizers/issues/1540
-# https://github.com/google/sanitizers/issues/1552
-
-RUN export CODENAME="$(lsb_release --codename --short | tr 'A-Z' 'a-z')" \
-    && echo "deb [trusted=yes] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-15 main" >> \
-        /etc/apt/sources.list.d/clang.list \
-    && apt-get update \
-    && apt-get install \
-        clang-15 \
-        clang-tidy-15 \
-        --yes --no-install-recommends \
-    && apt-get clean
-
 COPY build.sh /
+
 CMD ["bash", "-c", "/build.sh 2>&1"]

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -95,5 +95,6 @@ RUN mkdir /workdir && chmod 777 /workdir
 WORKDIR /workdir
 
 COPY build.sh /
+COPY daemon.json /etc/docker/
 
 CMD ["bash", "-c", "/build.sh 2>&1"]

--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -9,9 +9,6 @@ RUN apt purge cmake --yes
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
 RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
 RUN apt update && apt install cmake --yes
-RUN wget https://apt.llvm.org/llvm.sh \
-    && chmod +x llvm.sh \
-    && ./llvm.sh 14
 
 
 # Install Docker

--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -1,4 +1,36 @@
 #!/usr/bin/env bash
+
+set -e
+
+mkdir -p /etc/docker/
+echo '{
+    "ipv6": true,
+    "fixed-cidr-v6": "fd00::/8",
+    "ip-forward": true,
+    "log-level": "debug",
+    "insecure-registries" : ["dockerhub-proxy.dockerhub-proxy-zone:5000"],
+    "registry-mirrors" : ["http://dockerhub-proxy.dockerhub-proxy-zone:5000"]
+}' | dd of=/etc/docker/daemon.json 2>/dev/null
+
+# In case of test hung it is convenient to use pytest --pdb to debug it,
+# and on hung you can simply press Ctrl-C and it will spawn a python pdb,
+# but on SIGINT dockerd will exit, so ignore it to preserve the daemon.
+trap '' INT
+dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 --default-address-pool base=172.17.0.0/12,size=24 &
+
+set +e
+reties=0
+while true; do
+    docker info &>/dev/null && break
+    reties=$((reties+1))
+    if [[ $reties -ge 100 ]]; then # 10 sec max
+        echo "Can't start docker daemon, timeout exceeded." >&2
+        exit 1;
+    fi
+    sleep 0.1
+done
+set -e
+
 set -x -e
 
 exec &> >(ts)

--- a/docker/packager/binary/build.sh
+++ b/docker/packager/binary/build.sh
@@ -2,16 +2,6 @@
 
 set -e
 
-mkdir -p /etc/docker/
-echo '{
-    "ipv6": true,
-    "fixed-cidr-v6": "fd00::/8",
-    "ip-forward": true,
-    "log-level": "debug",
-    "insecure-registries" : ["dockerhub-proxy.dockerhub-proxy-zone:5000"],
-    "registry-mirrors" : ["http://dockerhub-proxy.dockerhub-proxy-zone:5000"]
-}' | dd of=/etc/docker/daemon.json 2>/dev/null
-
 # In case of test hung it is convenient to use pytest --pdb to debug it,
 # and on hung you can simply press Ctrl-C and it will spawn a python pdb,
 # but on SIGINT dockerd will exit, so ignore it to preserve the daemon.

--- a/docker/packager/binary/daemon.json
+++ b/docker/packager/binary/daemon.json
@@ -1,0 +1,8 @@
+{
+  "ipv6": true,
+  "fixed-cidr-v6": "fd00::/8",
+  "ip-forward": true,
+  "log-level": "debug",
+  "insecure-registries" : ["dockerhub-proxy.dockerhub-proxy-zone:5000"],
+  "registry-mirrors" : ["http://dockerhub-proxy.dockerhub-proxy-zone:5000"]
+}

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -143,9 +143,6 @@ def parse_env_variables(
     is_cross_ppc = compiler.endswith(PPC_SUFFIX)
     is_cross_freebsd = compiler.endswith(FREEBSD_SUFFIX)
 
-    cmake_flags.append("-DLINKER_NAME=/usr/lib/llvm-14/bin/ld.lld")
-    cmake_flags.append("-DFIPS_CLICKHOUSE=ON")
-
     if is_cross_darwin:
         cc = compiler[: -len(DARWIN_SUFFIX)]
         cmake_flags.append("-DCMAKE_AR:FILEPATH=/cctools/bin/x86_64-apple-darwin-ar")
@@ -195,7 +192,7 @@ def parse_env_variables(
         result.append("DEB_ARCH=amd64")
 
     if fips:
-        cmake_flags.append("-DLINKER_NAME=/usr/lib/llvm-15/bin/ld.lld")
+        cmake_flags.append("-DLINKER_NAME=/usr/lib/llvm-14/bin/ld.lld")
         cmake_flags.append("-DFIPS_CLICKHOUSE=ON")
 
     cxx = cc.replace("gcc", "g++").replace("clang", "clang++")

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -89,6 +89,7 @@ def run_docker_image_with_env(
     else:
         user = f"{os.geteuid()}:{os.getegid()}"
 
+    # Added v /var/run/docker.sock:/var/run/docker.sock, required for docker-in-docker to build BoringSSL in FIPS mode.
     cmd = (
         f"docker run -v /var/run/docker.sock:/var/run/docker.sock --network=host --user={user} --rm --volume={output}:/output "
         f"--volume={ch_root}:/build --volume={ccache_dir}:/ccache {env_part} "

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -90,7 +90,7 @@ def run_docker_image_with_env(
         user = f"{os.geteuid()}:{os.getegid()}"
 
     cmd = (
-        f"docker run --network=host --user={user} --rm --volume={output}:/output "
+        f"docker run -v /var/run/docker.sock:/var/run/docker.sock --network=host --user={user} --rm --volume={output}:/output "
         f"--volume={ch_root}:/build --volume={ccache_dir}:/ccache {env_part} "
         f"{interactive} {image_name}:{docker_image_version}"
     )
@@ -124,6 +124,7 @@ def parse_env_variables(
     additional_pkgs,
     with_coverage,
     with_binaries,
+    fips,
 ):
     DARWIN_SUFFIX = "-darwin"
     DARWIN_ARM_SUFFIX = "-darwin-aarch64"
@@ -141,6 +142,9 @@ def parse_env_variables(
     is_cross_arm = compiler.endswith(ARM_SUFFIX)
     is_cross_ppc = compiler.endswith(PPC_SUFFIX)
     is_cross_freebsd = compiler.endswith(FREEBSD_SUFFIX)
+
+    cmake_flags.append("-DLINKER_NAME=/usr/lib/llvm-14/bin/ld.lld")
+    cmake_flags.append("-DFIPS_CLICKHOUSE=ON")
 
     if is_cross_darwin:
         cc = compiler[: -len(DARWIN_SUFFIX)]
@@ -189,6 +193,10 @@ def parse_env_variables(
     else:
         cc = compiler
         result.append("DEB_ARCH=amd64")
+
+    if fips:
+        cmake_flags.append("-DLINKER_NAME=/usr/lib/llvm-15/bin/ld.lld")
+        cmake_flags.append("-DFIPS_CLICKHOUSE=ON")
 
     cxx = cc.replace("gcc", "g++").replace("clang", "clang++")
 
@@ -376,6 +384,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--as-root", action="store_true", help="if the container should run as root"
     )
+    parser.add_argument(
+        "--fips", action="store_true", help="enbale FIPS build", default=False
+    )
 
     args = parser.parse_args()
 
@@ -412,6 +423,7 @@ if __name__ == "__main__":
         args.additional_pkgs,
         args.with_coverage,
         args.with_binaries,
+        args.fips,
     )
 
     pre_build(args.clickhouse_repo_path, env_prepared)

--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -63,7 +63,7 @@ def get_packager_cmd(
     comp = build_config["compiler"]
     cmd = (
         f"cd {packager_path} && ./packager --output-dir={output_path} "
-        f"--package-type={package_type} --compiler={comp} --fips"
+        f"--package-type={package_type} --compiler={comp} --fips --as-root"
     )
 
     if build_config["build_type"]:

--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -63,7 +63,7 @@ def get_packager_cmd(
     comp = build_config["compiler"]
     cmd = (
         f"cd {packager_path} && ./packager --output-dir={output_path} "
-        f"--package-type={package_type} --compiler={comp}"
+        f"--package-type={package_type} --compiler={comp} --fips"
     )
 
     if build_config["build_type"]:


### PR DESCRIPTION
This enables building via workflows of FIPS build (with BoringSSL)
Changes:
- Different Docker image for building (installed Docker-in-Docker)
- Additional flags for packager