### PR TITLE
24.8 easier versioning part 3

### DIFF
--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -29,6 +29,7 @@ SET(VERSION_MAJOR {major})
 SET(VERSION_MINOR {minor})
 SET(VERSION_PATCH {patch})
 SET(VERSION_GITHASH {githash})
+SET(VERSION_TWEAK {tweak})
 SET(VERSION_DESCRIBE {describe})
 SET(VERSION_STRING {string})
 # end of autochange
@@ -302,18 +303,29 @@ def get_version_from_repo(
     )
 
     # if this commit is tagged, use tag's version instead of something stored in cmake
-    if git is not None and git.latest_tag and git.commits_since_latest == 0:
+    if git is not None and git.latest_tag:
         version_from_tag = get_version_from_tag(git.latest_tag)
-        # Tag has a priority over the version written in CMake.
-        # Version must match (except tweak, flavour, description, etc.) to avoid accidental mess.
-        if not (version_from_tag.major == cmake_version.major \
-            and version_from_tag.minor == cmake_version.minor \
-            and version_from_tag.patch == cmake_version.patch):
-            raise RuntimeError(f"Version generated from tag ({version_from_tag}) should have same major, minor, and patch values as version generated from cmake ({cmake_version})")
+        logging.debug(f'Git latest tag: {git.latest_tag} ({git.commits_since_latest} commits ago)\n'
+            f'"new" tag: {git.new_tag} ({git.commits_since_new})\n'
+            f'current commit: {git.sha}\n'
+            f'current brach: {git.branch}'
+        )
+        if git.commits_since_latest == 0:
+            # Tag has a priority over the version written in CMake.
+            # Version must match (except tweak, flavour, description, etc.) to avoid accidental mess.
+            if not (version_from_tag.major == cmake_version.major \
+                and version_from_tag.minor == cmake_version.minor \
+                and version_from_tag.patch == cmake_version.patch):
+                raise RuntimeError(f"Version generated from tag ({version_from_tag}) should have same major, minor, and patch values as version generated from cmake ({cmake_version})")
 
-        # Don't need to reset version completely, mostly because revision part is not set in tag, but must be preserved
-        cmake_version._flavour = version_from_tag._flavour
-        cmake_version.tweak = version_from_tag.tweak
+            # Don't need to reset version completely, mostly because revision part is not set in tag, but must be preserved
+            logging.debug(f"Resetting TWEAK and FLAVOUR of version from cmake {cmake_version} to values from tag: {version_from_tag.tweak}.{version_from_tag._flavour}")
+            cmake_version._flavour = version_from_tag._flavour
+            cmake_version.tweak = version_from_tag.tweak
+        else:
+            # We've had some number of commits since the latest tag.
+            logging.debug(f"Bumping the TWEAK of version from cmake {cmake_version} by {git.commits_since_latest}")
+            cmake_version.tweak = cmake_version.tweak + git.commits_since_latest
 
     return cmake_version
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Updating version tweak based on previous tag and number of commits since then

