### PR TITLE
24.3. Fix arm64 build of CH with BoringSSL from go 1.22

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -83,15 +83,15 @@ jobs:
       test_name: Compatibility check (amd64)
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-system-ubuntu-22.04
       data: ${{ needs.RunConfig.outputs.data }}
-  CompatibilityCheckAarch64:
-    needs: [RunConfig, BuilderDebAarch64]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_test.yml
-    secrets: inherit
-    with:
-      test_name: Compatibility check (aarch64)
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04
-      data: ${{ needs.RunConfig.outputs.data }}
+  # CompatibilityCheckAarch64:
+  #   needs: [RunConfig, BuilderDebAarch64]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   uses: ./.github/workflows/reusable_test.yml
+  #   secrets: inherit
+  #   with:
+  #     test_name: Compatibility check (aarch64)
+  #     runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04
+  #     data: ${{ needs.RunConfig.outputs.data }}
 #########################################################################################
 #################################### ORDINARY BUILDS ####################################
 #########################################################################################
@@ -106,17 +106,17 @@ jobs:
       data: ${{ needs.RunConfig.outputs.data }}
       # always rebuild on release branches to be able to publish from any commit
       force: true
-  BuilderDebAarch64:
-    needs: [RunConfig, BuildDockers]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_build.yml
-    secrets: inherit
-    with:
-      build_name: package_aarch64
-      checkout_depth: 0
-      data: ${{ needs.RunConfig.outputs.data }}
-      # always rebuild on release branches to be able to publish from any commit
-      force: true
+  # BuilderDebAarch64:
+  #   needs: [RunConfig, BuildDockers]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   uses: ./.github/workflows/reusable_build.yml
+  #   secrets: inherit
+  #   with:
+  #     build_name: package_aarch64
+  #     checkout_depth: 0
+  #     data: ${{ needs.RunConfig.outputs.data }}
+  #     # always rebuild on release branches to be able to publish from any commit
+  #     force: true
   BuilderDebAsan:
     needs: [RunConfig, BuildDockers]
     if: ${{ !failure() && !cancelled() }}
@@ -168,22 +168,23 @@ jobs:
       data: ${{ needs.RunConfig.outputs.data }}
       # always rebuild on release branches to be able to publish from any commit
       force: true
-  BuilderBinDarwinAarch64:
-    needs: [RunConfig, BuildDockers]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_build.yml
-    secrets: inherit
-    with:
-      build_name: binary_darwin_aarch64
-      checkout_depth: 0
-      data: ${{ needs.RunConfig.outputs.data }}
-      # always rebuild on release branches to be able to publish from any commit
-      force: true
+  # BuilderBinDarwinAarch64:
+  #   needs: [RunConfig, BuildDockers]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   uses: ./.github/workflows/reusable_build.yml
+  #   secrets: inherit
+  #   with:
+  #     build_name: binary_darwin_aarch64
+  #     checkout_depth: 0
+  #     data: ${{ needs.RunConfig.outputs.data }}
+  #     # always rebuild on release branches to be able to publish from any commit
+  #     force: true
+
 ############################################################################################
 ##################################### Docker images  #######################################
 ############################################################################################
   DockerServerImage:
-    needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
+    needs: [RunConfig, BuilderDebRelease]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     secrets: inherit
@@ -191,8 +192,9 @@ jobs:
       test_name: Docker server image
       runner_type: altinity-on-demand, altinity-type-cpx41, altinity-in-ash, altinity-image-x86-system-ubuntu-22.04
       data: ${{ needs.RunConfig.outputs.data }}
+
   DockerKeeperImage:
-    needs: [RunConfig, BuilderDebRelease, BuilderDebAarch64]
+    needs: [RunConfig, BuilderDebRelease]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/reusable_test.yml
     secrets: inherit
@@ -209,7 +211,7 @@ jobs:
     needs:
       - RunConfig
       - BuilderDebRelease
-      - BuilderDebAarch64
+      # - BuilderDebAarch64
       - BuilderDebAsan
       - BuilderDebTsan
       - BuilderDebUBsan
@@ -227,7 +229,7 @@ jobs:
     needs:
       - RunConfig
       - BuilderBinDarwin
-      - BuilderBinDarwinAarch64
+      # - BuilderBinDarwinAarch64
     uses: ./.github/workflows/reusable_test.yml
     secrets: inherit
     with:
@@ -238,9 +240,9 @@ jobs:
     if: ${{ !failure() && !cancelled() }}
     needs:
       - BuilderBinDarwin
-      - BuilderBinDarwinAarch64
+      # - BuilderBinDarwinAarch64
       - BuilderDebRelease
-      - BuilderDebAarch64
+      # - BuilderDebAarch64
     runs-on: [self-hosted, altinity-on-demand, altinity-setup-reporter, altinity-type-cax11, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04]
     steps:
       - name: Debug
