### PR TITLE
23.3.19 CI/CD: Update docker image tag 

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -301,6 +301,7 @@ jobs:
       test_name: Integration tests (release)
       runner_type: self-hosted, altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-app-docker-ce
       batches: 6
+      timeout_minutes: 180
       run_command: |
         cd "$REPO_COPY/tests/ci"
         python3 integration_test_check.py "$CHECK_NAME"

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -36,8 +36,7 @@ from version_helper import (
 TEMP_PATH = p.join(RUNNER_TEMP, "docker_images_check")
 BUCKETS = {
     "amd64": "package_release",
-    # NOTE(vnemkov): arm64 is temporary not supported
-    # "arm64": "package_aarch64"
+    "arm64": "package_aarch64"
 }
 git = Git(ignore_no_tags=True)
 
@@ -338,6 +337,7 @@ def main():
         args.bucket_prefix = (
             f"{S3_DOWNLOAD}/{S3_BUILDS_BUCKET}/{release_or_pr}/{pr_info.sha}"
         )
+        tags.append(f"{pr_info.number}-{pr_info.sha}")
 
     if args.push:
         subprocess.check_output(  # pylint: disable=unexpected-keyword-arg


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add `PR-commit` tag to clickhouse-server and clickhouse-keeper test images in additional to the existing `head` and `head-alpine` tags. This is to preserve testing images as previously all test images only had tag `head` and `head-alpine` tags and would be overwritten every CI/CD run.
- Add ARM arch to the clickhouse-server and clickhouse-keeper test images. 