### PR TITLE
24.3.5-FIPS Publishing server images created by PR

### DIFF
--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -447,7 +447,7 @@ bugfix_validate_check = DigestConfig(
 # common test params
 docker_server_job_config = JobConfig(
     required_on_release_branch=True,
-    run_command='docker_server.py --check-name "$CHECK_NAME" --release-type head --allow-build-reuse --push',
+    run_command='docker_server.py --check-name "$CHECK_NAME" --release-type head --allow-build-reuse',
     digest=DigestConfig(
         include_paths=[
             "tests/ci/docker_server.py",

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -447,7 +447,7 @@ bugfix_validate_check = DigestConfig(
 # common test params
 docker_server_job_config = JobConfig(
     required_on_release_branch=True,
-    run_command='docker_server.py --check-name "$CHECK_NAME" --release-type head --allow-build-reuse',
+    run_command='docker_server.py --check-name "$CHECK_NAME" --release-type head --allow-build-reuse --push',
     digest=DigestConfig(
         include_paths=[
             "tests/ci/docker_server.py",

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -365,8 +365,10 @@ def main():
     del args.image_repo
     del args.push
 
-    if pr_info.is_master():
-        push = True
+    # if pr_info.is_master():
+    #     push = True
+    # NOTE(vnemkov): always push (since we are pushing to a intermediary repo) for testing
+    push = True
 
     image = DockerImageData(image_path, image_repo, False)
     args.release_type = auto_release_type(args.version, args.release_type)

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -371,6 +371,11 @@ def main():
     image = DockerImageData(image_path, image_repo, False)
     args.release_type = auto_release_type(args.version, args.release_type)
     tags = gen_tags(args.version, args.release_type)
+
+    # NOTE(vnemkov): publish docker images created by PRs, so there is a way to test them
+    if pr_info.is_pr():
+        tags.append(f'PR-{pr_info.number}-{pr_info.sha}')
+
     repo_urls = {}
     direct_urls: Dict[str, List[str]] = {}
     release_or_pr, _ = get_release_or_pr(pr_info, args.version)

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -252,7 +252,9 @@ def build_and_push_image(
     init_args = ["docker", "buildx", "build"]
     if push:
         init_args.append("--push")
-        init_args.append("--output=type=image,push-by-digest=true")
+        # NOTE(vnemkov): since for FIPS we don't build arm64 images and don't merge that against amd64 images,
+        # we don't need to do `push-by-digest`.
+        init_args.append("--output=type=image")
         init_args.append(f"--tag={image.repo}")
     else:
         init_args.append("--output=type=docker")


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Publishing server and keeper images created by PR for testing purposes
