### PR TITLE
24.3 Pin cxx version

### DIFF
--- a/rust/skim/Cargo.toml
+++ b/rust/skim/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 
 [dependencies]
 skim = { version = "0.10.2", default-features = false }
-cxx = "1.0.83"
+cxx = "=1.0.83"
 term = "0.7.0"
 
 [build-dependencies]
-cxx-build = "1.0.83"
+cxx-build = "=1.0.83"
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Pin the version of cxx more strictly to prevent picking up latest version which requires a rust update. 