### PR TITLE
Backport 23.8 - #55627 fix `test_system_merges` flakines

### DIFF
--- a/tests/integration/test_system_merges/configs/user_overrides.xml
+++ b/tests/integration/test_system_merges/configs/user_overrides.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <function_sleep_max_microseconds_per_block>10G</function_sleep_max_microseconds_per_block>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_system_merges/test.py
+++ b/tests/integration/test_system_merges/test.py
@@ -10,6 +10,7 @@ cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
     main_configs=["configs/logs_config.xml"],
+    user_configs=["configs/user_overrides.xml"],
     with_zookeeper=True,
     macros={"shard": 0, "replica": 1},
 )
@@ -17,6 +18,7 @@ node1 = cluster.add_instance(
 node2 = cluster.add_instance(
     "node2",
     main_configs=["configs/logs_config.xml"],
+    user_configs=["configs/user_overrides.xml"],
     with_zookeeper=True,
     macros={"shard": 0, "replica": 2},
 )
@@ -183,10 +185,10 @@ def test_mutation_simple(started_cluster, replicated):
             starting_block, starting_block, starting_block + 1
         )
 
-        # ALTER will sleep for 3s * 3 (rows) = 9s
+        # ALTER will sleep for 9s
         def alter():
             node1.query(
-                f"ALTER TABLE {name} UPDATE a = 42 WHERE sleep(9) = 0",
+                f"ALTER TABLE {name} UPDATE a = 42 WHERE sleep(9) OR 1",
                 settings=settings,
             )
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Fix flakiness of `test_system_merges` (by increasing sleep interval properly) (#55627 by @azat)