@@ -279,17 +281,17 @@ jobs:
       data: ${{ needs.RunConfig.outputs.data }}
       run_command: |
         python3 install_check.py "$CHECK_NAME"
-  InstallPackagesTestAarch64:
-    needs: [RunConfig, BuilderDebAarch64]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_test.yml
-    secrets: inherit
-    with:
-      test_name: Install packages (arm64)
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04
-      data: ${{ needs.RunConfig.outputs.data }}
-      run_command: |
-        python3 install_check.py "$CHECK_NAME"
+  # InstallPackagesTestAarch64:
+  #   needs: [RunConfig, BuilderDebAarch64]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   uses: ./.github/workflows/reusable_test.yml
+  #   secrets: inherit
+  #   with:
+  #     test_name: Install packages (arm64)
+  #     runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04
+  #     data: ${{ needs.RunConfig.outputs.data }}
+  #     run_command: |
+  #       python3 install_check.py "$CHECK_NAME"
 ##############################################################################################
 ########################### FUNCTIONAl STATELESS TESTS #######################################
 ##############################################################################################
@@ -302,15 +304,15 @@ jobs:
       test_name: Stateless tests (release)
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-system-ubuntu-22.04
       data: ${{ needs.RunConfig.outputs.data }}
-  FunctionalStatelessTestAarch64:
-    needs: [RunConfig, BuilderDebAarch64]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_test.yml
-    secrets: inherit
-    with:
-      test_name: Stateless tests (aarch64)
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04
-      data: ${{ needs.RunConfig.outputs.data }}
+  # FunctionalStatelessTestAarch64:
+  #   needs: [RunConfig, BuilderDebAarch64]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   uses: ./.github/workflows/reusable_test.yml
+  #   secrets: inherit
+  #   with:
+  #     test_name: Stateless tests (aarch64)
+  #     runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04
+  #     data: ${{ needs.RunConfig.outputs.data }}
   FunctionalStatelessTestAsan:
     needs: [RunConfig, BuilderDebAsan]
     if: ${{ !failure() && !cancelled() }}
@@ -368,15 +370,15 @@ jobs:
       test_name: Stateful tests (release)
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-system-ubuntu-22.04
       data: ${{ needs.RunConfig.outputs.data }}
-  FunctionalStatefulTestAarch64:
-    needs: [RunConfig, BuilderDebAarch64]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_test.yml
-    secrets: inherit
-    with:
-      test_name: Stateful tests (aarch64)
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04
-      data: ${{ needs.RunConfig.outputs.data }}
+  # FunctionalStatefulTestAarch64:
+  #   needs: [RunConfig, BuilderDebAarch64]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   uses: ./.github/workflows/reusable_test.yml
+  #   secrets: inherit
+  #   with:
+  #     test_name: Stateful tests (aarch64)
+  #     runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-system-ubuntu-22.04
+  #     data: ${{ needs.RunConfig.outputs.data }}
   FunctionalStatefulTestAsan:
     needs: [RunConfig, BuilderDebAsan]
     if: ${{ !failure() && !cancelled() }}
@@ -520,18 +522,18 @@ jobs:
     with:
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-image-x86-app-docker-ce, altinity-setup-regression
       commit: c5e1513a2214ee33696c29717935e0a94989ac2a
-      arch: release 
+      arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-  RegressionTestsAarch64:
-    needs: [BuilderDebAarch64]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/regression.yml
-    secrets: inherit
-    with:
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-app-docker-ce, altinity-setup-regression
-      commit: c5e1513a2214ee33696c29717935e0a94989ac2a
-      arch: aarch64
-      build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  # RegressionTestsAarch64:
+  #   needs: [BuilderDebAarch64]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   uses: ./.github/workflows/regression.yml
+  #   secrets: inherit
+  #   with:
+  #     runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-app-docker-ce, altinity-setup-regression
+  #     commit: c5e1513a2214ee33696c29717935e0a94989ac2a
+  #     arch: aarch64
+  #     build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
   SignRelease:
     needs: [RunConfig, BuilderDebRelease]
     if: ${{ !failure() && !cancelled() }}
@@ -541,15 +543,15 @@ jobs:
       test_name: Sign release
       runner_type: altinity-on-demand, altinity-type-cpx41, altinity-in-ash, altinity-image-x86-system-ubuntu-22.04
       data: ${{ needs.RunConfig.outputs.data }}
