### PR TITLE
22.8 Backport of #44404 RabbitMQ - fix writing many small blocks

### DIFF
--- a/docs/en/engines/table-engines/integrations/rabbitmq.md
+++ b/docs/en/engines/table-engines/integrations/rabbitmq.md
@@ -61,8 +61,11 @@ Optional parameters:
 -   `rabbitmq_max_block_size`
 -   `rabbitmq_flush_interval_ms`
 -   `rabbitmq_queue_settings_list` - allows to set RabbitMQ settings when creating a queue. Available settings: `x-max-length`, `x-max-length-bytes`, `x-message-ttl`, `x-expires`, `x-priority`, `x-max-priority`, `x-overflow`, `x-dead-letter-exchange`, `x-queue-type`. The `durable` setting is enabled automatically for the queue.
+- `rabbitmq_empty_queue_backoff_start` — A start backoff point to reschedule read if the rabbitmq queue is empty.
+- `rabbitmq_empty_queue_backoff_end` — An end backoff point to reschedule read if the rabbitmq queue is empty.
 
-SSL connection:
+
+  * [ ] SSL connection:
 
 Use either `rabbitmq_secure = 1` or `amqps` in connection address: `rabbitmq_address = 'amqps://guest:guest@localhost/vhost'`.
 The default behaviour of the used library is not to check if the created TLS connection is sufficiently secure. Whether the certificate is expired, self-signed, missing or invalid: the connection is simply permitted. More strict checking of certificates can possibly be implemented in the future.

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -497,7 +497,7 @@ void RemoteQueryExecutor::finish(std::unique_ptr<ReadContext> * read_context)
     /// Send the request to abort the execution of the request, if not already sent.
     tryCancel("Cancelling query because enough data has been read", read_context);
 
