### PR TITLE
24.3 Always push builds report

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -193,6 +193,8 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 ./build_report_check.py --reports package_release package_aarch64 package_asan package_msan package_ubsan package_tsan package_debug binary_darwin binary_darwin_aarch64
       - name: Set status
+        # NOTE(vnemkov): generate and upload the report even if previous step failed
+        if: success() || failure()
         run: |
           python3 "$GITHUB_WORKSPACE/tests/ci/ci.py" --infile ${{ toJson(needs.RunConfig.outputs.data) }} --post --job-name Builds
   MarkReleaseReady:


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Always post build's report `report.html`.
