### PR TITLE
24.8.8 Fix test_grpc_protocol/test.py::test_ipv6_select_one

### DIFF
--- a/.github/actions/docker_setup/action.yml
+++ b/.github/actions/docker_setup/action.yml
@@ -17,7 +17,7 @@ runs:
         sudo cat <<EOT > /etc/docker/daemon.json
         {
           "ipv6": true,
-          "fixed-cidr-v6": "2001:3984:3989::/64"
+          "fixed-cidr-v6": "2001:db8:1::/64",
         }
         EOT
         sudo chown root:root /etc/docker/daemon.json

--- a/.github/actions/docker_setup/action.yml
+++ b/.github/actions/docker_setup/action.yml
@@ -17,7 +17,7 @@ runs:
         sudo cat <<EOT > /etc/docker/daemon.json
         {
           "ipv6": true,
-          "fixed-cidr-v6": "2001:db8:1::/64",
+          "fixed-cidr-v6": "2001:db8:1::/64"
         }
         EOT
         sudo chown root:root /etc/docker/daemon.json


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
fix IPv6 `test_grpc_protocol/test.py::test_ipv6_select_one` by setting up docker daemon's `fixed-cidr-v6`
