### PR TITLE
23.8  Fix kerberized hadoop dockerfile -  do not use ftp.pbone.net

### DIFF
--- a/docker/test/integration/kerberized_hadoop/Dockerfile
+++ b/docker/test/integration/kerberized_hadoop/Dockerfile
@@ -6,11 +6,11 @@ FROM sequenceiq/hadoop-docker:2.7.0
 RUN sed -i s/xMDkzMDE0MDExNVow/0MDkzMDE4MTQwM1ow/ /etc/pki/tls/certs/ca-bundle.crt
 
 
-RUN curl -o krb5-libs-1.10.3-65.el6.x86_64.rpm ftp://ftp.pbone.net/mirror/vault.centos.org/6.10/os/x86_64/Packages/krb5-libs-1.10.3-65.el6.x86_64.rpm && \
-    curl -o krb5-workstation-1.10.3-65.el6.x86_64.rpm ftp://ftp.pbone.net/mirror/vault.centos.org/6.9/os/x86_64/Packages/krb5-workstation-1.10.3-65.el6.x86_64.rpm && \
-    curl -o libkadm5-1.10.3-65.el6.x86_64.rpm ftp://ftp.pbone.net/mirror/vault.centos.org/6.10/os/x86_64/Packages/libkadm5-1.10.3-65.el6.x86_64.rpm && \
-    curl -o libss-1.41.12-24.el6.x86_64.rpm ftp://ftp.pbone.net/mirror/vault.centos.org/6.9/cr/x86_64/Packages/libss-1.41.12-24.el6.x86_64.rpm && \
-    curl -o libcom_err-1.41.12-24.el6.x86_64.rpm ftp://ftp.pbone.net/mirror/vault.centos.org/6.9/cr/x86_64/Packages/libcom_err-1.41.12-24.el6.x86_64.rpm && \
+RUN curl -o krb5-libs-1.10.3-65.el6.x86_64.rpm ftp://ftp.icm.edu.pl/vol/rzm6/linux-slc/slc610/x86_64/Packages/krb5-libs-1.10.3-65.el6.x86_64.rpm && \
+    curl -o krb5-workstation-1.10.3-65.el6.x86_64.rpm ftp://ftp.icm.edu.pl/vol/rzm6/linux-slc/slc610/x86_64/Packages/krb5-workstation-1.10.3-65.el6.x86_64.rpm && \
+    curl -o libkadm5-1.10.3-65.el6.x86_64.rpm ftp://ftp.icm.edu.pl/vol/rzm6/linux-slc/slc610/x86_64/Packages/libkadm5-1.10.3-65.el6.x86_64.rpm && \
+    curl -o libss-1.41.12-24.el6.x86_64.rpm http://ftp.pasteur.fr/mirrors/centos-vault/6.9/cr/x86_64/Packages/libss-1.41.12-24.el6.x86_64.rpm && \
+    curl -o libcom_err-1.41.12-24.el6.x86_64.rpm http://ftp.pasteur.fr/mirrors/centos-vault/6.9/cr/x86_64/Packages/libcom_err-1.41.12-24.el6.x86_64.rpm && \
     rpm -Uvh libkadm5-1.10.3-65.el6.x86_64.rpm libss-1.41.12-24.el6.x86_64.rpm krb5-libs-1.10.3-65.el6.x86_64.rpm krb5-workstation-1.10.3-65.el6.x86_64.rpm libcom_err-1.41.12-24.el6.x86_64.rpm && \
     rm -fr *.rpm
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

ftp.pbone.net used to obtain krb5 stuff does not work any more.