### PR TITLE
Attempt to fix failing tests by reducing parallelism

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -312,7 +312,7 @@ jobs:
     with:
       test_name: Integration tests (release)
       runner_type: stress-tester, func-tester
-      batches: 4
+      batches: 6
       run_command: |
         cd "$REPO_COPY/tests/ci"
         python3 integration_test_check.py "$CHECK_NAME"
@@ -322,7 +322,7 @@ jobs:
 #############################################################################################
   RegressionStart:
     ## Not depending on the tests above since they can fail at any given moment.
-    needs: [BuilderDebRelease, BuilderDebAarch64]
+    needs: [BuilderDebRelease, BuilderDebAarch64, IntegrationTestsRelease]
     runs-on: ubuntu-latest
     steps:
       - run: true

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -16,7 +16,7 @@ import zlib  # for crc32
 
 
 MAX_RETRY = 3
-NUM_WORKERS = 3
+NUM_WORKERS = 5
 SLEEP_BETWEEN_RETRIES = 5
 PARALLEL_GROUP_SIZE = 100
 CLICKHOUSE_BINARY_PATH = "usr/bin/clickhouse"
@@ -677,6 +677,11 @@ class ClickhouseIntegrationTestsRunner:
             parallel_cmd = (
                 " --parallel {} ".format(num_workers) if num_workers > 0 else ""
             )
+            # For each re-run reduce number of workers,
+            # to improve chances of tests passing.
+            if num_workers and num_workers > 0:
+                num_workers = max(1, num_workers // 2)
+
             # -r -- show extra test summary:
             # -f -- (f)ailed
             # -E -- (E)rror

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -15,8 +15,8 @@ import shlex
 import zlib  # for crc32
 
 
-MAX_RETRY = 1
-NUM_WORKERS = 5
+MAX_RETRY = 3
+NUM_WORKERS = 3
 SLEEP_BETWEEN_RETRIES = 5
 PARALLEL_GROUP_SIZE = 100
 CLICKHOUSE_BINARY_PATH = "usr/bin/clickhouse"


### PR DESCRIPTION
Also start regressions after integration tests, maybe that will help with the docker pull limit
