### PR TITLE
23.8 Amend "version is not official" log message on failure

### DIFF
--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -492,6 +492,10 @@ private:
                     LOG_FATAL(log, "ClickHouse version {} is old and should be upgraded to the latest version.", VERSION_STRING);
                 }
             }
+            else if constexpr (std::string_view(VERSION_OFFICIAL).contains("altinity build"))
+            {
+                LOG_FATAL(log, "You are using an Altinity Stable Build. Please log issues at https://github.com/Altinity/ClickHouse/issues. Thank you!");
+            }
             else
             {
                 LOG_FATAL(log, "This ClickHouse version is not official and should be upgraded to the official build.");


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove hostile "non-official" log message on failure.