### PR TITLE
Do not install clickhouse-diagnostics

### DIFF
--- a/packages/clickhouse-common-static.yaml
+++ b/packages/clickhouse-common-static.yaml
@@ -33,8 +33,9 @@ deb:
 contents:
 - src: root/usr/bin/clickhouse
   dst: /usr/bin/clickhouse
-- src: root/usr/bin/clickhouse-diagnostics
-  dst: /usr/bin/clickhouse-diagnostics
+# Excluded due to CVEs in go runtime that popup constantly
+# - src: root/usr/bin/clickhouse-diagnostics
+#   dst: /usr/bin/clickhouse-diagnostics
 - src: root/usr/bin/clickhouse-extract-from-config
   dst: /usr/bin/clickhouse-extract-from-config
 - src: root/usr/bin/clickhouse-library-bridge


### PR DESCRIPTION
### Changelog category (leave one):
- Security fix

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not install clickhouse-diagnostics due to large number of CVEs that popup in golang runtime
