### PR TITLE
Bumped Go version to get some CVE fixes

### DIFF
--- a/docker/packager/binary/Dockerfile
+++ b/docker/packager/binary/Dockerfile
@@ -53,7 +53,7 @@ RUN arch=${TARGETARCH:-amd64} \
   && dpkg -i /tmp/nfpm.deb \
   && rm /tmp/nfpm.deb
 
-ARG GO_VERSION=1.18.3
+ARG GO_VERSION=1.19.8
 # We need go for clickhouse-diagnostics
 RUN arch=${TARGETARCH:-amd64} \
   && curl -Lo /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" \


### PR DESCRIPTION
### Changelog category (leave one):
- Security fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Building `clickhouse-diagnostics` against Golang 1.19.8 in order to get CVE fixes :

pkg:golang/stdlib@1.19.5

    ✗ HIGH CVE-2022-41725 [Uncontrolled Resource Consumption]
      https://dso.docker.com/cve/CVE-2022-41725
      Affected range : <1.19.6
      Fixed version  : 1.19.6
      CVSS Score     : 7.5
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H

    ✗ HIGH CVE-2022-41724 [Uncontrolled Resource Consumption]
      https://dso.docker.com/cve/CVE-2022-41724
      Affected range : <1.19.6
      Fixed version  : 1.19.6
      CVSS Score     : 7.5
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H

    ✗ HIGH CVE-2022-41723 [Uncontrolled Resource Consumption]
      https://dso.docker.com/cve/CVE-2022-41723
      Affected range : <1.19.6
      Fixed version  : 1.19.6
      CVSS Score     : 7.5
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H

    ✗ HIGH CVE-2022-41722 [Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')]
      https://dso.docker.com/cve/CVE-2022-41722
      Affected range : <1.19.6
      Fixed version  : 1.19.6
      CVSS Score     : 7.5
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N

    ✗ MEDIUM CVE-2023-24532 [Incorrect Calculation]
      https://dso.docker.com/cve/CVE-2023-24532
      Affected range : <1.19.7
      Fixed version  : 1.19.7
      CVSS Score     : 5.3
      CVSS Vector    : CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N

    ✗ UNSPECIFIED CVE-2023-24538 [Improper Control of Generation of Code ('Code Injection')]
      https://dso.docker.com/cve/CVE-2023-24538
      Affected range : <1.19.8
      Fixed version  : 1.19.8

    ✗ UNSPECIFIED CVE-2023-24537 [Loop with Unreachable Exit Condition ('Infinite Loop')]
      https://dso.docker.com/cve/CVE-2023-24537
      Affected range : <1.19.8
      Fixed version  : 1.19.8

    ✗ UNSPECIFIED CVE-2023-24536 [Uncontrolled Resource Consumption]
      https://dso.docker.com/cve/CVE-2023-24536
      Affected range : <1.19.8
      Fixed version  : 1.19.8

    ✗ UNSPECIFIED CVE-2023-24534 [Uncontrolled Resource Consumption]
      https://dso.docker.com/cve/CVE-2023-24534
      Affected range : <1.19.8
      Fixed version  : 1.19.8
