### PR TITLE
23.3.19 CI/CD: Update Regression commit hash

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -315,7 +315,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: regression-tester, on-demand, type-cpx51, image-x86-app-docker-ce
-      commit: 09db6160aac30e37169797b73fac77b4cbca41c6
+      commit: 8722f3b9709a6f38f9ad25a51536c2fa68504c1c
       arch: release 
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'release' && github.sha }}
 
@@ -325,7 +325,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: regression-tester, on-demand, type-cax41, image-arm-app-docker-ce
-      commit: 09db6160aac30e37169797b73fac77b4cbca41c6
+      commit: 8722f3b9709a6f38f9ad25a51536c2fa68504c1c
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'release' && github.sha }}
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Update clickhouse-regression to pick up latest changes.
