### PR TITLE
23.8 fix `integration/test_storage_kerberized_hdfs` : build kererberized_hadoop image by downloading `commons-daemon` via https 

### DIFF
--- a/docker/test/integration/kerberized_hadoop/Dockerfile
+++ b/docker/test/integration/kerberized_hadoop/Dockerfile
@@ -15,7 +15,10 @@ RUN curl -o krb5-libs-1.10.3-65.el6.x86_64.rpm ftp://ftp.pbone.net/mirror/vault.
     rm -fr *.rpm
 
 RUN cd /tmp && \
-    curl http://archive.apache.org/dist/commons/daemon/source/commons-daemon-1.0.15-src.tar.gz -o commons-daemon-1.0.15-src.tar.gz && \
+    curl -o wget.rpm ftp://ftp.pbone.net/mirror/vault.centos.org/6.9/os/x86_64/Packages/wget-1.12-10.el6.x86_64.rpm && \
+    rpm -i wget.rpm && \
+    rm -fr *.rpm && \
+    wget --no-check-certificate https://archive.apache.org/dist/commons/daemon/source/commons-daemon-1.0.15-src.tar.gz && \
     tar xzf commons-daemon-1.0.15-src.tar.gz && \
     cd commons-daemon-1.0.15-src/src/native/unix && \
     ./configure && \


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes kerberized_hadoop docker image build issue, addresses https://github.com/ClickHouse/ClickHouse/issues/62873