### PR TITLE
Add config for marking broken integration tests

### DIFF
--- a/tests/integration/broken_tests.json
+++ b/tests/integration/broken_tests.json
@@ -1,0 +1,4 @@
+[
+    "test_replicated_merge_tree_replicated_db_ttl/test.py::test_replicated_db_and_ttl",
+    "test_storage_s3_queue/test.py::test_upgrade"
+]


### PR DESCRIPTION
### CI Fix or Improvement
Add [tests/integration/broken_tests.json](https://github.com/Altinity/ClickHouse/compare/customizations/24.3.9...strtgbb:ClickHouse:override_broken_tests?expand=1#diff-97496b5b35d32f1aaceccd0acfcba288e6d270339b158de1b0a066a4e6ea0eb3) which is used to selectively replace FAILED and ERROR statuses with BROKEN