### PR TITLE
Using bigger servers for build jobs

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -126,7 +126,7 @@ jobs:
 #########################################################################################
   BuilderDebRelease:
     needs: [DockerHubPush]
-    runs-on: [self-hosted, builder, on-demand, type-cpx51, image-x86-app-docker-ce]
+    runs-on: [self-hosted, builder, on-demand, type-ccx53, image-x86-app-docker-ce]
     timeout-minutes: 180
     steps:
       - name: Set envs
@@ -173,7 +173,7 @@ jobs:
           sudo rm -fr "$TEMP_PATH" "$CACHES_PATH"
   BuilderDebAarch64:
     needs: [DockerHubPush]
-    runs-on: [self-hosted, builder, on-demand, type-cax41, image-arm-app-docker-ce]
+    runs-on: [self-hosted, builder, on-demand, type-ccx53, image-x86-app-docker-ce]
     steps:
       - name: Set envs
         run: |


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Moving to larger server instances to speed up build stages