### PR TITLE
Add missing configuration in ClientSettings Object

### DIFF
--- a/src/Disks/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/ObjectStorages/S3/diskSettings.cpp
@@ -118,6 +118,7 @@ std::unique_ptr<S3::Client> getClient(
         .use_virtual_addressing = url.is_virtual_hosted_style,
         .disable_checksum = auth_settings.disable_checksum,
         .gcs_issue_compose_request = auth_settings.gcs_issue_compose_request,
+        .is_s3express_bucket = is_s3_express_bucket
     };
 
     auto credentials_configuration = S3::CredentialsConfiguration


### PR DESCRIPTION
Backport of https://github.com/ClickHouse/ClickHouse/pull/73777

`is_s3express_bucket` configuration was removed code refactoring changes in previous commit (https://github.com/ClickHouse/ClickHouse/commit/80f195d2b983c2db2feb2d5924d06588a7382d9c)

Added this back to fix the access to S3 Express

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes https://github.com/ClickHouse/ClickHouse/issues/72078 ( S3 Express Support was broken )
