### PR TITLE
23.3.19 CI/CD: Update Docker config for integration tests

### DIFF
--- a/docker/test/integration/runner/dockerd-entrypoint.sh
+++ b/docker/test/integration/runner/dockerd-entrypoint.sh
@@ -4,12 +4,12 @@ set -e
 mkdir -p /etc/docker/
 echo '{
     "ipv6": true,
-    "fixed-cidr-v6": "fd00::/8",
+    "fixed-cidr-v6": "2001:db8:1::/64",
     "ip-forward": true,
     "log-level": "debug",
     "storage-driver": "overlay2",
-    "insecure-registries" : ["dockerhub-proxy.dockerhub-proxy-zone:5000"],
-    "registry-mirrors" : ["http://dockerhub-proxy.dockerhub-proxy-zone:5000"]
+    "insecure-registries" : ["65.108.242.32:5000"],
+    "registry-mirrors" : ["65.108.242.32:5000"]
 }' | dd of=/etc/docker/daemon.json 2>/dev/null
 
 # In case of test hung it is convenient to use pytest --pdb to debug it,

--- a/docker/test/integration/runner/dockerd-entrypoint.sh
+++ b/docker/test/integration/runner/dockerd-entrypoint.sh
@@ -9,7 +9,7 @@ echo '{
     "log-level": "debug",
     "storage-driver": "overlay2",
     "insecure-registries" : ["65.108.242.32:5000"],
-    "registry-mirrors" : ["65.108.242.32:5000"]
+    "registry-mirrors" : ["http://65.108.242.32:5000"]
 }' | dd of=/etc/docker/daemon.json 2>/dev/null
 
 # In case of test hung it is convenient to use pytest --pdb to debug it,


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Change the integration test docker config to use `65.108.242.32` directly instead of `dockerhub-proxy.dockerhub-proxy-zone`