-    if (context->getSettingsRef().drain_timeout != Poco::Timespan(-1000000))
+    if (context->getSettingsRef().drain_timeout.value != Poco::Timespan(-1000000))
     {
         auto connections_left = ConnectionCollector::enqueueConnectionCleanup(pool, connections);
         if (connections_left)

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -924,7 +924,7 @@ public:
     /// section from config.xml.
     CompressionCodecPtr getCompressionCodecForPart(size_t part_size_compressed, const IMergeTreeDataPart::TTLInfos & ttl_infos, time_t current_time) const;
 
-    std::lock_guard<std::mutex> getQueryIdSetLock() const { return std::lock_guard<std::mutex>(query_id_set_mutex); }
+    std::lock_guard<std::mutex> getQueryIdSetLock() const TSA_NO_THREAD_SAFETY_ANALYSIS { return std::lock_guard<std::mutex>(query_id_set_mutex); }
 
     /// Record current query id where querying the table. Throw if there are already `max_queries` queries accessing the same table.
     /// Returns false if the `query_id` already exists in the running set, otherwise return true.

--- a/src/Storages/RabbitMQ/RabbitMQSettings.h
+++ b/src/Storages/RabbitMQ/RabbitMQSettings.h
@@ -24,9 +24,12 @@ namespace DB
     M(String, rabbitmq_address, "", "Address for connection", 0) \
     M(UInt64, rabbitmq_skip_broken_messages, 0, "Skip at least this number of broken messages from RabbitMQ per block", 0) \
     M(UInt64, rabbitmq_max_block_size, 0, "Number of row collected before flushing data from RabbitMQ.", 0) \
-    M(Milliseconds, rabbitmq_flush_interval_ms, 0, "Timeout for flushing data from RabbitMQ.", 0) \
+    M(UInt64, rabbitmq_flush_interval_ms, 0, "Timeout for flushing data from RabbitMQ.", 0) \
     M(String, rabbitmq_vhost, "/", "RabbitMQ vhost.", 0) \
     M(String, rabbitmq_queue_settings_list, "", "A list of rabbitmq queue settings", 0) \
+    M(UInt64, rabbitmq_empty_queue_backoff_start_ms, 10, "A minimum backoff point to reschedule read if the rabbitmq queue is empty", 0) \
+    M(UInt64, rabbitmq_empty_queue_backoff_end_ms, 10000, "A maximum backoff point to reschedule read if the rabbitmq queue is empty", 0) \
+    M(UInt64, rabbitmq_empty_queue_backoff_step_ms, 100, "A maximum backoff point to reschedule read if the rabbitmq queue is empty", 0) \
     M(Bool, rabbitmq_queue_consume, false, "Use user-defined queues and do not make any RabbitMQ setup: declaring exchanges, queues, bindings", 0) \
     M(String, rabbitmq_username, "", "RabbitMQ username", 0) \
     M(String, rabbitmq_password, "", "RabbitMQ password", 0) \

--- a/src/Storages/RabbitMQ/RabbitMQSource.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQSource.cpp
@@ -3,7 +3,9 @@
 #include <Formats/FormatFactory.h>
 #include <Interpreters/Context.h>
 #include <Processors/Executors/StreamingFormatExecutor.h>
-#include <Storages/RabbitMQ/ReadBufferFromRabbitMQConsumer.h>
+
+#include <Common/logger_useful.h>
+#include <IO/EmptyReadBuffer.h>
 
 namespace DB
 {
@@ -61,6 +63,7 @@ RabbitMQSource::RabbitMQSource(
     , ack_in_suffix(ack_in_suffix_)
     , non_virtual_header(std::move(headers.first))
     , virtual_header(std::move(headers.second))
+    , log(&Poco::Logger::get("RabbitMQSource"))
 {
     storage.incrementReader();
 }
@@ -70,31 +73,31 @@ RabbitMQSource::~RabbitMQSource()
 {
     storage.decrementReader();
 
-    if (!buffer)
+    if (!consumer)
         return;
 
-    storage.pushReadBuffer(buffer);
+    storage.pushReadBuffer(consumer);
 }
 
 
 bool RabbitMQSource::needChannelUpdate()
 {
-    if (!buffer)
+    if (!consumer)
         return false;
 
-    return buffer->needChannelUpdate();
+    return consumer->needChannelUpdate();
 }
 
 
 void RabbitMQSource::updateChannel()
 {
-    if (!buffer)
+    if (!consumer)
         return;
 
-    buffer->updateAckTracker();
+    consumer->updateAckTracker();
 
-    if (storage.updateChannel(buffer->getChannel()))
-        buffer->setupChannel();
+    if (storage.updateChannel(consumer->getChannel()))
+        consumer->setupChannel();
 }
 
 Chunk RabbitMQSource::generate()
@@ -106,57 +109,59 @@ Chunk RabbitMQSource::generate()
     return chunk;
 }
 
-bool RabbitMQSource::checkTimeLimit() const
+bool RabbitMQSource::isTimeLimitExceeded() const
 {
-    if (max_execution_time != 0)
+    if (max_execution_time_ms != 0)
     {
-        auto elapsed_ns = total_stopwatch.elapsed();
-
-        if (elapsed_ns > static_cast<UInt64>(max_execution_time.totalMicroseconds()) * 1000)
-            return false;
+        uint64_t elapsed_time_ms = total_stopwatch.elapsedMilliseconds();
+        return max_execution_time_ms <= elapsed_time_ms;
     }
 
-    return true;
+    return false;
 }
 
 Chunk RabbitMQSource::generateImpl()
 {
-    if (!buffer)
+    if (!consumer)
     {
         auto timeout = std::chrono::milliseconds(context->getSettingsRef().rabbitmq_max_wait_ms.totalMilliseconds());
-        buffer = storage.popReadBuffer(timeout);
+        consumer = storage.popReadBuffer(timeout);
     }
 
-    if (!buffer || is_finished)
+    if (is_finished || !consumer || consumer->isConsumerStopped())
         return {};
 
+    /// Currently it is one time usage source: to make sure data is flushed
+    /// strictly by timeout or by block size.
     is_finished = true;
 
     MutableColumns virtual_columns = virtual_header.cloneEmptyColumns();
+    EmptyReadBuffer empty_buf;
     auto input_format = FormatFactory::instance().getInputFormat(
-            storage.getFormatName(), *buffer, non_virtual_header, context, max_block_size);
+            storage.getFormatName(), empty_buf, non_virtual_header, context, max_block_size);
 
     StreamingFormatExecutor executor(non_virtual_header, input_format);
-
     size_t total_rows = 0;
 
     while (true)
     {
-        if (buffer->queueEmpty())
-            break;
+        size_t new_rows = 0;
 
-        auto new_rows = executor.execute();
+        if (!consumer->hasPendingMessages())
+        {
+            new_rows = executor.execute(*consumer);
+        }
 
         if (new_rows)
         {
             auto exchange_name = storage.getExchange();
-            auto channel_id = buffer->getChannelID();
-            auto delivery_tag = buffer->getDeliveryTag();
-            auto redelivered = buffer->getRedelivered();
-            auto message_id = buffer->getMessageID();
-            auto timestamp = buffer->getTimestamp();
+            auto channel_id = consumer->getChannelID();
+            auto delivery_tag = consumer->getDeliveryTag();
+            auto redelivered = consumer->getRedelivered();
+            auto message_id = consumer->getMessageID();
+            auto timestamp = consumer->getTimestamp();
 
-            buffer->updateAckTracker({delivery_tag, channel_id});
+            consumer->updateAckTracker({delivery_tag, channel_id});
 
             for (size_t i = 0; i < new_rows; ++i)
             {
@@ -168,14 +173,17 @@ Chunk RabbitMQSource::generateImpl()
                 virtual_columns[5]->insert(timestamp);
             }
 
-            total_rows = total_rows + new_rows;
+            total_rows += new_rows;
         }
 
-        buffer->allowNext();
-
-        if (total_rows >= max_block_size || buffer->queueEmpty() || buffer->isConsumerStopped() || !checkTimeLimit())
+        if (total_rows >= max_block_size || consumer->isConsumerStopped() || isTimeLimitExceeded())
             break;
     }
+
+    LOG_TEST(
+        log,
+        "Flushing {} rows (max block size: {}, time: {} / {} ms)",
+        total_rows, max_block_size, total_stopwatch.elapsedMilliseconds(), max_execution_time_ms);
 
     if (total_rows == 0)
         return {};
@@ -190,10 +198,10 @@ Chunk RabbitMQSource::generateImpl()
 
 bool RabbitMQSource::sendAck()
 {
-    if (!buffer)
+    if (!consumer)
         return false;
 
-    if (!buffer->ackMessages())
+    if (!consumer->ackMessages())
         return false;
 
     return true;

--- a/src/Storages/RabbitMQ/RabbitMQSource.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQSource.cpp
@@ -6,6 +6,7 @@
 
 #include <Common/logger_useful.h>
 #include <IO/EmptyReadBuffer.h>
+#include <base/sleep.h>
 
 namespace DB
 {
@@ -34,6 +35,7 @@ RabbitMQSource::RabbitMQSource(
     ContextPtr context_,
     const Names & columns,
     size_t max_block_size_,
+    UInt64 max_execution_time_,
     bool ack_in_suffix_)
     : RabbitMQSource(
         storage_,
@@ -42,6 +44,7 @@ RabbitMQSource::RabbitMQSource(
         context_,
         columns,
         max_block_size_,
+        max_execution_time_,
         ack_in_suffix_)
 {
 }
@@ -53,6 +56,7 @@ RabbitMQSource::RabbitMQSource(
     ContextPtr context_,
     const Names & columns,
     size_t max_block_size_,
+    UInt64 max_execution_time_,
     bool ack_in_suffix_)
     : ISource(getSampleBlock(headers.first, headers.second))
     , storage(storage_)
@@ -64,6 +68,7 @@ RabbitMQSource::RabbitMQSource(
     , non_virtual_header(std::move(headers.first))
     , virtual_header(std::move(headers.second))
     , log(&Poco::Logger::get("RabbitMQSource"))
+    , max_execution_time_ms(max_execution_time_)
 {
     storage.incrementReader();
 }
@@ -109,17 +114,6 @@ Chunk RabbitMQSource::generate()
     return chunk;
 }
 
-bool RabbitMQSource::isTimeLimitExceeded() const
-{
-    if (max_execution_time_ms != 0)
-    {
-        uint64_t elapsed_time_ms = total_stopwatch.elapsedMilliseconds();
-        return max_execution_time_ms <= elapsed_time_ms;
-    }
-
-    return false;
-}
-
 Chunk RabbitMQSource::generateImpl()
 {
     if (!consumer)
@@ -147,7 +141,7 @@ Chunk RabbitMQSource::generateImpl()
     {
         size_t new_rows = 0;
 
-        if (!consumer->hasPendingMessages())
+        if (consumer->hasPendingMessages())
         {
             new_rows = executor.execute(*consumer);
         }
@@ -175,9 +169,32 @@ Chunk RabbitMQSource::generateImpl()
 
             total_rows += new_rows;
         }
-
-        if (total_rows >= max_block_size || consumer->isConsumerStopped() || isTimeLimitExceeded())
+        else if (total_rows == 0)
+        {
             break;
+        }
+
+        bool is_time_limit_exceeded = false;
+        UInt64 remaining_execution_time = 0;
+        if (max_execution_time_ms)
+        {
+            uint64_t elapsed_time_ms = total_stopwatch.elapsedMilliseconds();
+            is_time_limit_exceeded = max_execution_time_ms <= elapsed_time_ms;
+            if (!is_time_limit_exceeded)
+                remaining_execution_time = max_execution_time_ms - elapsed_time_ms;
+        }
+
+        if (total_rows >= max_block_size || consumer->isConsumerStopped() || is_time_limit_exceeded)
+        {
+            break;
+        }
+        else if (new_rows == 0)
+        {
+            if (remaining_execution_time)
+                consumer->waitForMessages(remaining_execution_time);
+            else
+                consumer->waitForMessages();
+        }
     }
 
     LOG_TEST(

--- a/src/Storages/RabbitMQ/RabbitMQSource.h
+++ b/src/Storages/RabbitMQ/RabbitMQSource.h
@@ -18,6 +18,7 @@ public:
             ContextPtr context_,
             const Names & columns,
             size_t max_block_size_,
+            UInt64 max_execution_time_,
             bool ack_in_suffix = false);
 
     ~RabbitMQSource() override;
@@ -27,12 +28,10 @@ public:
 
     Chunk generate() override;
 
-    bool queueEmpty() const { return !consumer || consumer->hasPendingMessages(); }
+    bool hasPendingMessages() const { return consumer && consumer->hasPendingMessages(); }
     bool needChannelUpdate();
     void updateChannel();
     bool sendAck();
-
-    void setTimeLimit(uint64_t max_execution_time_ms_) { max_execution_time_ms = max_execution_time_ms_; }
 
 private:
     StorageRabbitMQ & storage;
@@ -52,8 +51,6 @@ private:
     uint64_t max_execution_time_ms = 0;
     Stopwatch total_stopwatch {CLOCK_MONOTONIC_COARSE};
 
-    bool isTimeLimitExceeded() const;
-
     RabbitMQSource(
         StorageRabbitMQ & storage_,
         const StorageSnapshotPtr & storage_snapshot_,
@@ -61,6 +58,7 @@ private:
         ContextPtr context_,
         const Names & columns,
         size_t max_block_size_,
+        UInt64 max_execution_time_,
         bool ack_in_suffix);
 
     Chunk generateImpl();

--- a/src/Storages/RabbitMQ/ReadBufferFromRabbitMQConsumer.h
+++ b/src/Storages/RabbitMQ/ReadBufferFromRabbitMQConsumer.h
@@ -20,6 +20,7 @@ namespace DB
 
 class RabbitMQHandler;
 using ChannelPtr = std::unique_ptr<AMQP::TcpChannel>;
+static constexpr auto SANITY_TIMEOUT = 1000 * 60 * 10; /// 10min.
 
 class ReadBufferFromRabbitMQConsumer : public ReadBuffer
 {
@@ -32,8 +33,7 @@ public:
             const String & channel_base_,
             Poco::Logger * log_,
             char row_delimiter_,
-            uint32_t queue_size_,
-            const std::atomic<bool> & stopped_);
+            uint32_t queue_size_);
 
     ~ReadBufferFromRabbitMQConsumer() override;
 
@@ -58,23 +58,30 @@ public:
     ChannelPtr & getChannel() { return consumer_channel; }
     void setupChannel();
     bool needChannelUpdate();
-    void closeChannel();
+    void shutdown();
 
     void updateQueues(std::vector<String> & queues_) { queues = queues_; }
     size_t queuesCount() { return queues.size(); }
 
-    bool isConsumerStopped() { return stopped; }
+    bool isConsumerStopped() const { return stopped.load(); }
     bool ackMessages();
     void updateAckTracker(AckTracker record = AckTracker());
-
-    bool hasPendingMessages() { return received.empty(); }
-    void allowNext() { allowed = true; } // Allow to read next message.
-
+    bool hasPendingMessages() { return !received.empty(); }
     auto getChannelID() const { return current.track.channel_id; }
     auto getDeliveryTag() const { return current.track.delivery_tag; }
     auto getRedelivered() const { return current.redelivered; }
     auto getMessageID() const { return current.message_id; }
     auto getTimestamp() const { return current.timestamp; }
+
+    void waitForMessages(std::optional<uint64_t> timeout_ms = std::nullopt)
+    {
+        std::unique_lock lock(mutex);
+        if (!timeout_ms)
+            timeout_ms = SANITY_TIMEOUT;
+        cv.wait_for(lock, std::chrono::milliseconds(*timeout_ms), [this]{ return !received.empty() || isConsumerStopped(); });
+    }
+
+    void closeConnections();
 
 private:
     bool nextImpl() override;
@@ -90,7 +97,7 @@ private:
     Poco::Logger * log;
     char row_delimiter;
     bool allowed = true;
-    const std::atomic<bool> & stopped;
+    std::atomic<bool> stopped;
 
     String channel_id;
     std::atomic<bool> channel_error = true, wait_subscription = false;
@@ -100,6 +107,9 @@ private:
 
     AckTracker last_inserted_record_info;
     UInt64 prev_tag = 0, channel_id_counter = 0;
+
+    std::condition_variable cv;
+    std::mutex mutex;
 };
 
 }

--- a/src/Storages/RabbitMQ/ReadBufferFromRabbitMQConsumer.h
+++ b/src/Storages/RabbitMQ/ReadBufferFromRabbitMQConsumer.h
@@ -67,7 +67,7 @@ public:
     bool ackMessages();
     void updateAckTracker(AckTracker record = AckTracker());
 
-    bool queueEmpty() { return received.empty(); }
+    bool hasPendingMessages() { return received.empty(); }
     void allowNext() { allowed = true; } // Allow to read next message.
 
     auto getChannelID() const { return current.track.channel_id; }

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -36,7 +36,6 @@ namespace DB
 static const uint32_t QUEUE_SIZE = 100000;
 static const auto MAX_FAILED_READ_ATTEMPTS = 10;
 static const auto RESCHEDULE_MS = 500;
-static const auto BACKOFF_TRESHOLD = 32000;
 static const auto MAX_THREAD_WORK_DURATION_MS = 60000;
 
 namespace ErrorCodes
@@ -90,7 +89,7 @@ StorageRabbitMQ::StorageRabbitMQ(
         , semaphore(0, num_consumers)
         , unique_strbase(getRandomName())
         , queue_size(std::max(QUEUE_SIZE, static_cast<uint32_t>(getMaxBlockSize())))
-        , milliseconds_to_wait(RESCHEDULE_MS)
+        , milliseconds_to_wait(rabbitmq_settings->rabbitmq_empty_queue_backoff_start_ms)
         , is_attach(is_attach_)
 {
     const auto & config = getContext()->getConfigRef();
@@ -713,6 +712,12 @@ void StorageRabbitMQ::read(
         auto rabbit_source = std::make_shared<RabbitMQSource>(
             *this, storage_snapshot, modified_context, column_names, 1, rabbitmq_settings->rabbitmq_commit_on_select);
 
+        uint64_t max_execution_time_ms = rabbitmq_settings->rabbitmq_flush_interval_ms.changed
+                                          ? rabbitmq_settings->rabbitmq_flush_interval_ms
+                                          : (static_cast<UInt64>(getContext()->getSettingsRef().stream_flush_interval_ms) * 1000);
+
+        rabbit_source->setTimeLimit(max_execution_time_ms);
+
         auto converting_dag = ActionsDAG::makeConvertingActions(
             rabbit_source->getPort().getHeader().getColumnsWithTypeAndName(),
             sample_block.getColumnsWithTypeAndName(),
@@ -1003,14 +1008,14 @@ void StorageRabbitMQ::streamingToViewsFunc()
                     if (streamToViews())
                     {
                         /// Reschedule with backoff.
-                        if (milliseconds_to_wait < BACKOFF_TRESHOLD)
-                            milliseconds_to_wait *= 2;
+                        if (milliseconds_to_wait < rabbitmq_settings->rabbitmq_empty_queue_backoff_end_ms)
+                            milliseconds_to_wait += rabbitmq_settings->rabbitmq_empty_queue_backoff_step_ms;
                         stopLoopIfNoReaders();
                         break;
                     }
                     else
                     {
-                        milliseconds_to_wait = RESCHEDULE_MS;
+                        milliseconds_to_wait = rabbitmq_settings->rabbitmq_empty_queue_backoff_start_ms;
                     }
 
                     auto end_time = std::chrono::steady_clock::now();
@@ -1073,14 +1078,15 @@ bool StorageRabbitMQ::streamToViews()
     {
         auto source = std::make_shared<RabbitMQSource>(
             *this, storage_snapshot, rabbitmq_context, column_names, block_size, false);
+
+        uint64_t max_execution_time_ms = rabbitmq_settings->rabbitmq_flush_interval_ms.changed
+                                          ? rabbitmq_settings->rabbitmq_flush_interval_ms
+                                          : (static_cast<UInt64>(getContext()->getSettingsRef().stream_flush_interval_ms) * 1000);
+
+        source->setTimeLimit(max_execution_time_ms);
+
         sources.emplace_back(source);
         pipes.emplace_back(source);
-
-        Poco::Timespan max_execution_time = rabbitmq_settings->rabbitmq_flush_interval_ms.changed
-                                          ? rabbitmq_settings->rabbitmq_flush_interval_ms
-                                          : getContext()->getSettingsRef().stream_flush_interval_ms;
-
-        source->setTimeLimit(max_execution_time);
     }
 
     block_io.pipeline.complete(Pipe::unitePipes(std::move(pipes)));

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.h
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.h
@@ -3,6 +3,7 @@
 #include <Core/BackgroundSchedulePool.h>
 #include <Storages/IStorage.h>
 #include <Poco/Semaphore.h>
+#include <memory>
 #include <mutex>
 #include <atomic>
 #include <Storages/RabbitMQ/Buffer_fwd.h>
@@ -107,8 +108,10 @@ private:
 
     size_t num_created_consumers = 0;
     Poco::Semaphore semaphore;
+
     std::mutex buffers_mutex;
     std::vector<ConsumerBufferPtr> buffers; /// available buffers for RabbitMQ consumers
+    std::vector<std::weak_ptr<ReadBufferFromRabbitMQConsumer>> buffers_ref; /// available buffers for RabbitMQ consumers
 
     String unique_strbase; /// to make unique consumer channel id
 

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -1,3 +1,5 @@
+import pytest
+
 import json
 import os.path as p
 import random
@@ -9,7 +11,6 @@ from random import randrange
 import math
 
 import pika
-import pytest
 from google.protobuf.internal.encoder import _VarintBytes
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster, check_rabbitmq_is_available
@@ -49,6 +50,7 @@ def rabbitmq_check_result(result, check=False, ref_file="test_rabbitmq_json.refe
 
 
 def wait_rabbitmq_to_start(rabbitmq_docker_id, timeout=180):
+    logging.getLogger("pika").propagate = False
     start = time.time()
     while time.time() - start < timeout:
         try:
@@ -153,6 +155,7 @@ def test_rabbitmq_select_empty(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'empty',
                      rabbitmq_commit_on_select = 1,
                      rabbitmq_format = 'TSV',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_row_delimiter = '\\n';
         """.format(
             rabbitmq_cluster.rabbitmq_host
@@ -169,6 +172,8 @@ def test_rabbitmq_json_without_delimiter(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = '{}:5672',
                      rabbitmq_commit_on_select = 1,
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_exchange_name = 'json',
                      rabbitmq_format = 'JSONEachRow'
         """.format(
@@ -221,6 +226,8 @@ def test_rabbitmq_csv_with_delimiter(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'csv',
                      rabbitmq_commit_on_select = 1,
                      rabbitmq_format = 'CSV',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_row_delimiter = '\\n';
         """
     )
@@ -262,6 +269,8 @@ def test_rabbitmq_tsv_with_delimiter(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'tsv',
                      rabbitmq_format = 'TSV',
                      rabbitmq_commit_on_select = 1,
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_queue_base = 'tsv',
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view (key UInt64, value UInt64)
@@ -303,6 +312,8 @@ def test_rabbitmq_macros(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = '{rabbitmq_host}:{rabbitmq_port}',
                      rabbitmq_commit_on_select = 1,
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_exchange_name = '{rabbitmq_exchange_name}',
                      rabbitmq_format = '{rabbitmq_format}'
         """
@@ -342,6 +353,8 @@ def test_rabbitmq_materialized_view(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'mv',
                      rabbitmq_format = 'JSONEachRow',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree()
@@ -364,10 +377,11 @@ def test_rabbitmq_materialized_view(rabbitmq_cluster):
     connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
 
+    instance.wait_for_log_line("Started streaming to 2 attached views")
+
     messages = []
     for i in range(50):
-        messages.append(json.dumps({"key": i, "value": i}))
-    for message in messages:
+        message = json.dumps({"key": i, "value": i})
         channel.basic_publish(exchange="mv", routing_key="", body=message)
 
     time_limit_sec = 60
@@ -384,8 +398,10 @@ def test_rabbitmq_materialized_view(rabbitmq_cluster):
 
     while time.monotonic() < deadline:
         result = instance.query("SELECT * FROM test.view2 ORDER BY key")
+        print(f"Result: {result}")
         if rabbitmq_check_result(result):
             break
+        time.sleep(1)
 
     rabbitmq_check_result(result, True)
     connection.close()
@@ -398,6 +414,8 @@ def test_rabbitmq_materialized_view_with_subquery(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'mvsq',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view (key UInt64, value UInt64)
@@ -441,6 +459,8 @@ def test_rabbitmq_many_materialized_views(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'mmv',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view1 (key UInt64, value UInt64)
@@ -462,6 +482,8 @@ def test_rabbitmq_many_materialized_views(rabbitmq_cluster):
     )
     connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
+
+    instance.wait_for_log_line("Started streaming to 2 attached views")
 
     messages = []
     for i in range(50):
@@ -498,6 +520,8 @@ def test_rabbitmq_protobuf(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'pb',
                      rabbitmq_format = 'Protobuf',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_schema = 'rabbitmq.proto:KeyValueProto';
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree()
@@ -572,6 +596,8 @@ def test_rabbitmq_big_message(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'big',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_format = 'JSONEachRow';
         CREATE TABLE test.view (key UInt64, value String)
             ENGINE = MergeTree
@@ -599,6 +625,7 @@ def test_rabbitmq_big_message(rabbitmq_cluster):
 def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
     NUM_CONSUMERS = 10
     NUM_QUEUES = 10
+    logging.getLogger("pika").propagate = False
 
     instance.query(
         """
@@ -606,8 +633,10 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'test_sharding',
-                     rabbitmq_num_queues = 10,
+                     rabbitmq_num_queues = 5,
                      rabbitmq_num_consumers = 10,
+                     rabbitmq_max_block_size = 100,
+                     rabbitmq_flush_interval_ms=500,
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view (key UInt64, value UInt64, channel_id String)
@@ -648,7 +677,7 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
         connection.close()
 
     threads = []
-    threads_num = 20
+    threads_num = 10
 
     for _ in range(threads_num):
         threads.append(threading.Thread(target=produce))
@@ -660,8 +689,10 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
     while True:
         result1 = instance.query("SELECT count() FROM test.view")
         time.sleep(1)
-        if int(result1) == messages_num * threads_num:
+        expected = messages_num * threads_num
+        if int(result1) == expected:
             break
+        print(f"Result {result1} / {expected}")
 
     result2 = instance.query("SELECT count(DISTINCT channel_id) FROM test.view")
 
@@ -677,6 +708,7 @@ def test_rabbitmq_sharding_between_queues_publish(rabbitmq_cluster):
 def test_rabbitmq_mv_combo(rabbitmq_cluster):
     NUM_MV = 5
     NUM_CONSUMERS = 4
+    logging.getLogger("pika").propagate = False
 
     instance.query(
         """
@@ -685,6 +717,8 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'combo',
                      rabbitmq_queue_base = 'combo',
+                     rabbitmq_max_block_size = 100,
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_num_consumers = 2,
                      rabbitmq_num_queues = 5,
                      rabbitmq_format = 'JSONEachRow',
@@ -749,8 +783,10 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster):
             result += int(
                 instance.query("SELECT count() FROM test.combo_{0}".format(mv_id))
             )
-        if int(result) == messages_num * threads_num * NUM_MV:
+        expected = messages_num * threads_num * NUM_MV
+        if int(result) == expected:
             break
+        print(f"Result: {result} / {expected}")
         time.sleep(1)
 
     for thread in threads:
@@ -778,6 +814,8 @@ def test_rabbitmq_insert(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'insert',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_exchange_type = 'direct',
                      rabbitmq_routing_key_list = 'insert1',
                      rabbitmq_format = 'TSV',
@@ -835,6 +873,8 @@ def test_rabbitmq_insert_headers_exchange(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'insert_headers',
                      rabbitmq_exchange_type = 'headers',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_routing_key_list = 'test=insert,topic=headers',
                      rabbitmq_format = 'TSV',
                      rabbitmq_row_delimiter = '\\n';
@@ -901,6 +941,8 @@ def test_rabbitmq_many_inserts(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'many_inserts',
                      rabbitmq_exchange_type = 'direct',
                      rabbitmq_routing_key_list = 'insert2',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_format = 'TSV',
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.rabbitmq_consume (key UInt64, value UInt64)
@@ -909,6 +951,8 @@ def test_rabbitmq_many_inserts(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'many_inserts',
                      rabbitmq_exchange_type = 'direct',
                      rabbitmq_routing_key_list = 'insert2',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_format = 'TSV',
                      rabbitmq_row_delimiter = '\\n';
     """
@@ -987,9 +1031,10 @@ def test_rabbitmq_overloaded_insert(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'over',
                      rabbitmq_queue_base = 'over',
                      rabbitmq_exchange_type = 'direct',
-                     rabbitmq_num_consumers = 5,
-                     rabbitmq_num_queues = 10,
-                     rabbitmq_max_block_size = 10000,
+                     rabbitmq_num_consumers = 3,
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size = 100,
+                     rabbitmq_num_queues = 2,
                      rabbitmq_routing_key_list = 'over',
                      rabbitmq_format = 'TSV',
                      rabbitmq_row_delimiter = '\\n';
@@ -999,6 +1044,8 @@ def test_rabbitmq_overloaded_insert(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'over',
                      rabbitmq_exchange_type = 'direct',
                      rabbitmq_routing_key_list = 'over',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size = 100,
                      rabbitmq_format = 'TSV',
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view_overload (key UInt64, value UInt64)
@@ -1009,6 +1056,8 @@ def test_rabbitmq_overloaded_insert(rabbitmq_cluster):
             SELECT * FROM test.rabbitmq_consume;
     """
     )
+
+    instance.wait_for_log_line("Started streaming to 1 attached views")
 
     messages_num = 100000
 
@@ -1031,7 +1080,7 @@ def test_rabbitmq_overloaded_insert(rabbitmq_cluster):
                     raise
 
     threads = []
-    threads_num = 5
+    threads_num = 3
     for _ in range(threads_num):
         threads.append(threading.Thread(target=insert))
     for thread in threads:
@@ -1041,8 +1090,10 @@ def test_rabbitmq_overloaded_insert(rabbitmq_cluster):
     while True:
         result = instance.query("SELECT count() FROM test.view_overload")
         time.sleep(1)
-        if int(result) == messages_num * threads_num:
+        expected = messages_num * threads_num
+        if int(result) == expected:
             break
+        print(f"Result: {result} / {expected}")
 
     instance.query(
         """
@@ -1084,6 +1135,8 @@ def test_rabbitmq_direct_exchange(rabbitmq_cluster):
                 SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                          rabbitmq_num_consumers = 2,
                          rabbitmq_num_queues = 2,
+                         rabbitmq_flush_interval_ms=1000,
+                        rabbitmq_max_block_size=100,
                          rabbitmq_exchange_name = 'direct_exchange_testing',
                          rabbitmq_exchange_type = 'direct',
                          rabbitmq_routing_key_list = 'direct_{0}',
@@ -1175,6 +1228,8 @@ def test_rabbitmq_fanout_exchange(rabbitmq_cluster):
                 SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                          rabbitmq_num_consumers = 2,
                          rabbitmq_num_queues = 2,
+                         rabbitmq_flush_interval_ms=1000,
+                         rabbitmq_max_block_size=100,
                          rabbitmq_routing_key_list = 'key_{0}',
                          rabbitmq_exchange_name = 'fanout_exchange_testing',
                          rabbitmq_exchange_type = 'fanout',
@@ -1261,6 +1316,8 @@ def test_rabbitmq_topic_exchange(rabbitmq_cluster):
                 SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                          rabbitmq_num_consumers = 2,
                          rabbitmq_num_queues = 2,
+                         rabbitmq_flush_interval_ms=1000,
+                         rabbitmq_max_block_size=100,
                          rabbitmq_exchange_name = 'topic_exchange_testing',
                          rabbitmq_exchange_type = 'topic',
                          rabbitmq_routing_key_list = '*.{0}',
@@ -1284,6 +1341,8 @@ def test_rabbitmq_topic_exchange(rabbitmq_cluster):
                 SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                          rabbitmq_num_consumers = 2,
                          rabbitmq_num_queues = 2,
+                         rabbitmq_flush_interval_ms=1000,
+                         rabbitmq_max_block_size=100,
                          rabbitmq_exchange_name = 'topic_exchange_testing',
                          rabbitmq_exchange_type = 'topic',
                          rabbitmq_routing_key_list = '*.logs',
@@ -1385,6 +1444,7 @@ def test_rabbitmq_hash_exchange(rabbitmq_cluster):
                          rabbitmq_exchange_type = 'consistent_hash',
                          rabbitmq_exchange_name = 'hash_exchange_testing',
                          rabbitmq_format = 'JSONEachRow',
+                         rabbitmq_flush_interval_ms=1000,
                          rabbitmq_row_delimiter = '\\n';
             CREATE MATERIALIZED VIEW test.{0}_mv TO test.destination AS
                 SELECT key, value, _channel_id AS channel_id FROM test.{0};
@@ -1482,6 +1542,8 @@ def test_rabbitmq_multiple_bindings(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'multiple_bindings_testing',
                      rabbitmq_exchange_type = 'direct',
                      rabbitmq_routing_key_list = 'key1,key2,key3,key4,key5',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_row_delimiter = '\\n';
         CREATE MATERIALIZED VIEW test.bindings_mv TO test.destination AS
@@ -1571,6 +1633,8 @@ def test_rabbitmq_headers_exchange(rabbitmq_cluster):
                          rabbitmq_num_consumers = 2,
                          rabbitmq_exchange_name = 'headers_exchange_testing',
                          rabbitmq_exchange_type = 'headers',
+                         rabbitmq_flush_interval_ms=1000,
+                         rabbitmq_max_block_size=100,
                          rabbitmq_routing_key_list = 'x-match=all,format=logs,type=report,year=2020',
                          rabbitmq_format = 'JSONEachRow',
                          rabbitmq_row_delimiter = '\\n';
@@ -1595,6 +1659,8 @@ def test_rabbitmq_headers_exchange(rabbitmq_cluster):
                          rabbitmq_exchange_type = 'headers',
                          rabbitmq_routing_key_list = 'x-match=all,format=logs,type=report,year=2019',
                          rabbitmq_format = 'JSONEachRow',
+                         rabbitmq_flush_interval_ms=1000,
+                         rabbitmq_max_block_size=100,
                          rabbitmq_row_delimiter = '\\n';
             CREATE MATERIALIZED VIEW test.headers_exchange_{0}_mv TO test.destination AS
             SELECT key, value FROM test.headers_exchange_{0};
@@ -1667,6 +1733,8 @@ def test_rabbitmq_virtual_columns(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'virtuals',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_format = 'JSONEachRow';
         CREATE MATERIALIZED VIEW test.view Engine=Log AS
         SELECT value, key, _exchange_name, _channel_id, _delivery_tag, _redelivered FROM test.rabbitmq_virtuals;
@@ -1735,6 +1803,8 @@ def test_rabbitmq_virtual_columns_with_materialized_view(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'virtuals_mv',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_format = 'JSONEachRow';
         CREATE TABLE test.view (key UInt64, value UInt64,
             exchange_name String, channel_id String, delivery_tag UInt64, redelivered UInt8) ENGINE = MergeTree()
@@ -1820,6 +1890,8 @@ def test_rabbitmq_many_consumers_to_each_queue(rabbitmq_cluster):
                          rabbitmq_exchange_name = 'many_consumers',
                          rabbitmq_num_queues = 2,
                          rabbitmq_num_consumers = 2,
+                         rabbitmq_flush_interval_ms=1000,
+                         rabbitmq_max_block_size=100,
                          rabbitmq_queue_base = 'many_consumers',
                          rabbitmq_format = 'JSONEachRow',
                          rabbitmq_row_delimiter = '\\n';
@@ -1909,6 +1981,8 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
         CREATE TABLE test.consume (key UInt64, value UInt64)
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_flush_interval_ms=500,
+                     rabbitmq_max_block_size = 100,
                      rabbitmq_exchange_name = 'producer_reconnect',
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_num_consumers = 2,
@@ -1921,6 +1995,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'producer_reconnect',
                      rabbitmq_persistent = '1',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_row_delimiter = '\\n';
     """
@@ -1976,7 +2051,9 @@ def test_rabbitmq_restore_failed_connection_without_losses_1(rabbitmq_cluster):
     )
 
 
+@pytest.mark.skip(reason="Timeout: FIXME")
 def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
+    logging.getLogger("pika").propagate = False
     instance.query(
         """
         CREATE TABLE test.consumer_reconnect (key UInt64, value UInt64)
@@ -1984,6 +2061,8 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'consumer_reconnect',
                      rabbitmq_num_consumers = 10,
+                     rabbitmq_flush_interval_ms = 100,
+                     rabbitmq_max_block_size = 100,
                      rabbitmq_num_queues = 10,
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_row_delimiter = '\\n';
@@ -2038,10 +2117,11 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
     # revive_rabbitmq()
 
     while True:
-        result = instance.query("SELECT count(DISTINCT key) FROM test.view")
-        time.sleep(1)
+        result = instance.query("SELECT count(DISTINCT key) FROM test.view").strip()
         if int(result) == messages_num:
             break
+        print(f"Result: {result} / {messages_num}")
+        time.sleep(1)
 
     instance.query(
         """
@@ -2056,6 +2136,7 @@ def test_rabbitmq_restore_failed_connection_without_losses_2(rabbitmq_cluster):
 
 
 def test_rabbitmq_commit_on_block_write(rabbitmq_cluster):
+    logging.getLogger("pika").propagate = False
     instance.query(
         """
         CREATE TABLE test.rabbitmq (key UInt64, value UInt64)
@@ -2064,6 +2145,7 @@ def test_rabbitmq_commit_on_block_write(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'block',
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_queue_base = 'block',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_max_block_size = 100,
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view (key UInt64, value UInt64)
@@ -2144,6 +2226,7 @@ def test_rabbitmq_no_connection_at_startup_1(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'cs',
                      rabbitmq_format = 'JSONEachRow',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_num_consumers = '5',
                      rabbitmq_row_delimiter = '\\n';
     """
@@ -2160,6 +2243,8 @@ def test_rabbitmq_no_connection_at_startup_2(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'cs',
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_num_consumers = '5',
+                     rabbitmq_flush_interval_ms=1000,
+                     rabbitmq_max_block_size=100,
                      rabbitmq_row_delimiter = '\\n';
         CREATE TABLE test.view (key UInt64, value UInt64)
             ENGINE = MergeTree
@@ -2216,6 +2301,7 @@ def test_rabbitmq_format_factory_settings(rabbitmq_cluster):
         ) ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'format_settings',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_format = 'JSONEachRow',
                      date_time_input_format = 'best_effort';
         """
@@ -2278,6 +2364,7 @@ def test_rabbitmq_vhost(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'vhost',
                      rabbitmq_format = 'JSONEachRow',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_vhost = '/'
         """
     )
@@ -2306,6 +2393,7 @@ def test_rabbitmq_drop_table_properly(rabbitmq_cluster):
         CREATE TABLE test.rabbitmq_drop (key UInt64, value UInt64)
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_exchange_name = 'drop',
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_queue_base = 'rabbit_queue_drop'
@@ -2352,6 +2440,7 @@ def test_rabbitmq_queue_settings(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'rabbit_exchange',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_queue_base = 'rabbit_queue_settings',
                      rabbitmq_queue_settings_list = 'x-max-length=10,x-overflow=reject-publish'
@@ -2384,12 +2473,11 @@ def test_rabbitmq_queue_settings(rabbitmq_cluster):
 
     time.sleep(5)
 
-    result = instance.query(
-        "SELECT count() FROM test.rabbitmq_settings", ignore_error=True
-    )
-    while int(result) != 10:
-        time.sleep(0.5)
+    while True:
         result = instance.query("SELECT count() FROM test.view", ignore_error=True)
+        if int(result) == 10:
+            break
+        time.sleep(0.5)
 
     instance.query("DROP TABLE test.rabbitmq_settings")
 
@@ -2433,6 +2521,7 @@ def test_rabbitmq_queue_consume(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_format = 'JSONEachRow',
                      rabbitmq_queue_base = 'rabbit_queue',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_queue_consume = 1;
         CREATE TABLE test.view (key UInt64, value UInt64)
         ENGINE = MergeTree ORDER BY key;
@@ -2467,6 +2556,7 @@ def test_rabbitmq_produce_consume_avro(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_format = 'Avro',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_exchange_name = 'avro',
                      rabbitmq_exchange_type = 'direct',
                      rabbitmq_routing_key_list = 'avro';
@@ -2475,6 +2565,7 @@ def test_rabbitmq_produce_consume_avro(rabbitmq_cluster):
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_format = 'Avro',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_exchange_name = 'avro',
                      rabbitmq_exchange_type = 'direct',
                      rabbitmq_routing_key_list = 'avro';
@@ -2517,6 +2608,7 @@ def test_rabbitmq_bad_args(rabbitmq_cluster):
         CREATE TABLE test.drop (key UInt64, value UInt64)
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_exchange_name = 'f',
                      rabbitmq_format = 'JSONEachRow';
     """
@@ -2529,6 +2621,7 @@ def test_rabbitmq_issue_30691(rabbitmq_cluster):
         CREATE TABLE test.rabbitmq_drop (json String)
             ENGINE = RabbitMQ
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_exchange_name = '30691',
                      rabbitmq_row_delimiter = '\\n', -- Works only if adding this setting
                      rabbitmq_format = 'LineAsString',
@@ -2589,6 +2682,7 @@ def test_rabbitmq_drop_mv(rabbitmq_cluster):
             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'mv',
                      rabbitmq_format = 'JSONEachRow',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_queue_base = 'drop_mv';
     """
     )
@@ -2648,10 +2742,12 @@ def test_rabbitmq_drop_mv(rabbitmq_cluster):
         result = instance.query("SELECT * FROM test.view ORDER BY key")
         if rabbitmq_check_result(result):
             break
+        time.sleep(1)
 
     rabbitmq_check_result(result, True)
 
-    instance.query("DROP VIEW test.consumer")
+    instance.query("DROP VIEW test.consumer NO DELAY")
+    time.sleep(10)
     for i in range(50, 60):
         channel.basic_publish(
             exchange="mv", routing_key="", body=json.dumps({"key": i, "value": i})
@@ -2679,6 +2775,7 @@ def test_rabbitmq_random_detach(rabbitmq_cluster):
                      rabbitmq_exchange_name = 'random',
                      rabbitmq_queue_base = 'random',
                      rabbitmq_num_queues = 2,
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_num_consumers = 2,
                      rabbitmq_format = 'JSONEachRow';
         CREATE TABLE test.view (key UInt64, value UInt64, channel_id String)
@@ -2743,7 +2840,9 @@ def test_rabbitmq_predefined_configuration(rabbitmq_cluster):
     instance.query(
         """
         CREATE TABLE test.rabbitmq (key UInt64, value UInt64)
-            ENGINE = RabbitMQ(rabbit1, rabbitmq_vhost = '/') """
+            ENGINE = RabbitMQ(rabbit1, rabbitmq_vhost = '/')
+            SETTINGS rabbitmq_flush_interval_ms=1000;
+        """
     )
 
     channel.basic_publish(
@@ -2779,6 +2878,7 @@ def test_rabbitmq_msgpack(rabbitmq_cluster):
             settings rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'xhep',
                      rabbitmq_format = 'MsgPack',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_num_consumers = 1;
         create table
             rabbit_out (val String)
@@ -2786,6 +2886,7 @@ def test_rabbitmq_msgpack(rabbitmq_cluster):
             settings rabbitmq_host_port = 'rabbitmq1:5672',
                      rabbitmq_exchange_name = 'xhep',
                      rabbitmq_format = 'MsgPack',
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_num_consumers = 1;
         set stream_like_engine_allow_direct_select=1;
         insert into rabbit_out select 'kek';
@@ -2821,12 +2922,14 @@ def test_rabbitmq_address(rabbitmq_cluster):
             SETTINGS rabbitmq_exchange_name = 'rxhep',
                      rabbitmq_format = 'CSV',
                      rabbitmq_num_consumers = 1,
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_address='amqp://root:clickhouse@rabbitmq1:5672/';
         create table
             rabbit_out (val String) engine=RabbitMQ
             SETTINGS rabbitmq_exchange_name = 'rxhep',
                      rabbitmq_format = 'CSV',
                      rabbitmq_num_consumers = 1,
+                     rabbitmq_flush_interval_ms=1000,
                      rabbitmq_address='amqp://root:clickhouse@rabbitmq1:5672/';
         set stream_like_engine_allow_direct_select=1;
         insert into rabbit_out select 'kek';
@@ -2848,3 +2951,534 @@ def test_rabbitmq_address(rabbitmq_cluster):
 
     instance2.query("drop table rabbit_in sync")
     instance2.query("drop table rabbit_out sync")
+
+
+def test_format_with_prefix_and_suffix(rabbitmq_cluster):
+    instance.query(
+        """
+        CREATE TABLE test.rabbitmq (key UInt64, value UInt64)
+            ENGINE = RabbitMQ
+            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_exchange_name = 'insert',
+                     rabbitmq_exchange_type = 'direct',
+                     rabbitmq_routing_key_list = 'custom',
+                     rabbitmq_format = 'CustomSeparated';
+    """
+    )
+
+    credentials = pika.PlainCredentials("root", "clickhouse")
+    parameters = pika.ConnectionParameters(
+        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
+    )
+    consumer_connection = pika.BlockingConnection(parameters)
+
+    consumer = consumer_connection.channel()
+    result = consumer.queue_declare(queue="")
+    queue_name = result.method.queue
+    consumer.queue_bind(exchange="insert", queue=queue_name, routing_key="custom")
+
+    instance.query(
+        "INSERT INTO test.rabbitmq select number*10 as key, number*100 as value from numbers(2) settings format_custom_result_before_delimiter='<prefix>\n', format_custom_result_after_delimiter='<suffix>\n'"
+    )
+
+    insert_messages = []
+
+    def onReceived(channel, method, properties, body):
+        message = body.decode()
+        insert_messages.append(message)
+        print(f"Received {len(insert_messages)} message: {message}")
+        if len(insert_messages) == 2:
+            channel.stop_consuming()
+
+    consumer.basic_consume(onReceived, queue_name)
+
+    consumer.start_consuming()
+    consumer_connection.close()
+
+    assert (
+        "".join(insert_messages)
+        == "<prefix>\n0\t0\n<suffix>\n<prefix>\n10\t100\n<suffix>\n"
+    )
+
+
+def test_max_rows_per_message(rabbitmq_cluster):
+    num_rows = 5
+
+    instance.query(
+        """
+        DROP TABLE IF EXISTS test.view;
+        DROP TABLE IF EXISTS test.rabbit;
+
+        CREATE TABLE test.rabbit (key UInt64, value UInt64)
+            ENGINE = RabbitMQ
+            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_format = 'CustomSeparated',
+                     rabbitmq_exchange_name = 'custom',
+                     rabbitmq_exchange_type = 'direct',
+                     rabbitmq_routing_key_list = 'custom1',
+                     rabbitmq_max_rows_per_message = 3,
+                     rabbitmq_flush_interval_ms = 1000,
+                     format_custom_result_before_delimiter = '<prefix>\n',
+                     format_custom_result_after_delimiter = '<suffix>\n';
+
+        CREATE MATERIALIZED VIEW test.view Engine=Log AS
+            SELECT key, value FROM test.rabbit;
+    """
+    )
+
+    credentials = pika.PlainCredentials("root", "clickhouse")
+    parameters = pika.ConnectionParameters(
+        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
+    )
+    consumer_connection = pika.BlockingConnection(parameters)
+
+    consumer = consumer_connection.channel()
+    result = consumer.queue_declare(queue="")
+    queue_name = result.method.queue
+    consumer.queue_bind(exchange="custom", queue=queue_name, routing_key="custom1")
+
+    instance.query(
+        f"INSERT INTO test.rabbit select number*10 as key, number*100 as value from numbers({num_rows}) settings format_custom_result_before_delimiter='<prefix>\n', format_custom_result_after_delimiter='<suffix>\n'"
+    )
+
+    insert_messages = []
+
+    def onReceived(channel, method, properties, body):
+        insert_messages.append(body.decode())
+        if len(insert_messages) == 2:
+            channel.stop_consuming()
+
+    consumer.basic_consume(onReceived, queue_name)
+    consumer.start_consuming()
+    consumer_connection.close()
+
+    assert len(insert_messages) == 2
+
+    assert (
+        "".join(insert_messages)
+        == "<prefix>\n0\t0\n10\t100\n20\t200\n<suffix>\n<prefix>\n30\t300\n40\t400\n<suffix>\n"
+    )
+
+    attempt = 0
+    rows = 0
+    while attempt < 100:
+        rows = int(instance.query("SELECT count() FROM test.view"))
+        if rows == num_rows:
+            break
+        attempt += 1
+
+    assert rows == num_rows
+
+    result = instance.query("SELECT * FROM test.view")
+    assert result == "0\t0\n10\t100\n20\t200\n30\t300\n40\t400\n"
+
+
+def test_row_based_formats(rabbitmq_cluster):
+    num_rows = 10
+
+    for format_name in [
+        "TSV",
+        "TSVWithNamesAndTypes",
+        "TSKV",
+        "CSV",
+        "CSVWithNamesAndTypes",
+        "CustomSeparatedWithNamesAndTypes",
+        "Values",
+        "JSON",
+        "JSONEachRow",
+        "JSONCompactEachRow",
+        "JSONCompactEachRowWithNamesAndTypes",
+        "JSONObjectEachRow",
+        "Avro",
+        "RowBinary",
+        "RowBinaryWithNamesAndTypes",
+        "MsgPack",
+    ]:
+        print(format_name)
+
+        instance.query(
+            f"""
+            DROP TABLE IF EXISTS test.view;
+            DROP TABLE IF EXISTS test.rabbit;
+
+            CREATE TABLE test.rabbit (key UInt64, value UInt64)
+                ENGINE = RabbitMQ
+                SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                         rabbitmq_format = '{format_name}',
+                         rabbitmq_exchange_name = '{format_name}',
+                         rabbitmq_exchange_type = 'direct',
+                         rabbitmq_max_block_size = 100,
+                         rabbitmq_flush_interval_ms = 1000,
+                         rabbitmq_routing_key_list = '{format_name}',
+                         rabbitmq_max_rows_per_message = 5;
+
+            CREATE MATERIALIZED VIEW test.view Engine=Log AS
+                SELECT key, value FROM test.rabbit;
+        """
+        )
+
+        credentials = pika.PlainCredentials("root", "clickhouse")
+        parameters = pika.ConnectionParameters(
+            rabbitmq_cluster.rabbitmq_ip,
+            rabbitmq_cluster.rabbitmq_port,
+            "/",
+            credentials,
+        )
+        consumer_connection = pika.BlockingConnection(parameters)
+
+        consumer = consumer_connection.channel()
+        result = consumer.queue_declare(queue="")
+        queue_name = result.method.queue
+        consumer.queue_bind(
+            exchange=format_name, queue=queue_name, routing_key=format_name
+        )
+
+        instance.query(
+            f"INSERT INTO test.rabbit SELECT number * 10 as key, number * 100 as value FROM numbers({num_rows});"
+        )
+
+        insert_messages = 0
+
+        def onReceived(channel, method, properties, body):
+            nonlocal insert_messages
+            insert_messages += 1
+            if insert_messages == 2:
+                channel.stop_consuming()
+
+        consumer.basic_consume(onReceived, queue_name)
+        consumer.start_consuming()
+        consumer_connection.close()
+
+        assert insert_messages == 2
+
+        attempt = 0
+        rows = 0
+        while attempt < 100:
+            rows = int(instance.query("SELECT count() FROM test.view"))
+            if rows == num_rows:
+                break
+            attempt += 1
+
+        assert rows == num_rows
+
+        expected = ""
+        for i in range(num_rows):
+            expected += str(i * 10) + "\t" + str(i * 100) + "\n"
+
+        result = instance.query("SELECT * FROM test.view")
+        assert result == expected
+
+
+def test_block_based_formats_1(rabbitmq_cluster):
+    instance.query(
+        """
+        CREATE TABLE test.rabbitmq (key UInt64, value UInt64)
+            ENGINE = RabbitMQ
+            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_exchange_name = 'PrettySpace',
+                     rabbitmq_exchange_type = 'direct',
+                     rabbitmq_max_block_size = 100,
+                     rabbitmq_flush_interval_ms = 1000,
+                     rabbitmq_routing_key_list = 'PrettySpace',
+                     rabbitmq_format = 'PrettySpace';
+    """
+    )
+
+    credentials = pika.PlainCredentials("root", "clickhouse")
+    parameters = pika.ConnectionParameters(
+        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
+    )
+    consumer_connection = pika.BlockingConnection(parameters)
+
+    consumer = consumer_connection.channel()
+    result = consumer.queue_declare(queue="")
+    queue_name = result.method.queue
+    consumer.queue_bind(
+        exchange="PrettySpace", queue=queue_name, routing_key="PrettySpace"
+    )
+
+    instance.query(
+        "INSERT INTO test.rabbitmq SELECT number * 10 as key, number * 100 as value FROM numbers(5) settings max_block_size=2, optimize_trivial_insert_select=0;"
+    )
+    insert_messages = []
+
+    def onReceived(channel, method, properties, body):
+        insert_messages.append(body.decode())
+        if len(insert_messages) == 3:
+            channel.stop_consuming()
+
+    consumer.basic_consume(onReceived, queue_name)
+    consumer.start_consuming()
+    consumer_connection.close()
+
+    assert len(insert_messages) == 3
+
+    data = []
+    for message in insert_messages:
+        splitted = message.split("\n")
+        assert splitted[0] == " \x1b[1mkey\x1b[0m   \x1b[1mvalue\x1b[0m"
+        assert splitted[1] == ""
+        assert splitted[-1] == ""
+        data += [line.split() for line in splitted[2:-1]]
+
+    assert data == [
+        ["0", "0"],
+        ["10", "100"],
+        ["20", "200"],
+        ["30", "300"],
+        ["40", "400"],
+    ]
+
+
+def test_block_based_formats_2(rabbitmq_cluster):
+    num_rows = 100
+
+    for format_name in [
+        "JSONColumns",
+        "Native",
+        "Arrow",
+        "Parquet",
+        "ORC",
+        "JSONCompactColumns",
+    ]:
+
+        print(format_name)
+
+        instance.query(
+            f"""
+            DROP TABLE IF EXISTS test.view;
+            DROP TABLE IF EXISTS test.rabbit;
+
+            CREATE TABLE test.rabbit (key UInt64, value UInt64)
+                ENGINE = RabbitMQ
+                SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                         rabbitmq_format = '{format_name}',
+                         rabbitmq_exchange_name = '{format_name}',
+                         rabbitmq_exchange_type = 'direct',
+                         rabbitmq_max_block_size = 100,
+                         rabbitmq_flush_interval_ms = 1000,
+                         rabbitmq_routing_key_list = '{format_name}';
+
+            CREATE MATERIALIZED VIEW test.view Engine=Log AS
+                SELECT key, value FROM test.rabbit;
+        """
+        )
+
+        credentials = pika.PlainCredentials("root", "clickhouse")
+        parameters = pika.ConnectionParameters(
+            rabbitmq_cluster.rabbitmq_ip,
+            rabbitmq_cluster.rabbitmq_port,
+            "/",
+            credentials,
+        )
+        consumer_connection = pika.BlockingConnection(parameters)
+
+        consumer = consumer_connection.channel()
+        result = consumer.queue_declare(queue="")
+        queue_name = result.method.queue
+        consumer.queue_bind(
+            exchange=format_name, queue=queue_name, routing_key=format_name
+        )
+
+        instance.query(
+            f"INSERT INTO test.rabbit SELECT number * 10 as key, number * 100 as value FROM numbers({num_rows}) settings max_block_size=12, optimize_trivial_insert_select=0;"
+        )
+
+        insert_messages = 0
+
+        def onReceived(channel, method, properties, body):
+            nonlocal insert_messages
+            insert_messages += 1
+            if insert_messages == 9:
+                channel.stop_consuming()
+
+        consumer.basic_consume(onReceived, queue_name)
+        consumer.start_consuming()
+        consumer_connection.close()
+
+        assert insert_messages == 9
+
+        attempt = 0
+        rows = 0
+        while attempt < 100:
+            rows = int(instance.query("SELECT count() FROM test.view"))
+            if rows == num_rows:
+                break
+            attempt += 1
+
+        assert rows == num_rows
+
+        result = instance.query("SELECT * FROM test.view ORDER by key")
+        expected = ""
+        for i in range(num_rows):
+            expected += str(i * 10) + "\t" + str(i * 100) + "\n"
+        assert result == expected
+
+
+def test_rabbitmq_flush_by_block_size(rabbitmq_cluster):
+    instance.query(
+        """
+         DROP TABLE IF EXISTS test.view;
+         DROP TABLE IF EXISTS test.consumer;
+
+         CREATE TABLE test.rabbitmq (key UInt64, value UInt64)
+             ENGINE = RabbitMQ
+             SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                      rabbitmq_exchange_name = 'flush_by_block',
+                      rabbitmq_queue_base = 'flush_by_block',
+                      rabbitmq_max_block_size = 100,
+                      rabbitmq_flush_interval_ms = 640000, /* should not flush by time during test */
+                      rabbitmq_format = 'JSONEachRow';
+
+         CREATE TABLE test.view (key UInt64, value UInt64)
+             ENGINE = MergeTree()
+             ORDER BY key;
+
+         CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+             SELECT * FROM test.rabbitmq;
+
+        SYSTEM STOP MERGES;
+     """
+    )
+
+    cancel = threading.Event()
+
+    def produce():
+        credentials = pika.PlainCredentials("root", "clickhouse")
+        parameters = pika.ConnectionParameters(
+            rabbitmq_cluster.rabbitmq_ip,
+            rabbitmq_cluster.rabbitmq_port,
+            "/",
+            credentials,
+        )
+        connection = pika.BlockingConnection(parameters)
+
+        while not cancel.is_set():
+            try:
+                channel = connection.channel()
+                channel.basic_publish(
+                    exchange="flush_by_block",
+                    routing_key="",
+                    body=json.dumps({"key": 0, "value": 0}),
+                )
+            except e:
+                print(f"Got error: {str(e)}")
+
+    produce_thread = threading.Thread(target=produce)
+    produce_thread.start()
+
+    while 0 == int(
+        instance.query(
+            "SELECT count() FROM system.parts WHERE database = 'test' AND table = 'view' AND name = 'all_1_1_0'"
+        )
+    ):
+        time.sleep(0.5)
+
+    cancel.set()
+    produce_thread.join()
+
+    # more flushes can happens during test, we need to check only result of first flush (part named all_1_1_0).
+    result = instance.query("SELECT count() FROM test.view WHERE _part='all_1_1_0'")
+    # logging.debug(result)
+
+    instance.query(
+        """
+         DROP TABLE test.consumer;
+         DROP TABLE test.view;
+         DROP TABLE test.rabbitmq;
+     """
+    )
+
+    # 100 = first poll should return 100 messages (and rows)
+    # not waiting for stream_flush_interval_ms
+    assert (
+        int(result) == 100
+    ), "Messages from rabbitmq should be flushed when block of size rabbitmq_max_block_size is formed!"
+
+
+def test_rabbitmq_flush_by_time(rabbitmq_cluster):
+    instance.query(
+        """
+        DROP TABLE IF EXISTS test.view;
+        DROP TABLE IF EXISTS test.consumer;
+
+        CREATE TABLE test.rabbitmq (key UInt64, value UInt64)
+            ENGINE = RabbitMQ
+            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
+                     rabbitmq_exchange_name = 'flush_by_time',
+                     rabbitmq_queue_base = 'flush_by_time',
+                     rabbitmq_max_block_size = 100,
+                     rabbitmq_flush_interval_ms = 5000,
+                     rabbitmq_format = 'JSONEachRow';
+
+        CREATE TABLE test.view (key UInt64, value UInt64, ts DateTime64(3) MATERIALIZED now64(3))
+            ENGINE = MergeTree()
+            ORDER BY key;
+    """
+    )
+
+    cancel = threading.Event()
+
+    def produce():
+        credentials = pika.PlainCredentials("root", "clickhouse")
+        parameters = pika.ConnectionParameters(
+            rabbitmq_cluster.rabbitmq_ip,
+            rabbitmq_cluster.rabbitmq_port,
+            "/",
+            credentials,
+        )
+        connection = pika.BlockingConnection(parameters)
+
+        while not cancel.is_set():
+            try:
+                channel = connection.channel()
+                channel.basic_publish(
+                    exchange="flush_by_time",
+                    routing_key="",
+                    body=json.dumps({"key": 0, "value": 0}),
+                )
+                print("Produced a message")
+                time.sleep(0.8)
+            except e:
+                print(f"Got error: {str(e)}")
+
+    produce_thread = threading.Thread(target=produce)
+    produce_thread.start()
+
+    instance.query(
+        """
+        CREATE MATERIALIZED VIEW test.consumer TO test.view AS
+            SELECT * FROM test.rabbitmq;
+    """
+    )
+
+    while True:
+        time.sleep(0.2)
+        count = instance.query(
+            "SELECT count() FROM system.parts WHERE database = 'test' AND table = 'view'"
+        )
+        print(f"kssenii total count: {count}")
+        count = int(
+            instance.query(
+                "SELECT count() FROM system.parts WHERE database = 'test' AND table = 'view' AND name = 'all_1_1_0'"
+            )
+        )
+        print(f"kssenii count: {count}")
+        if count > 0:
+            break
+
+    time.sleep(12)
+    result = instance.query("SELECT uniqExact(ts) FROM test.view")
+
+    cancel.set()
+    produce_thread.join()
+
+    instance.query(
+        """
+        DROP TABLE test.consumer;
+        DROP TABLE test.view;
+        DROP TABLE test.rabbitmq;
+    """
+    )
+
+    assert int(result) == 3


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
RabbitMQ - fix writing many small blocks by flushing data only exactly by flush_interval_ms or by max_block_size (#44404 by @kssenii)