### PR TITLE
23.3 CI/CD: Fix SignRelease job

### DIFF
--- a/tests/ci/sign_release.py
+++ b/tests/ci/sign_release.py
@@ -70,7 +70,7 @@ def main():
         hashed_file_path = hash_file(full_path)
         signed_file_path = sign_file(hashed_file_path)
         s3_path = s3_path_prefix / os.path.basename(signed_file_path)
-        s3_helper.upload_build_file_to_s3(Path(signed_file_path), s3_path)
+        s3_helper.upload_build_file_to_s3(Path(signed_file_path), str(s3_path))
         print(f'Uploaded file {signed_file_path} to {s3_path}')
 
     # Signed hashes are:

--- a/tests/ci/sign_release.py
+++ b/tests/ci/sign_release.py
@@ -7,6 +7,7 @@ from s3_helper import S3Helper
 from pr_info import PRInfo
 from build_download_helper import download_builds_filter
 import hashlib
+from pathlib import Path
 
 GPG_BINARY_SIGNING_KEY = os.getenv("GPG_BINARY_SIGNING_KEY")
 GPG_BINARY_SIGNING_PASSPHRASE = os.getenv("GPG_BINARY_SIGNING_PASSPHRASE")
@@ -57,9 +58,9 @@ def main():
 
     s3_helper = S3Helper()
 
-    s3_path_prefix = f"{pr_info.number}/{pr_info.sha}/" + CHECK_NAME.lower().replace(
+    s3_path_prefix = Path(f"{pr_info.number}/{pr_info.sha}/" + CHECK_NAME.lower().replace(
         " ", "_"
-    ).replace("(", "_").replace(")", "_").replace(",", "_")
+    ).replace("(", "_").replace(")", "_").replace(",", "_"))
 
     # downloads `package_release` artifacts generated
     download_builds_filter(CHECK_NAME, reports_path, TEMP_PATH)
@@ -68,8 +69,8 @@ def main():
         full_path = os.path.join(TEMP_PATH, f)
         hashed_file_path = hash_file(full_path)
         signed_file_path = sign_file(hashed_file_path)
-        s3_path = f'{s3_path_prefix}/{os.path.basename(signed_file_path)}'
-        s3_helper.upload_build_file_to_s3(signed_file_path, s3_path)
+        s3_path = s3_path_prefix / os.path.basename(signed_file_path)
+        s3_helper.upload_build_file_to_s3(Path(signed_file_path), s3_path)
         print(f'Uploaded file {signed_file_path} to {s3_path}')
 
     # Signed hashes are:


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
sign_release.py using `Path` instead of `str`, as required by `s3_helper.py`.


Fixes https://github.com/Altinity/ClickHouse/actions/runs/7826936815/job/21356218878:
```
Traceback (most recent call last):
  File "/home/ubuntu/_work/ClickHouse/ClickHouse/tests/ci/sign_release.py", line 94, in <module>
    main()
  File "/home/ubuntu/_work/ClickHouse/ClickHouse/tests/ci/sign_release.py", line 72, in main
    s3_helper.upload_build_file_to_s3(signed_file_path, s3_path)
  File "/home/ubuntu/_work/ClickHouse/ClickHouse/tests/ci/s3_helper.py", line 126, in upload_build_file_to_s3
    return self._upload_file_to_s3(S3_BUILDS_BUCKET, file_path, s3_path)
  File "/home/ubuntu/_work/ClickHouse/ClickHouse/tests/ci/s3_helper.py", line 60, in _upload_file_to_s3
    if file_path.stat().st_size < 64 * 1024 * 1024:
AttributeError: 'str' object has no attribute 'stat'
```


