### PR TITLE
Keeper in fips mode

### DIFF
--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -168,6 +168,13 @@ KeeperServer::KeeperServer(
     if (coordination_settings->quorum_reads)
         LOG_WARNING(log, "Quorum reads enabled, Keeper will work slower.");
 
+#if USE_SSL
+    if (FIPS_mode())
+    {
+        LOG_INFO(log, "Starting in FIPS mode, KAT test result: {}", BORINGSSL_self_test());
+    }
+#endif
+
     keeper_context->digest_enabled = config.getBool("keeper_server.digest_enabled", false);
     keeper_context->ignore_system_path_on_startup = config.getBool("keeper_server.ignore_system_path_on_startup", false);
 


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Better SSL configuration of Keeper (should match capabilities of CH server). Writing to a log if Keeper starts in FIPS mode.