-  SignAarch64:
-    needs: [RunConfig, BuilderDebAarch64]
-    if: ${{ !failure() && !cancelled() }}
-    uses: ./.github/workflows/reusable_sign.yml
-    secrets: inherit
-    with:
-      test_name: Sign aarch64
-      runner_type: altinity-on-demand, altinity-type-cpx41, altinity-in-ash, altinity-image-x86-system-ubuntu-22.04
-      data: ${{ needs.RunConfig.outputs.data }}
+  # SignAarch64:
+  #   needs: [RunConfig, BuilderDebAarch64]
+  #   if: ${{ !failure() && !cancelled() }}
+  #   uses: ./.github/workflows/reusable_sign.yml
+  #   secrets: inherit
+  #   with:
+  #     test_name: Sign aarch64
+  #     runner_type: altinity-on-demand, altinity-type-cpx41, altinity-in-ash, altinity-image-x86-system-ubuntu-22.04
+  #     data: ${{ needs.RunConfig.outputs.data }}
   FinishCheck:
     if: ${{ !failure() && !cancelled() }}
     needs:
@@ -560,14 +562,14 @@ jobs:
       - MarkReleaseReady
       - FunctionalStatelessTestDebug
       - FunctionalStatelessTestRelease
-      - FunctionalStatelessTestAarch64
+      # - FunctionalStatelessTestAarch64
       - FunctionalStatelessTestAsan
       - FunctionalStatelessTestTsan
       - FunctionalStatelessTestMsan
       - FunctionalStatelessTestUBsan
       - FunctionalStatefulTestDebug
       - FunctionalStatefulTestRelease
-      - FunctionalStatefulTestAarch64
+      # - FunctionalStatefulTestAarch64
       - FunctionalStatefulTestAsan
       - FunctionalStatefulTestTsan
       - FunctionalStatefulTestMsan
@@ -581,9 +583,9 @@ jobs:
       - IntegrationTestsTsan
       - IntegrationTestsRelease
       - CompatibilityCheckX86
-      - CompatibilityCheckAarch64
+      # - CompatibilityCheckAarch64
       - RegressionTestsRelease
-      - RegressionTestsAarch64
+      # - RegressionTestsAarch64
       - SignRelease
     runs-on: [self-hosted, altinity-on-demand, altinity-type-cax11, altinity-image-arm-system-ubuntu-22.04, altinity-setup-regression]
     steps:

--- a/contrib/boringssl-cmake/CMakeLists.txt
+++ b/contrib/boringssl-cmake/CMakeLists.txt
@@ -54,6 +54,14 @@ foreach(file_to_download IN LISTS FILES_TO_DOWNLOAD)
         WORLD_READ WORLD_WRITE WORLD_EXECUTE)
 endforeach()
 
+if (ARCH_AMD64)
+  set(CH_BORINGSSL_GOARCH "amd64")
+elseif(ARCH_AARCH64)
+  set(CH_BORINGSSL_GOARCH "arm64")
+else()
+  message(FATAL_ERROR "Unsupported architecture for building BoringSSL in FIPS mode")
+endif()
+
 # Build driver - the script that triggers the build and pulls out results from docker container
 file(WRITE ${BORINGSSL_BUILD_DIR}/build_boringssl_fips.sh
 "#!/bin/bash
@@ -62,7 +70,7 @@ set -ex
 OUTPUT_DIR=$1
 shift
 
-docker build . -t boringssl-builder --build-arg='GOARCH=amd64' --build-arg='GoV=1.22.5'
+docker build . -t boringssl-builder --build-arg='GOARCH=${CH_BORINGSSL_GOARCH}'
 readonly id=$(docker create boringssl-builder)
 
 docker start -a $id #| tr -dc \\\\x0-\\\\x9

--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -15,7 +15,7 @@ RUN arch=${TARGETARCH:-amd64} \
 # All versions starting from 3.17, there is a critical CVE-2024-5535
 # https://security.alpinelinux.org/vuln/CVE-2024-5535
 # on 17th of July 2024, alpine:3.16.9 had only 1 medium
-FROM alpine:3.16.9
+FROM alpine:3.20
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -375,7 +375,7 @@ def main():
     direct_urls: Dict[str, List[str]] = {}
     release_or_pr, _ = get_release_or_pr(pr_info, args.version)
 
-    for arch, build_name in zip(ARCH, ("package_release")):
+    for arch, build_name in zip(ARCH, ("package_release",)):
         if not args.bucket_prefix:
             repo_urls[
                 arch

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -35,7 +35,10 @@ from version_helper import (
 
 git = Git(ignore_no_tags=True)
 
-ARCH = ("amd64", "arm64")
+ARCH = (
+    "amd64",
+#    "arm64",
+)
 
 
 class DelOS(argparse.Action):
@@ -372,7 +375,7 @@ def main():
     direct_urls: Dict[str, List[str]] = {}
     release_or_pr, _ = get_release_or_pr(pr_info, args.version)
 
-    for arch, build_name in zip(ARCH, ("package_release", "package_aarch64")):
+    for arch, build_name in zip(ARCH, ("package_release")):
         if not args.bucket_prefix:
             repo_urls[
                 arch


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Build BoringSSL for either amd64 or arm64 based on target architecture. Also set base image for keeper to be alpine 3:20, as now it has no CVEs.
