### PR TITLE
23.3 CI/CD: Attempt to fix BuilderReport

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -188,7 +188,6 @@ jobs:
       test_name: ClickHouse build check
       runner_type: style-checker, on-demand, type-cpx31, image-x86-app-docker-ce
       timeout_minutes: 180
-      download_artifacts_pattern: build_report_*
       additional_envs: |
         NEEDS_DATA<<NDENV
         ${{ toJSON(needs) }}

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -188,7 +188,7 @@ jobs:
       test_name: ClickHouse build check
       runner_type: style-checker, on-demand, type-cpx31, image-x86-app-docker-ce
       timeout_minutes: 180
-      download_artifacts_pattern: build_report_*.json
+      download_artifacts_pattern: build_report_*
       additional_envs: |
         NEEDS_DATA<<NDENV
         ${{ toJSON(needs) }}
@@ -311,7 +311,7 @@ jobs:
 ##################################### REGRESSION TESTS ######################################
 #############################################################################################
   RegressionTestsRelease:
-    needs: [BuilderDebRelease]
+    needs: [BuilderReport]
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
@@ -321,7 +321,7 @@ jobs:
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'release' && github.sha }}
 
   RegressionTestsAarch64:
-    needs: [BuilderDebAarch64]
+    needs: [BuilderReport]
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -188,6 +188,7 @@ jobs:
       test_name: ClickHouse build check
       runner_type: style-checker, on-demand, type-cpx31, image-x86-app-docker-ce
       timeout_minutes: 180
+      download_artifacts_pattern: build_report_*.json
       additional_envs: |
         NEEDS_DATA<<NDENV
         ${{ toJSON(needs) }}

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -38,10 +38,6 @@ name: Testing workflow
       additional_envs:
         description: additional ENV variables to setup the job
         type: string
-      download_artifacts_pattern:
-        description: A glob pattern to the artifacts that should be downloaded. (see https://github.com/actions/download-artifact `pattern`)
-        type: string
-        required: false
     secrets:
       secret_envs:
         description: if given, it's passed to the environments
@@ -159,9 +155,8 @@ jobs:
           job_type: test
 
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
-          pattern: ${{ inputs.download_artifacts_pattern }}
           path: ${{ env.REPORTS_PATH }}
 
       - name: Docker setup

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -38,6 +38,10 @@ name: Testing workflow
       additional_envs:
         description: additional ENV variables to setup the job
         type: string
+      download_artifacts_pattern:
+        description: A glob pattern to the artifacts that should be downloaded. (see https://github.com/actions/download-artifact `pattern`)
+        type: string
+        required: false
     secrets:
       secret_envs:
         description: if given, it's passed to the environments
@@ -155,8 +159,9 @@ jobs:
           job_type: test
 
       - name: Download json reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
+          pattern: ${{ inputs.download_artifacts_pattern }}
           path: ${{ env.REPORTS_PATH }}
 
       - name: Docker setup


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Download only `build_report_*.json` artifacts, since it looks like other artifacts can't be processed by `tests/ci/build_report_check.py`

In certain scenarios BuilderReport was executed after regression scripts, which generate (and upload) lots of artifacts. And it takes too long to download all those artifacts and script essentially fails to parse one of the files.

Downloading only build reports (`build_report_*.json`) should speed up download artifacts stage and set environment in which `build_report_check.py` is invoked against artifacts it can actually process.
