### PR TITLE
23.8 Integration retries with no parallelism

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -311,7 +311,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Integration tests (release)
-      runner_type: stress-tester, func-tester
+      runner_type: self-hosted, altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-app-docker-ce
       batches: 6
       run_command: |
         cd "$REPO_COPY/tests/ci"

--- a/tests/integration/ci-runner.py
+++ b/tests/integration/ci-runner.py
@@ -16,7 +16,7 @@ import zlib  # for crc32
 
 
 MAX_RETRY = 3
-NUM_WORKERS = 5
+NUM_WORKERS = 10
 SLEEP_BETWEEN_RETRIES = 5
 PARALLEL_GROUP_SIZE = 100
 CLICKHOUSE_BINARY_PATH = "usr/bin/clickhouse"
@@ -675,7 +675,7 @@ class ClickhouseIntegrationTestsRunner:
 
             test_cmd = " ".join([shlex.quote(test) for test in sorted(test_names)])
             parallel_cmd = (
-                " --parallel {} ".format(num_workers) if num_workers > 0 else ""
+                " --parallel {} ".format(num_workers) if (num_workers > 0 or i > 0) else ""
             )
             # For each re-run reduce number of workers,
             # to improve chances of tests passing.


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Removing parallel runs during retries