### PR TITLE
Update CICD jobs to reflect test fails

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -524,6 +524,7 @@ jobs:
           cp -r "$GITHUB_WORKSPACE" "$TEMP_PATH"
           cd "$REPO_COPY/tests/ci"
           python3 integration_test_check.py "$CHECK_NAME"
+          cat ${{runner.temp}}/integration_tests_release/results/output_dir/check_status.tsv
       - name: Cleanup
         if: always()
         run: |


### PR DESCRIPTION
Updating the CI pipeline to reflect fails in integration, stateless, and stateful tests.