### PR TITLE
23.8 Pin cxx version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,14 +7,6 @@ members = [
 ]
 resolver = "2"
 
-# enforce a specific version of `cxx`
-[patch.crates-io]
-cxx = "1.0.102"
-cxx-build = "1.0.102"
-cxxbridge-flags = "1.0.102"
-cxxbridge-macro = "1.0.102"
-link-cplusplus = "1.0.9"
-
 # FIXME: even though the profiles should be defined in the main cargo config we
 # cannot do this yet, since we compile each package separatelly, so you should
 # ignore warning from cargo about this.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,14 @@ members = [
 ]
 resolver = "2"
 
+# enforce a specific version of `cxx`
+[patch.crates-io]
+cxx = "1.0.102"
+cxx-build = "1.0.102"
+cxxbridge-flags = "1.0.102"
+cxxbridge-macro = "1.0.102"
+link-cplusplus = "1.0.9"
+
 # FIXME: even though the profiles should be defined in the main cargo config we
 # cannot do this yet, since we compile each package separatelly, so you should
 # ignore warning from cargo about this.

--- a/rust/skim/Cargo.toml
+++ b/rust/skim/Cargo.toml
@@ -11,7 +11,7 @@ cxx = "=1.0.83"
 term = "0.7.0"
 
 [build-dependencies]
-cxx-build = "1.0.83"
+cxx-build = "=1.0.83"
 
 [lib]
 crate-type = ["staticlib"]

--- a/rust/skim/Cargo.toml
+++ b/rust/skim/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 skim = { version = "0.10.2", default-features = false }
-cxx = "1.0.83"
+cxx = "=1.0.83"
 term = "0.7.0"
 
 [build-dependencies]


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Pin version of cxx to prevent picking up latest version