### PR TITLE
23.8 Backport of #62886: fix kererberized_hadoop image

### DIFF
--- a/docker/test/integration/kerberized_hadoop/Dockerfile
+++ b/docker/test/integration/kerberized_hadoop/Dockerfile
@@ -14,14 +14,14 @@ RUN curl -o krb5-libs-1.10.3-65.el6.x86_64.rpm ftp://ftp.icm.edu.pl/vol/rzm6/lin
     rpm -Uvh libkadm5-1.10.3-65.el6.x86_64.rpm libss-1.41.12-24.el6.x86_64.rpm krb5-libs-1.10.3-65.el6.x86_64.rpm krb5-workstation-1.10.3-65.el6.x86_64.rpm libcom_err-1.41.12-24.el6.x86_64.rpm && \
     rm -fr *.rpm
 
+ADD https://archive.apache.org/dist/commons/daemon/source/commons-daemon-1.0.15-src.tar.gz /tmp/commons-daemon-1.0.15-src.tar.gz
+
 RUN cd /tmp && \
-    curl -o wget.rpm ftp://ftp.pbone.net/mirror/vault.centos.org/6.9/os/x86_64/Packages/wget-1.12-10.el6.x86_64.rpm && \
-    rpm -i wget.rpm && \
-    rm -fr *.rpm && \
-    wget --no-check-certificate https://archive.apache.org/dist/commons/daemon/source/commons-daemon-1.0.15-src.tar.gz && \
     tar xzf commons-daemon-1.0.15-src.tar.gz && \
     cd commons-daemon-1.0.15-src/src/native/unix && \
     ./configure && \
     make && \
     cp ./jsvc /usr/local/hadoop-2.7.0/sbin && \
-    [ -e /usr/local/hadoop ] || ln -s ./hadoop-2.7.0 /usr/local/hadoop
+    cd /tmp && \
+    rm -rf commons-daemon-1.0.15-src* && \
+    { [ -e /usr/local/hadoop ] || ln -s ./hadoop-2.7.0 /usr/local/hadoop; }


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Build kererberized_hadoop image by downloading commons-daemon via https (#62886 by @ilejn )
