### PR TITLE
24.8 altinity test fix

### DIFF
--- a/docker/test/integration/base/Dockerfile
+++ b/docker/test/integration/base/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
         python3-pip \
         libcurl4-openssl-dev \
         libssl-dev \
+        iptables \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 

--- a/docker/test/integration/runner/requirements.txt
+++ b/docker/test/integration/runner/requirements.txt
@@ -112,5 +112,5 @@ wadllib~=1.3.6
 websocket-client~=0.59.0
 wheel~=0.37.1
 zipp~=1.0.0
-deltalake~=0.16.0
+deltalake==0.16.0
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
integration-tests-runner: Pin python deltalake library version to 0.16.0, integration-test: Add iptables
