### PR TITLE
Fixed stateless test `02780_final_streams_data_skipping_index`

### DIFF
--- a/tests/queries/0_stateless/02780_final_streams_data_skipping_index.reference
+++ b/tests/queries/0_stateless/02780_final_streams_data_skipping_index.reference
@@ -9,17 +9,15 @@ ExpressionTransform × 2
     (ReadFromMergeTree)
     ExpressionTransform × 2
       AggregatingSortedTransform 2 → 1
-        ExpressionTransform × 2
-          FilterSortedStreamByRange × 2
-          Description: filter values in [(999424), +inf)
-            ExpressionTransform × 2
-              MergeTreeInOrder × 2 0 → 1
-                AggregatingSortedTransform
+        FilterSortedStreamByRange × 2
+        Description: filter values in [(999424), +inf)
+          ExpressionTransform × 2
+            MergeTreeInOrder × 2 0 → 1
+              AggregatingSortedTransform
+                FilterSortedStreamByRange
+                Description: filter values in [-inf, (999424))
                   ExpressionTransform
-                    FilterSortedStreamByRange
-                    Description: filter values in [-inf, (999424))
-                      ExpressionTransform
-                        MergeTreeInOrder 0 → 1
+                    MergeTreeInOrder 0 → 1
 EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
 SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=0
 FORMAT LineAsString;
@@ -30,14 +28,12 @@ ExpressionTransform × 2
     (ReadFromMergeTree)
     ExpressionTransform × 2
       AggregatingSortedTransform 2 → 1
-        ExpressionTransform × 2
-          FilterSortedStreamByRange × 2
-          Description: filter values in [(999424), +inf)
-            ExpressionTransform × 2
-              MergeTreeInOrder × 2 0 → 1
-                AggregatingSortedTransform
+        FilterSortedStreamByRange × 2
+        Description: filter values in [(999424), +inf)
+          ExpressionTransform × 2
+            MergeTreeInOrder × 2 0 → 1
+              AggregatingSortedTransform
+                FilterSortedStreamByRange
+                Description: filter values in [-inf, (999424))
                   ExpressionTransform
-                    FilterSortedStreamByRange
-                    Description: filter values in [-inf, (999424))
-                      ExpressionTransform
-                        MergeTreeInOrder 0 → 1
+                    MergeTreeInOrder 0 → 1


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed tests, that started to fail since the pipeline layout changed.

If we'd revert all the changes done to `src/Processors/QueryPlan/PartsSplitter.cpp` in #50429 (backported via https://github.com/Altinity/ClickHouse/pull/307), then on 23.3.13 `queries/0_stateless/02780_final_streams_data_skipping_index.stdout` looks like this:
```
-- { echoOn }
EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=1
FORMAT LineAsString;
(Expression)
ExpressionTransform × 2
  (Filter)
  FilterTransform × 2
    (ReadFromMergeTree)
    ExpressionTransform × 2
      AggregatingSortedTransform 63 → 1
        FilterSortedStreamByRange × 63
        Description: filter values in [(999424), +inf)
          ExpressionTransform × 63
            MergeTreeInOrder × 63 0 → 1
              AggregatingSortedTransform 62 → 1
                FilterSortedStreamByRange × 62
                Description: filter values in [-inf, (999424))
                  ExpressionTransform × 62
                    MergeTreeInOrder × 62 0 → 1
EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=0
FORMAT LineAsString;
(Expression)
ExpressionTransform × 2
  (Filter)
  FilterTransform × 2
    (ReadFromMergeTree)
    ExpressionTransform × 2
      AggregatingSortedTransform 2 → 1
        FilterSortedStreamByRange × 2
        Description: filter values in [(999424), +inf)
          ExpressionTransform × 2
            MergeTreeInOrder × 2 0 → 1
              AggregatingSortedTransform
                FilterSortedStreamByRange
                Description: filter values in [-inf, (999424))
                  ExpressionTransform
                    MergeTreeInOrder 0 → 1
```

With code modifications from #50429, we see a significant reduction of threads (from **64** to **2**) used in stages starting with `AggregatingSortedTransform`, and `queries/0_stateless/02780_final_streams_data_skipping_index.stdout` looks like this:
```
-- { echoOn }
EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=1
FORMAT LineAsString;
(Expression)
ExpressionTransform × 2
  (Filter)
  FilterTransform × 2
    (ReadFromMergeTree)
    ExpressionTransform × 2
      AggregatingSortedTransform 2 → 1
        FilterSortedStreamByRange × 2
        Description: filter values in [(999424), +inf)
          ExpressionTransform × 2
            MergeTreeInOrder × 2 0 → 1
              AggregatingSortedTransform
                FilterSortedStreamByRange
                Description: filter values in [-inf, (999424))
                  ExpressionTransform
                    MergeTreeInOrder 0 → 1
EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=0
FORMAT LineAsString;
(Expression)
ExpressionTransform × 2
  (Filter)
  FilterTransform × 2
    (ReadFromMergeTree)
    ExpressionTransform × 2
      AggregatingSortedTransform 2 → 1
        FilterSortedStreamByRange × 2
        Description: filter values in [(999424), +inf)
          ExpressionTransform × 2
            MergeTreeInOrder × 2 0 → 1
              AggregatingSortedTransform
                FilterSortedStreamByRange
                Description: filter values in [-inf, (999424))
                  ExpressionTransform
                    MergeTreeInOrder 0 → 1
```
diff is 
```diff
--- queries/0_stateless/02780_final_streams_data_skipping_index.stdout on unmodified 23.3.13
+++ queries/0_stateless/02780_final_streams_data_skipping_index.stdout on 23.3.13 + #50429
@@ -8,16 +8,16 @@
   FilterTransform × 2
     (ReadFromMergeTree)
     ExpressionTransform × 2
-      AggregatingSortedTransform 63 → 1
-        FilterSortedStreamByRange × 63
+      AggregatingSortedTransform 2 → 1
+        FilterSortedStreamByRange × 2
         Description: filter values in [(999424), +inf)
-          ExpressionTransform × 63
-            MergeTreeInOrder × 63 0 → 1
-              AggregatingSortedTransform 62 → 1
-                FilterSortedStreamByRange × 62
+          ExpressionTransform × 2
+            MergeTreeInOrder × 2 0 → 1
+              AggregatingSortedTransform
+                FilterSortedStreamByRange
                 Description: filter values in [-inf, (999424))
-                  ExpressionTransform × 62
-                    MergeTreeInOrder × 62 0 → 1
+                  ExpressionTransform
+                    MergeTreeInOrder 0 → 1
 EXPLAIN PIPELINE SELECT * FROM data FINAL WHERE v1 >= now() - INTERVAL 180 DAY
 SETTINGS max_threads=2, max_final_threads=2, force_data_skipping_indices='v1_index', use_skip_indexes_if_final=0
 FORMAT LineAsString;

```