### PR TITLE
Trigger regression_start only if BuilderDebRelease passed

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -573,7 +573,11 @@ jobs:
 ##################################### REGRESSION TESTS ######################################
 #############################################################################################
   regression_start:
-    needs: [FunctionalStatelessTestRelease, FunctionalStatefulTestRelease, IntegrationTestsRelease0, IntegrationTestsRelease1]
+    needs: [BuilderDebRelease, FunctionalStatelessTestRelease, FunctionalStatefulTestRelease, IntegrationTestsRelease0, IntegrationTestsRelease1]
+    # Run AFTER any of tests, but only if `BuilderDebRelease` succeed.
+    # Since we can't reference jobs directly and get their status, 
+    # check if any of jobs succeeds.
+    if: ${{ always() && contains(needs.*.result, 'success') }}
     runs-on: ubuntu-latest
     steps:
       - run: true

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -573,11 +573,8 @@ jobs:
 ##################################### REGRESSION TESTS ######################################
 #############################################################################################
   regression_start:
-    needs: [BuilderDebRelease, FunctionalStatelessTestRelease, FunctionalStatefulTestRelease, IntegrationTestsRelease0, IntegrationTestsRelease1]
-    # Run AFTER any of tests, but only if `BuilderDebRelease` succeed.
-    # Since we can't reference jobs directly and get their status, 
-    # check if any of jobs succeeds.
-    if: ${{ always() && contains(needs.*.result, 'success') }}
+    ## Not depending on the tests above since they can fail at any given moment.
+    needs: [BuilderDebRelease]
     runs-on: ubuntu-latest
     steps:
       - run: true


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

Trigger `regression_start` right after `BuilderDebRelease` passes, just so regression tests do not depend on other tests to pass