### PR TITLE
22.8.15 Backport of #53286 - Bring back dns tests

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_coredns.yml
+++ b/docker/test/integration/runner/compose/docker_compose_coredns.yml
@@ -2,7 +2,7 @@ version: "2.3"
 
 services:
   coredns:
-    image: coredns/coredns:latest
+    image: coredns/coredns:1.9.3 # :latest broke this test
     restart: always
     volumes:
       - ${COREDNS_CONFIG_DIR}/example.com:/example.com

--- a/tests/integration/test_reverse_dns_query/configs/listen_host.xml
+++ b/tests/integration/test_reverse_dns_query/configs/listen_host.xml
@@ -1,5 +1,5 @@
-<yandex>
+<clickhouse>
     <listen_host>::</listen_host>
     <listen_host>0.0.0.0</listen_host>
     <listen_try>1</listen_try>
-</yandex>
+</clickhouse>

--- a/tests/integration/test_reverse_dns_query/coredns_config/Corefile
+++ b/tests/integration/test_reverse_dns_query/coredns_config/Corefile
@@ -1,4 +1,8 @@
 . {
+    hosts /example.com {
+        reload "20ms"
+        fallthrough
+    }
     forward . 127.0.0.11
     log
 }

--- a/tests/integration/test_reverse_dns_query/coredns_config/example.com
+++ b/tests/integration/test_reverse_dns_query/coredns_config/example.com
@@ -1,0 +1,1 @@
+filled in runtime, but needs to exist in order to be volume mapped in docker

--- a/tests/integration/test_reverse_dns_query/test.py
+++ b/tests/integration/test_reverse_dns_query/test.py
@@ -1,4 +1,5 @@
 import pytest
+import socket
 from helpers.cluster import ClickHouseCluster, get_docker_compose_path, run_and_check
 from time import sleep
 import os
@@ -30,6 +31,28 @@ def started_cluster():
         cluster.shutdown()
 
 
+def check_ptr_record(ip, hostname):
+    try:
+        host, aliaslist, ipaddrlist = socket.gethostbyaddr(ip)
+        if hostname.lower() == host.lower():
+            return True
+    except socket.herror:
+        pass
+    return False
+
+
+def setup_dns_server(ip):
+    domains_string = "test.example.com"
+    example_file_path = f'{ch_server.env_variables["COREDNS_CONFIG_DIR"]}/example.com'
+    run_and_check(f"echo '{ip} {domains_string}' > {example_file_path}", shell=True)
+
+    # DNS server takes time to reload the configuration.
+    for try_num in range(10):
+        if all(check_ptr_record(ip, host) for host in domains_string.split()):
+            break
+        sleep(1)
+
+
 def setup_ch_server(dns_server_ip):
     ch_server.exec_in_container(
         (["bash", "-c", f"echo 'nameserver {dns_server_ip}' > /etc/resolv.conf"])
@@ -42,9 +65,10 @@ def setup_ch_server(dns_server_ip):
 
 def test_reverse_dns_query(started_cluster):
     dns_server_ip = cluster.get_instance_ip(cluster.coredns_host)
-
+    random_ipv6 = "4ae8:fa0f:ee1d:68c5:0b76:1b79:7ae6:1549" # https://commentpicker.com/ip-address-generator.php
+    setup_dns_server(random_ipv6)
     setup_ch_server(dns_server_ip)
 
     for _ in range(0, 200):
-        response = ch_server.query("select reverseDNSQuery('2001:4860:4860::8888')")
-        assert response == "['dns.google']\n"
+        response = ch_server.query(f"select reverseDNSQuery('{random_ipv6}')")
+        assert response == "['test.example.com']\n"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Three tests were failing / flaky:

test_host_regexp_multiple_ptr_records
test_host_regexp_multiple_ptr_records_concurrent
test_reverse_dns_query
Hard coding coredns version to 1.9.3 (latest version of coredns when these tests were introduced) fixed 1 and 2. The latter was failing because we relied on google dns, but that can fail sometimes. To fix this, I simply setup a DNS server for this test as well. It does not rely on 3rd party stuff anymore.

Backport https://github.com/ClickHouse/ClickHouse/pull/53286

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
