### PR TITLE
22.8 Backport of #41483 Fix nullptr dereference in DB::VolumeJBOD::reserve

### DIFF
--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -71,6 +71,7 @@ public:
     virtual const String & getName() const = 0;
 
     /// Reserve the specified number of bytes.
+    /// Returns valid reservation or nullptr when failure.
     virtual ReservationPtr reserve(UInt64 bytes) = 0;
 
     virtual ~Space() = default;

--- a/src/Disks/VolumeJBOD.h
+++ b/src/Disks/VolumeJBOD.h
@@ -82,6 +82,9 @@ private:
         ReservationPtr reserve(uint64_t bytes)
         {
             ReservationPtr reservation = disk->reserve(bytes);
+            if (!reservation)
+                return {};
+
             /// Not just subtract bytes, but update the value,
             /// since some reservations may be done directly via IDisk, or not by ClickHouse.
             free_size = reservation->getUnreservedSpace();


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in official stable or prestable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible server crash when using the JBOD feature. This fixes #41365

Original PR: #41483