### PR TITLE
24.3 Fix test integration/test_user_defined_object_persistence/test.py::test_persistence

### DIFF
--- a/src/Analyzer/Passes/QueryAnalysisPass.cpp
+++ b/src/Analyzer/Passes/QueryAnalysisPass.cpp
@@ -5105,7 +5105,7 @@ ProjectionName QueryAnalyzer::resolveWindow(QueryTreeNodePtr & node, IdentifierR
         auto window_node_it = scope_window_name_to_window_node.find(parent_window_name);
         if (window_node_it == scope_window_name_to_window_node.end())
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "Window '{}' does not exists. In scope {}",
+                "Window '{}' does not exist. In scope {}",
                 parent_window_name,
                 nearest_query_scope->scope_node->formatASTForErrorMessage());
 
@@ -5880,7 +5880,7 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
     {
         if (!AggregateFunctionFactory::instance().isAggregateFunctionName(function_name))
         {
-            throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION, "Aggregate function with name '{}' does not exists. In scope {}{}",
+            throw Exception(ErrorCodes::UNKNOWN_AGGREGATE_FUNCTION, "Aggregate function with name '{}' does not exist. In scope {}{}",
                             function_name, scope.scope_node->formatASTForErrorMessage(),
                             getHintsErrorMessageSuffix(AggregateFunctionFactory::instance().getHints(function_name)));
         }
@@ -5962,7 +5962,7 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
             auto hints = name_prompter.getHints(function_name, possible_function_names);
 
             throw Exception(ErrorCodes::UNKNOWN_FUNCTION,
-                "Function with name '{}' does not exists. In scope {}{}",
+                "Function with name '{}' does not exist. In scope {}{}",
                 function_name,
                 scope.scope_node->formatASTForErrorMessage(),
                 getHintsErrorMessageSuffix(hints));
@@ -8083,7 +8083,7 @@ void QueryAnalyzer::resolveQuery(const QueryTreeNodePtr & query_node, Identifier
             auto window_node_it = scope.window_name_to_window_node.find(parent_window_name);
             if (window_node_it == scope.window_name_to_window_node.end())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                    "Window '{}' does not exists. In scope {}",
+                    "Window '{}' does not exist. In scope {}",
                     parent_window_name,
                     scope.scope_node->formatASTForErrorMessage());
 

--- a/tests/integration/test_access_for_functions/test.py
+++ b/tests/integration/test_access_for_functions/test.py
@@ -42,7 +42,7 @@ def test_access_rights_for_function():
     function_resolution_error = instance.query_and_get_error("SELECT MySum(1, 2)")
     assert (
         "Unknown function MySum" in function_resolution_error
-        or "Function with name 'MySum' does not exists." in function_resolution_error
+        or "Function with name 'MySum' does not exist." in function_resolution_error
     )
 
     instance.query("REVOKE CREATE FUNCTION ON *.* FROM A")

--- a/tests/integration/test_sql_user_defined_functions_on_cluster/test.py
+++ b/tests/integration/test_sql_user_defined_functions_on_cluster/test.py
@@ -28,7 +28,7 @@ def test_sql_user_defined_functions_on_cluster():
         error_message = node.query_and_get_error("SELECT test_function(1);")
         assert (
             "Unknown function test_function" in error_message
-            or "Function with name 'test_function' does not exists. In scope SELECT test_function(1)"
+            or "Function with name 'test_function' does not exist. In scope SELECT test_function(1)"
             in error_message
         )
 

--- a/tests/integration/test_user_defined_object_persistence/test.py
+++ b/tests/integration/test_user_defined_object_persistence/test.py
@@ -43,14 +43,14 @@ def test_persistence():
     error_message = instance.query_and_get_error("SELECT MySum1(1, 2)")
     assert (
         "Unknown function MySum1" in error_message
-        or "Function with name 'MySum1' does not exists. In scope SELECT MySum1(1, 2)"
+        or "Function with name 'MySum1' does not exist. In scope SELECT MySum1(1, 2)"
         in error_message
     )
 
     error_message = instance.query_and_get_error("SELECT MySum2(1, 2)")
     assert (
         "Unknown function MySum2" in error_message
-        or "Function with name 'MySum2' does not exists. In scope SELECT MySum2(1, 2)"
+        or "Function with name 'MySum2' does not exist. In scope SELECT MySum2(1, 2)"
         in error_message
     )
 


### PR DESCRIPTION
Fix typos in tests and QueryAnalysisPass.

Upstream has fixed this issue in 24.5+.