### PR TITLE
24.3 fix Keper base image CVE

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -12,7 +12,10 @@ RUN arch=${TARGETARCH:-amd64} \
     && ln -s "${rarch}-linux-gnu" /lib/linux-gnu
 
 
-FROM alpine
+# All versions starting from 3.17, there is a critical CVE-2024-5535
+# https://security.alpinelinux.org/vuln/CVE-2024-5535
+# on 17th of July 2024, alpine:3.16.9 had only 1 medium
+FROM alpine:3.16.9
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
All versions starting from 3.17, there is a critical CVE-2024-5535. As of now, alpine:3.16.9 had only 1 medium

https://security.alpinelinux.org/vuln/CVE-2024-5535


