### PR TITLE
23.3 Change docker compose default subnet mask

### DIFF
--- a/docker/test/integration/runner/compose/docker_compose_net.yml
+++ b/docker/test/integration/runner/compose/docker_compose_net.yml
@@ -5,7 +5,7 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-      - subnet: 10.5.0.0/12
+      - subnet: 10.0.0.0/12 # why ? 10.5.0.0/12 caused an error for whatever reason
         gateway: 10.5.1.1
       - subnet: 2001:3984:3989::/64
         gateway: 2001:3984:3989::1


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
attempt to fix `docker compose up` error that pops up on some integration tests:
```
E               invalid network config:
E               invalid subnet 10.5.0.0/12: it should be 10.0.0.0/12
```