### PR TITLE
23.3 Fix of DockerServerImages

### DIFF
--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -34,7 +34,11 @@ from version_helper import (
 )
 
 TEMP_PATH = p.join(RUNNER_TEMP, "docker_images_check")
-BUCKETS = {"amd64": "package_release", "arm64": "package_aarch64"}
+BUCKETS = {
+    "amd64": "package_release",
+    # NOTE(vnemkov): arm64 is temporary not supported
+    # "arm64": "package_aarch64"
+}
 git = Git(ignore_no_tags=True)
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Not building server images in DockerServerImages step for aarch64 (arm64) for now