### PR TITLE
23.8 Using 'gh-data' instead of 'default' for CI/CD events reporting

### DIFF
--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -491,7 +491,7 @@ FORMAT JSONCompactEachRow"""
         log_url,
         f"Build ({build_name})",
     )
-    ch_helper.insert_events_into(db="default", table="checks", events=prepared_events)
+    ch_helper.insert_events_into(db="gh-data", table="checks", events=prepared_events)
 
     # Fail the build job if it didn't succeed
     if build_status != SUCCESS:

--- a/tests/ci/install_check.py
+++ b/tests/ci/install_check.py
@@ -372,7 +372,7 @@ def main():
         args.check_name,
     )
 
-    ch_helper.insert_events_into(db="default", table="checks", events=prepared_events)
+    ch_helper.insert_events_into(db="gh-data", table="checks", events=prepared_events)
 
     if state == FAILURE:
         sys.exit(1)

--- a/tests/ci/sqlancer_check.py
+++ b/tests/ci/sqlancer_check.py
@@ -160,7 +160,7 @@ def main():
         report_url,
         check_name,
     )
-    ch_helper.insert_events_into(db="default", table="checks", events=prepared_events)
+    ch_helper.insert_events_into(db="gh-data", table="checks", events=prepared_events)
 
 
 if __name__ == "__main__":

--- a/tests/ci/sqltest.py
+++ b/tests/ci/sqltest.py
@@ -146,7 +146,7 @@ def main():
         check_name,
     )
 
-    ch_helper.insert_events_into(db="default", table="checks", events=prepared_events)
+    ch_helper.insert_events_into(db="gh-data", table="checks", events=prepared_events)
 
     logging.info("Result: '%s', '%s', '%s'", status, description, report_url)
     print(f"::notice ::Report url: {report_url}")


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Using 'gh-data' instead of 'default' for CI/CD events reporting