### PR TITLE
24.3 Docker test images for server and keeper

### DIFF
--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -447,7 +447,7 @@ bugfix_validate_check = DigestConfig(
 # common test params
 docker_server_job_config = JobConfig(
     required_on_release_branch=True,
-    run_command='docker_server.py --check-name "$CHECK_NAME" --release-type head --allow-build-reuse',
+    run_command='docker_server.py --check-name "$CHECK_NAME" --release-type head --allow-build-reuse --push',
     digest=DigestConfig(
         include_paths=[
             "tests/ci/docker_server.py",

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -60,7 +60,7 @@ def parse_args() -> argparse.Namespace:
         "--version",
         type=version_arg,
         default=get_version_from_repo(git=git).string,
-        help="a version to build, automaticaly got from version_helper, accepts either "
+        help="a version to build, automatically got from version_helper, accepts either "
         "tag ('refs/tags/' is removed automatically) or a normal 22.2.2.2 format",
     )
     parser.add_argument(
@@ -75,13 +75,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--image-path",
         type=str,
-        default="",
+        default="docker/server",
         help="a path to docker context directory",
     )
     parser.add_argument(
         "--image-repo",
         type=str,
-        default="",
+        default="altinityinfra/clickhouse-server",
         help="image name on docker hub",
     )
     parser.add_argument(
@@ -249,7 +249,7 @@ def build_and_push_image(
     init_args = ["docker", "buildx", "build"]
     if push:
         init_args.append("--push")
-        init_args.append("--output=type=image,push-by-digest=true")
+        init_args.append("--output=type=image")
         init_args.append(f"--tag={image.repo}")
     else:
         init_args.append("--output=type=docker")

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -75,13 +75,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--image-path",
         type=str,
-        default="docker/server",
+        default="",
         help="a path to docker context directory",
     )
     parser.add_argument(
         "--image-repo",
         type=str,
-        default="altinityinfra/clickhouse-server",
+        default="",
         help="image name on docker hub",
     )
     parser.add_argument(

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -368,6 +368,7 @@ def main():
     image = DockerImageData(image_path, image_repo, False)
     args.release_type = auto_release_type(args.version, args.release_type)
     tags = gen_tags(args.version, args.release_type)
+    tags.append(f'{pr_info.number}-{args.version}')
     repo_urls = {}
     direct_urls: Dict[str, List[str]] = {}
     release_or_pr, _ = get_release_or_pr(pr_info, args.version)


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Enable pushing docker test images for server and keeper 