### PR TITLE
24.8 unmark previously broken ubsan tests

### DIFF
--- a/tests/broken_tests.json
+++ b/tests/broken_tests.json
@@ -7,38 +7,5 @@
     },
     "03206_no_exceptions_clickhouse_local": {
         "reason": "Fails on asan,msan,tsan,debug,Aarch64"
-    },
-    "00763_long_lock_buffer_alter_destination_table": {
-        "reason": "Error, server died on ubsan"
-    },
-    "00825_protobuf_format_squares": {
-        "reason": "Error, server died on ubsan"
-    },
-    "01034_move_partition_from_table_zookeeper": {
-        "reason": "Error, server died on ubsan"
-    },
-    "01326_build_id": {
-        "reason": "Error, server died on ubsan"
-    },
-    "01475_read_subcolumns_3": {
-        "reason": "Error, server died on ubsan"
-    },
-    "01508_query_obfuscator": {
-        "reason": "Error, server died on ubsan"
-    },
-    "02118_deserialize_whole_text": {
-        "reason": "Error, server died on ubsan"
-    },
-    "02918_multif_for_nullable": {
-        "reason": "Error, server died on ubsan"
-    },
-    "03023_remove_unused_column_distinct": {
-        "reason": "Error, server died on ubsan"
-    },
-    "03215_parallel_replicas_crash_after_refactoring": {
-        "reason": "Error, server died on ubsan"
-    },
-    "03222_pr_asan_index_granularity": {
-        "reason": "Error, server died on ubsan"
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)

Since the root cause of the ubsan fails was identified, these tests most likely no longer need to be marked.