### PR TITLE
23.8.16 Reuse unchanged images

### DIFF
--- a/minor-change
+++ b/minor-change
@@ -1,0 +1,1 @@
+new commit

--- a/tests/ci/build_check.py
+++ b/tests/ci/build_check.py
@@ -251,7 +251,7 @@ def main():
     # e.g. `binary_darwin_aarch64/clickhouse` for `binary_darwin`
     check_for_success_run(s3_helper, f"{s3_path_prefix}/", build_name, version)
 
-    docker_image = get_image_with_version(IMAGES_PATH, IMAGE_NAME)
+    docker_image = get_image_with_version(IMAGES_PATH, IMAGE_NAME, version=pr_info.docker_image_tag)
     image_version = docker_image.version
 
     logging.info("Got version from repo %s", version.string)

--- a/tests/ci/docker_images_check.py
+++ b/tests/ci/docker_images_check.py
@@ -91,23 +91,38 @@ def get_changed_docker_images(
         str(files_changed),
     )
 
-    # Rebuild all images
-    changed_images = [DockerImage(dockerfile_dir, image_description["name"], image_description.get("only_amd64", False)) for dockerfile_dir, image_description in images_dict.items()]
+    # Find changed images
+    all_images = []
+    changed_images = []
+    for dockerfile_dir, image_description in images_dict.items():
+        all_images.append(DockerImage(dockerfile_dir, image_description["name"], image_description.get("only_amd64", False)))
+        for f in files_changed:
+            if f.startswith(dockerfile_dir):
+                name = image_description["name"]
+                only_amd64 = image_description.get("only_amd64", False)
+                logging.info(
+                    "Found changed file '%s' which affects "
+                    "docker image '%s' with path '%s'",
+                    f,
+                    name,
+                    dockerfile_dir,
+                )
+                changed_images.append(DockerImage(dockerfile_dir, name, only_amd64))
+                break
 
-    # for dockerfile_dir, image_description in images_dict.items():
-    #     for f in files_changed:
-    #         if f.startswith(dockerfile_dir):
-    #             name = image_description["name"]
-    #             only_amd64 = image_description.get("only_amd64", False)
-    #             logging.info(
-    #                 "Found changed file '%s' which affects "
-    #                 "docker image '%s' with path '%s'",
-    #                 f,
-    #                 name,
-    #                 dockerfile_dir,
-    #             )
-    #             changed_images.append(DockerImage(dockerfile_dir, name, only_amd64))
-    #             break
+    # Rebuild all on opened PR or during release
+    if pr_info.event['action'] in ['opened', 'reopened', 'published', 'prereleased']:
+        changed_images = all_images
+
+    # Check that image for the PR exists
+    elif pr_info.event['action'] == 'synchronize':
+        unchanged_images = [
+            image for image in all_images if image not in changed_images
+        ]
+        logging.info(f"Unchanged images: {unchanged_images}")
+        for image in unchanged_images:
+            if subprocess.run(f"docker manifest inspect {image.repo}:{pr_info.number}", shell=True).returncode != 0:
+                changed_images.append(image)
 
     # The order is important: dependents should go later than bases, so that
     # they are built with updated base versions.

--- a/tests/ci/functional_test_check.py
+++ b/tests/ci/functional_test_check.py
@@ -303,7 +303,7 @@ def main():
             sys.exit(0)
 
     image_name = get_image_name(check_name)
-    docker_image = get_image_with_version(reports_path, image_name)
+    docker_image = get_image_with_version(reports_path, image_name, version=pr_info.docker_image_tag)
 
     packages_path = temp_path / "packages"
     packages_path.mkdir(parents=True, exist_ok=True)

--- a/tests/ci/install_check.py
+++ b/tests/ci/install_check.py
@@ -290,7 +290,7 @@ def main():
             sys.exit(0)
 
     docker_images = {
-        name: get_image_with_version(REPORTS_PATH, name, args.download)
+        name: get_image_with_version(REPORTS_PATH, name, args.download, pr_info.docker_image_tag)
         for name in (RPM_IMAGE, DEB_IMAGE)
     }
     prepare_test_scripts()

--- a/tests/ci/integration_test_check.py
+++ b/tests/ci/integration_test_check.py
@@ -219,7 +219,7 @@ def main():
     #     logging.info("Check is already finished according to github status, exiting")
     #     sys.exit(0)
 
-    images = get_images_with_versions(reports_path, IMAGES)
+    images = get_images_with_versions(reports_path, IMAGES, version=pr_info.docker_image_tag)
     result_path = temp_path / "output_dir"
     result_path.mkdir(parents=True, exist_ok=True)
 

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -115,6 +115,7 @@ class PRInfo:
 
         if "pull_request" in github_event:  # pull request and other similar events
             self.number = github_event["pull_request"]["number"]  # type: int
+            self.docker_image_tag = str(self.number) # type: str
             if pr_event_from_api:
                 try:
                     response = get_gh_api(
@@ -191,6 +192,7 @@ class PRInfo:
             if pull_request is None or pull_request["state"] == "closed":
                 # it's merged PR to master
                 self.number = 0
+                self.docker_image_tag = str(self.number) + "-" + str(self.sha)
                 self.labels = set()
                 self.pr_html_url = f"{repo_prefix}/commits/{ref}"
                 self.base_ref = ref
@@ -202,6 +204,7 @@ class PRInfo:
                 )
             else:
                 self.number = pull_request["number"]
+                self.docker_image_tag = str(self.number)
                 self.labels = {label["name"] for label in pull_request["labels"]}
 
                 self.base_ref = pull_request["base"]["ref"]
@@ -248,6 +251,7 @@ class PRInfo:
                 "GITHUB_SHA", "0000000000000000000000000000000000000000"
             )
             self.number = 0
+            self.docker_image_tag = str(self.number) + "-" + str(self.sha)
             self.labels = set()
             repo_prefix = f"{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}"
             self.task_url = GITHUB_RUN_URL

--- a/tests/ci/stress_check.py
+++ b/tests/ci/stress_check.py
@@ -124,7 +124,7 @@ def run_stress_test(docker_image_name: str) -> None:
         logging.info("Check is already finished according to github status, exiting")
         sys.exit(0)
 
-    docker_image = get_image_with_version(reports_path, docker_image_name)
+    docker_image = get_image_with_version(reports_path, docker_image_name, version=pr_info.docker_image_tag)
 
     packages_path = temp_path / "packages"
     packages_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
PR #382 rebased onto 23.8.16

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Docker images used for the pipeline are built on opened or re-opened pull requests, during release or prelease, or when the related dockerfiles are updated.
- Pull request runs use `<PR number>` docker image tag. Release and prerelease use `0-<commit sha>`