### PR TITLE
23.8.1 Fix issues with tests

### DIFF
--- a/docker/test/integration/runner/Dockerfile
+++ b/docker/test/integration/runner/Dockerfile
@@ -99,6 +99,7 @@ RUN python3 -m pip install --no-cache-dir \
     pytz \
     pyyaml==5.3.1 \
     redis \
+    requests==2.31.0 \
     requests-kerberos \
     tzlocal==2.1 \
     retry \


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Pinned version of pip packet `requests==2.31.0` in attempt to fix: 'Error while fetching server API version: Not supported URL scheme http+docker'

