### PR TITLE
24.3 Keeper set base image to alpine:3.20.3

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -12,10 +12,9 @@ RUN arch=${TARGETARCH:-amd64} \
     && ln -s "${rarch}-linux-gnu" /lib/linux-gnu
 
 
-# All versions starting from 3.17, there is a critical CVE-2024-5535
-# https://security.alpinelinux.org/vuln/CVE-2024-5535
-# on 17th of July 2024, alpine:3.16.9 had only 1 medium
-FROM alpine:3.16.9
+# As of Nov 3rd 2024, alpine:3.20.3 has 1 "unknown"-type CVE:
+# * https://security.alpinelinux.org/vuln/CVE-2024-9143
+FROM alpine:3.20.3
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Set keeper base image to `alpine:3.20.3` (lowest number of CVEs)

