### PR TITLE
24.3 Add config for marking broken integration tests

### DIFF
--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -932,7 +932,7 @@ class ClickhouseIntegrationTestsRunner:
             for fail_status in ("ERROR", "FAILED"):
                 for failed_test in group_counters[fail_status]:
                     if failed_test in known_broken_tests.keys():
-                        fail_message = known_broken_tests[failed_test]
+                        fail_message = known_broken_tests["message"][failed_test]
                         mark_as_broken = False
                         for log_path in log_paths:
                             if log_path.endswith(".log"):

--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -932,7 +932,7 @@ class ClickhouseIntegrationTestsRunner:
             for fail_status in ("ERROR", "FAILED"):
                 for failed_test in group_counters[fail_status]:
                     if failed_test in known_broken_tests.keys():
-                        fail_message = known_broken_tests["message"][failed_test]
+                        fail_message = known_broken_tests[failed_test]["message"]
                         mark_as_broken = False
                         for log_path in log_paths:
                             if log_path.endswith(".log"):

--- a/tests/integration/broken_tests.json
+++ b/tests/integration/broken_tests.json
@@ -1,0 +1,4 @@
+[
+    "test_replicated_merge_tree_replicated_db_ttl/test.py::test_replicated_db_and_ttl",
+    "test_storage_s3_queue/test.py::test_upgrade"
+]

--- a/tests/integration/broken_tests.json
+++ b/tests/integration/broken_tests.json
@@ -1,4 +1,10 @@
 {
-    "test_replicated_merge_tree_replicated_db_ttl/test.py::test_replicated_db_and_ttl": "DB::Exception: Replicated is an experimental database engine.",
-    "test_storage_s3_queue/test.py::test_upgrade": "DB::Exception: S3Queue is experimental."
+    "test_replicated_merge_tree_replicated_db_ttl/test.py::test_replicated_db_and_ttl": {
+        "message": "DB::Exception: Replicated is an experimental database engine.",
+        "reason": "Will not work without allow_experimental_database_replicated=1"
+    },
+    "test_storage_s3_queue/test.py::test_upgrade": {
+        "message": "DB::Exception: S3Queue is experimental.",
+        "reason": "Will not work without allow_experimental_s3queue=1"
+    }
 }

--- a/tests/integration/broken_tests.json
+++ b/tests/integration/broken_tests.json
@@ -1,4 +1,4 @@
-[
-    "test_replicated_merge_tree_replicated_db_ttl/test.py::test_replicated_db_and_ttl",
-    "test_storage_s3_queue/test.py::test_upgrade"
-]
+{
+    "test_replicated_merge_tree_replicated_db_ttl/test.py::test_replicated_db_and_ttl": "DB::Exception: Replicated is an experimental database engine.",
+    "test_storage_s3_queue/test.py::test_upgrade": "DB::Exception: S3Queue is experimental."
+}


### PR DESCRIPTION
### CI Fix or Improvement
Add [tests/integration/broken_tests.json](https://github.com/Altinity/ClickHouse/compare/customizations/24.3.9...strtgbb:ClickHouse:override_broken_tests?expand=1#diff-97496b5b35d32f1aaceccd0acfcba288e6d270339b158de1b0a066a4e6ea0eb3) which is used to selectively replace FAILED and ERROR statuses with BROKEN

Supersedes https://github.com/Altinity/ClickHouse/pull/469