### PR TITLE
24.8 easier versioning part 2

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -24,6 +24,8 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - 'releases/24.8**'
+    tags:
+    - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -24,8 +24,6 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - 'releases/24.8**'
-    tags:
-    - '*'
   workflow_dispatch:
 
 jobs:

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -80,8 +80,12 @@ def get_pr_for_commit(sha, ref):
             ref,
             sha,
         )
-        first_pr = our_prs[0]
-        return first_pr
+        if len(our_prs) != 0:
+            first_pr = our_prs[0]
+            return first_pr
+        else:
+            return None
+
     except Exception as ex:
         logging.error(
             "Cannot fetch PR info from commit ref %s, sha %s, exception: %s",

--- a/tests/ci/test_version.py
+++ b/tests/ci/test_version.py
@@ -22,9 +22,10 @@ class TestFunctions(unittest.TestCase):
             ("v31.1.1.2-testing", vh.get_version_from_string("31.1.1.2")),
             ("refs/tags/v31.1.1.2-testing", vh.get_version_from_string("31.1.1.2")),
         )
-        for test_case in cases:
-            version = vh.version_arg(test_case[0])
-            self.assertEqual(test_case[1], version)
+        for i, test_case in enumerate(cases):
+            with self.subTest(test_case, i=i):
+                version = vh.version_arg(test_case[0])
+                self.assertEqual(test_case[1], version)
         error_cases = (
             "0.0.0",
             "1.1.1.a",
@@ -48,33 +49,40 @@ class TestFunctions(unittest.TestCase):
             expected: CHV
 
         cases = (
+            # TestCase(
+            #     "v24.6.1.1-new",
+            #     15,
+            #     "v24.4.1.2088-stable",
+            #     415,
+            #     CHV(24, 5, 1, 54487, None, 415),
+            # ),
+            # TestCase(
+            #     "v24.6.1.1-testing",
+            #     15,
+            #     "v24.4.1.2088-stable",
+            #     415,
+            #     CHV(24, 5, 1, 54487, None, 15),
+            # ),
+            # TestCase(
+            #     "v24.6.1.1-stable",
+            #     15,
+            #     "v24.4.1.2088-stable",
+            #     415,
+            #     CHV(24, 5, 1, 54487, None, 15),
+            # ),
+            # TestCase(
+            #     "v24.5.1.1-stable",
+            #     15,
+            #     "v24.4.1.2088-stable",
+            #     415,
+            #     CHV(24, 5, 1, 54487, None, 15),
+            # ),
             TestCase(
-                "v24.6.1.1-new",
-                15,
+                "v24.5.1.100-stable",
+                0,
                 "v24.4.1.2088-stable",
                 415,
-                CHV(24, 5, 1, 54487, None, 415),
-            ),
-            TestCase(
-                "v24.6.1.1-testing",
-                15,
-                "v24.4.1.2088-stable",
-                415,
-                CHV(24, 5, 1, 54487, None, 15),
-            ),
-            TestCase(
-                "v24.6.1.1-stable",
-                15,
-                "v24.4.1.2088-stable",
-                415,
-                CHV(24, 5, 1, 54487, None, 15),
-            ),
-            TestCase(
-                "v24.5.1.1-stable",
-                15,
-                "v24.4.1.2088-stable",
-                415,
-                CHV(24, 5, 1, 54487, None, 15),
+                CHV(24, 5, 1, 54487, None, 100),
             ),
         )
         git = Git(True)

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -309,7 +309,7 @@ def get_version_from_repo(
         if not (version_from_tag.major == cmake_version.major \
             and version_from_tag.minor == cmake_version.minor \
             and version_from_tag.patch == cmake_version.patch):
-            raise RuntimeError("Version generated from tag ({version_from_tag}) should have same major, minor, and patch values as version generated from cmake ({cmake_version})")
+            raise RuntimeError(f"Version generated from tag ({version_from_tag}) should have same major, minor, and patch values as version generated from cmake ({cmake_version})")
 
         # Don't need to reset version completely, mostly because revision part is not set in tag, but must be preserved
         cmake_version._flavour = version_from_tag._flavour

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -300,17 +300,21 @@ def get_version_from_repo(
         tweak=versions.get("tweak", versions["revision"]),
         flavour=versions.get("flavour", None)
     )
-    # Since 24.5 we have tags like v24.6.1.1-new, and we must check if the release
-    # branch already has it's own commit. It's necessary for a proper tweak version
-    if git is not None and git.latest_tag:
+
+    # if this commit is tagged, use tag's version instead of something stored in cmake
+    if git is not None and git.latest_tag and git.commits_since_latest == 0:
         version_from_tag = get_version_from_tag(git.latest_tag)
-        if (
-            version_from_tag.description == VersionType.NEW
-            and cmake_version < version_from_tag
-        ):
-            # We are in a new release branch without existing release.
-            # We should change the tweak version to a `tweak_to_new`
-            cmake_version.tweak = git.tweak_to_new
+        # Tag has a priority over the version written in CMake.
+        # Version must match (except tweak, flavour, description, etc.) to avoid accidental mess.
+        if not (version_from_tag.major == cmake_version.major \
+            and version_from_tag.minor == cmake_version.minor \
+            and version_from_tag.patch == cmake_version.patch):
+            raise RuntimeError("Version generated from tag ({version_from_tag}) should have same major, minor, and patch values as version generated from cmake ({cmake_version})")
+
+        # Don't need to reset version completely, mostly because revision part is not set in tag, but must be preserved
+        cmake_version._flavour = version_from_tag._flavour
+        cmake_version.tweak = version_from_tag.tweak
+
     return cmake_version
 
 
@@ -333,9 +337,16 @@ def get_version_from_string(
 
 def get_version_from_tag(tag: str) -> ClickHouseVersion:
     Git.check_tag(tag)
-    tag, description = tag[1:].split("-", 1)
-    version = get_version_from_string(tag)
-    version.with_description(description)
+    tag = tag[1:] # strip initial 'v'
+    if '-' in tag:
+        # Upstream tags with dash
+        tag, description = tag.split("-", 1)
+        version = get_version_from_string(tag)
+        version.with_description(description)
+    else:
+        # Altinity's tags, with dots as separators between parts (handled properly down the road)
+        version = get_version_from_string(tag)
+
     return version
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Version is based on tag, if there is a new tag
