### PR TITLE
24.8 Fix Aarch64 integration test

### DIFF
--- a/tests/integration/test_backward_compatibility/test_short_strings_aggregation.py
+++ b/tests/integration/test_backward_compatibility/test_short_strings_aggregation.py
@@ -7,8 +7,10 @@ cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
     with_zookeeper=False,
+    # NOTE(vnemkov): here and below upstream uses clickhouse/clickhouse-server:24.1,
+    # the first Altinity Stable release after that was 24.3.5.47.altinitystable
     image="altinity/clickhouse-server",
-    tag="24.1" if is_arm() else CLICKHOUSE_CI_MIN_TESTED_VERSION,
+    tag="24.3.5.47.altinitystable" if is_arm() else CLICKHOUSE_CI_MIN_TESTED_VERSION,
     stay_alive=True,
     with_installed_binary=True,
 )
@@ -16,7 +18,7 @@ node2 = cluster.add_instance(
     "node2",
     with_zookeeper=False,
     image="altinity/clickhouse-server",
-    tag="24.1" if is_arm() else CLICKHOUSE_CI_MIN_TESTED_VERSION,
+    tag="24.3.5.47.altinitystable" if is_arm() else CLICKHOUSE_CI_MIN_TESTED_VERSION,
     stay_alive=True,
     with_installed_binary=True,
 )


### PR DESCRIPTION
instead of nonexisting altinity/clickhouse-server:24.1

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Using altinity/clickhouse-server:24.3.5.47.altinitystable for `tests/integration/test_backward_compatibility/test_short_strings_aggregation.py` on aarch64