### PR TITLE
24.8 Add regression to ci_running

### DIFF
--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -15,6 +15,10 @@ S3_BUCKET = "altinity-build-artifacts"
 
 
 def get_checks_fails(client: Client, job_url: str):
+    """
+    Get tests that did not succeed for the given job URL.
+    Exclude checks that have status 'error' as they are counted in get_checks_errors.
+    """
     columns = (
         "check_name, check_status, test_name, test_status, report_url as results_link"
     )
@@ -28,6 +32,9 @@ def get_checks_fails(client: Client, job_url: str):
 
 
 def get_checks_errors(client: Client, job_url: str):
+    """
+    Get checks that have status 'error' for the given job URL.
+    """
     columns = (
         "check_name, check_status, test_name, test_status, report_url as results_link"
     )
@@ -40,6 +47,9 @@ def get_checks_errors(client: Client, job_url: str):
 
 
 def get_regression_fails(client: Client, job_url: str):
+    """
+    Get regression tests that did not succeed for the given job URL.
+    """
     # If you rename the alias for report_url, also update the formatters in format_results_as_html_table
     query = f"""SELECT arch, status, test_name, results_link
             FROM (

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -20,7 +20,7 @@ def get_checks_fails(client: Client, job_url: str):
     Exclude checks that have status 'error' as they are counted in get_checks_errors.
     """
     columns = (
-        "check_name, check_status, test_name, test_status, report_url as results_link"
+        "check_status, check_name, test_status, test_name, report_url as results_link"
     )
     query = f"""SELECT {columns} FROM `gh-data`.checks 
                 WHERE task_url='{job_url}' 
@@ -36,7 +36,7 @@ def get_checks_errors(client: Client, job_url: str):
     Get checks that have status 'error' for the given job URL.
     """
     columns = (
-        "check_name, check_status, test_name, test_status, report_url as results_link"
+        "check_status, check_name, test_status, test_name, report_url as results_link"
     )
     query = f"""SELECT {columns} FROM `gh-data`.checks 
                 WHERE task_url='{job_url}' 

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -11,9 +11,13 @@ from botocore.exceptions import NoCredentialsError
 DATABASE_HOST_VAR = "CHECKS_DATABASE_HOST"
 DATABASE_USER_VAR = "CHECKS_DATABASE_USER"
 DATABASE_PASSWORD_VAR = "CHECKS_DATABASE_PASSWORD"
+S3_BUCKET = "altinity-build-artifacts"
+
 
 def get_checks_fails(client: Client, job_url: str):
-    columns = "check_name, check_status, test_name, test_status, report_url as results_link"
+    columns = (
+        "check_name, check_status, test_name, test_status, report_url as results_link"
+    )
     query = f"""SELECT {columns} FROM `gh-data`.checks 
                 WHERE task_url='{job_url}' 
                 AND test_status in ('FAIL', 'ERROR') 
@@ -22,7 +26,9 @@ def get_checks_fails(client: Client, job_url: str):
 
 
 def get_checks_errors(client: Client, job_url: str):
-    columns = "check_name, check_status, test_name, test_status, report_url as results_link"
+    columns = (
+        "check_name, check_status, test_name, test_status, report_url as results_link"
+    )
     query = f"""SELECT {columns} FROM `gh-data`.checks 
                 WHERE task_url='{job_url}' 
                 AND check_status=='error'
@@ -38,6 +44,7 @@ def get_regression_fails(client: Client, job_url: str):
                 """
     return client.query_dataframe(query)
 
+
 def url_to_html_link(url: str) -> str:
     if not url:
         return ""
@@ -46,13 +53,16 @@ def url_to_html_link(url: str) -> str:
         text = "results"
     return f'<a href="{url}">{text}</a>'
 
+
 def format_results_as_html_table(results) -> str:
     if results.empty:
         return ""
     results.columns = [col.replace("_", " ").title() for col in results.columns]
-    html = results.to_html(index=False, formatters={"Results Link": url_to_html_link}, escape=False)
+    html = results.to_html(
+        index=False, formatters={"Results Link": url_to_html_link}, escape=False
+    )
     return html
-    
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Create a combined CI report.")
@@ -60,7 +70,13 @@ def parse_args() -> argparse.Namespace:
         "--actions-job-url", required=True, help="URL of the actions job"
     )
     parser.add_argument(
-        "--ci-running-report-url", required=True, help="URL of the CI running report"
+        "--pr-number", required=True, help="Pull request number for the S3 path"
+    )
+    parser.add_argument(
+        "--commit-sha", required=True, help="Commit SHA for the S3 path"
+    )
+    parser.add_argument(
+        "--no-upload", action="store_true", help="Do not upload the report"
     )
     return parser.parse_args()
 
@@ -68,7 +84,7 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
 
-    client = Client(
+    db_client = Client(
         host=os.getenv(DATABASE_HOST_VAR),
         user=os.getenv(DATABASE_USER_VAR),
         password=os.getenv(DATABASE_PASSWORD_VAR),
@@ -78,45 +94,51 @@ def main():
         settings={"use_numpy": True},
     )
 
-    ci_running_report_url = args.ci_running_report_url
+    s3_path = (
+        f"https://s3.amazonaws.com/{S3_BUCKET}/{args.pr_number}/{args.commit_sha}/"
+    )
+    report_destination_url = s3_path + "combined_report.html"
+    ci_running_report_url = s3_path + "ci_running.html"
+
     response = requests.get(ci_running_report_url)
-
-    report_destination_url = ci_running_report_url.replace("ci_running.html", "combined_report.html")
-    _, pr_number, commit_sha, _ = ci_running_report_url.rsplit("/", 3)
-
     if response.status_code == 200:
         ci_running_report = response.text
     else:
         print(
-            f"Failed to download CI running report. Status code: {response.status_code}"
+            f"Failed to download CI running report. Status code: {response.status_code}, Response: {response.text}"
         )
+        exit(1)
 
     combined_report = f"""{ci_running_report.split("</body>")[0]}
 <h2>Checks Fails</h2>
-{format_results_as_html_table(get_checks_fails(client, args.actions_job_url))}
+{format_results_as_html_table(get_checks_fails(db_client, args.actions_job_url))}
 
 <h2>Checks Errors</h2>
-{format_results_as_html_table(get_checks_errors(client, args.actions_job_url))}
+{format_results_as_html_table(get_checks_errors(db_client, args.actions_job_url))}
 
 <h2>Regression Fails</h2>
-{format_results_as_html_table(get_regression_fails(client, args.actions_job_url))}
+{format_results_as_html_table(get_regression_fails(db_client, args.actions_job_url))}
 
 </body>
 </html>
 """
-    
+
     report_path = Path("combined_report.html")
     report_path.write_text(combined_report, encoding="utf-8")
 
+    if args.no_upload:
+        print(f"Report saved to {report_path}")
+        exit(0)
+
     # Upload the report to S3
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client("s3")
 
     try:
         s3_client.put_object(
-            Bucket="altinity-build-artifacts",
-            Key=f"{pr_number}/{commit_sha}/combined_report.html",
+            Bucket=S3_BUCKET,
+            Key=f"{args.pr_number}/{args.commit_sha}/combined_report.html",
             Body=combined_report,
-            ContentType='text/html'
+            ContentType="text/html; charset=utf-8",
         )
     except NoCredentialsError:
         print("Credentials not available for S3 upload.")

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -130,7 +130,9 @@ def main():
 
 </body>
 </html>
-"""
+""".replace(
+        "ClickHouse CI running for", "Combined CI Report for"
+    )
 
     report_path = Path("combined_report.html")
     report_path.write_text(combined_report, encoding="utf-8")

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -78,13 +78,23 @@ def url_to_html_link(url: str) -> str:
     return f'<a href="{url}">{text}</a>'
 
 
+def format_test_name_for_linewrap(text: str) -> str:
+    """Tweak the test name to improve line wrapping."""
+    return text.replace(".py::", "/")
+
+
 def format_results_as_html_table(results) -> str:
     if results.empty:
         return ""
     results.columns = [col.replace("_", " ").title() for col in results.columns]
     html = (
         results.to_html(
-            index=False, formatters={"Results Link": url_to_html_link}, escape=False
+            index=False,
+            formatters={
+                "Results Link": url_to_html_link,
+                "Test Name": format_test_name_for_linewrap,
+            },
+            escape=False,
         )  # tbody/thead tags interfere with the table sorting script
         .replace("<tbody>\n", "")
         .replace("</tbody>\n", "")
@@ -148,17 +158,17 @@ def main():
     combined_report = (
         ci_running_report.replace("ClickHouse CI running for", "Combined CI Report for")
         .replace(
-            "</h1>",
-            f"""</h1>
-<h2>Table of Contents</h2>
+            "<table>",
+            f"""<h2>Table of Contents</h2>
 <ul>
     <li><a href="#ci-jobs-status">CI Jobs Status</a></li>
     <li><a href="#checks-fails">Checks Fails</a> ({len(fail_results['checks_fails'])})</li>
     <li><a href="#checks-errors">Checks Errors</a> ({len(fail_results['checks_errors'])})</li>
     <li><a href="#regression-fails">Regression Fails</a> ({len(fail_results['regression_fails'])})</li>
 </ul>
+
 <h2 id="ci-jobs-status">CI Jobs Status</h2>
-""",
+<table>""",
         )
         .replace(
             "</table>",

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -100,6 +100,7 @@ def format_results_as_html_table(results) -> str:
         .replace("</tbody>\n", "")
         .replace("<thead>\n", "")
         .replace("</thead>\n", "")
+        .replace('<table border="1"', '<table style="min-width: min(900px, 98vw);"')
     )
     return html
 

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import argparse
+import os
+from pathlib import Path
+
+import requests
+from clickhouse_driver import Client
+import boto3
+from botocore.exceptions import NoCredentialsError
+
+DATABASE_HOST_VAR = "CHECKS_DATABASE_HOST"
+DATABASE_USER_VAR = "CHECKS_DATABASE_USER"
+DATABASE_PASSWORD_VAR = "CHECKS_DATABASE_PASSWORD"
+
+def get_checks_fails(client: Client, job_url: str):
+    columns = "check_name, check_status, test_name, test_status, report_url as results_link"
+    query = f"""SELECT {columns} FROM `gh-data`.checks 
+                WHERE task_url='{job_url}' 
+                AND test_status in ('FAIL', 'ERROR') 
+                """
+    return client.query_dataframe(query)
+
+
+def get_checks_errors(client: Client, job_url: str):
+    columns = "check_name, check_status, test_name, test_status, report_url as results_link"
+    query = f"""SELECT {columns} FROM `gh-data`.checks 
+                WHERE task_url='{job_url}' 
+                AND check_status=='error'
+                """
+    return client.query_dataframe(query)
+
+
+def get_regression_fails(client: Client, job_url: str):
+    columns = "architecture, result, test_name, report_url as results_link"
+    query = f"""SELECT {columns} FROM `gh-data`.clickhouse_regression_results 
+                WHERE job_url='{job_url}' 
+                AND result IN ('Fail', 'Error')
+                """
+    return client.query_dataframe(query)
+
+def url_to_html_link(url: str) -> str:
+    if not url:
+        return ""
+    text = url.split("/")[-1]
+    if not text:
+        text = "results"
+    return f'<a href="{url}">{text}</a>'
+
+def format_results_as_html_table(results) -> str:
+    if results.empty:
+        return ""
+    results.columns = [col.replace("_", " ").title() for col in results.columns]
+    html = results.to_html(index=False, formatters={"Results Link": url_to_html_link}, escape=False)
+    return html
+    
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create a combined CI report.")
+    parser.add_argument(
+        "--actions-job-url", required=True, help="URL of the actions job"
+    )
+    parser.add_argument(
+        "--ci-running-report-url", required=True, help="URL of the CI running report"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    client = Client(
+        host=os.getenv(DATABASE_HOST_VAR),
+        user=os.getenv(DATABASE_USER_VAR),
+        password=os.getenv(DATABASE_PASSWORD_VAR),
+        port=9440,
+        secure="y",
+        verify=False,
+        settings={"use_numpy": True},
+    )
+
+    ci_running_report_url = args.ci_running_report_url
+    response = requests.get(ci_running_report_url)
+
+    report_destination_url = ci_running_report_url.replace("ci_running.html", "combined_report.html")
+    _, pr_number, commit_sha, _ = ci_running_report_url.rsplit("/", 3)
+
+    if response.status_code == 200:
+        ci_running_report = response.text
+    else:
+        print(
+            f"Failed to download CI running report. Status code: {response.status_code}"
+        )
+
+    combined_report = f"""{ci_running_report.split("</body>")[0]}
+<h2>Checks Fails</h2>
+{format_results_as_html_table(get_checks_fails(client, args.actions_job_url))}
+
+<h2>Checks Errors</h2>
+{format_results_as_html_table(get_checks_errors(client, args.actions_job_url))}
+
+<h2>Regression Fails</h2>
+{format_results_as_html_table(get_regression_fails(client, args.actions_job_url))}
+
+</body>
+</html>
+"""
+    
+    report_path = Path("combined_report.html")
+    report_path.write_text(combined_report, encoding="utf-8")
+
+    # Upload the report to S3
+    s3_client = boto3.client('s3')
+
+    try:
+        s3_client.put_object(
+            Bucket="altinity-build-artifacts",
+            Key=f"{pr_number}/{commit_sha}/combined_report.html",
+            Body=combined_report,
+            ContentType='text/html'
+        )
+    except NoCredentialsError:
+        print("Credentials not available for S3 upload.")
+
+    print(report_destination_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -139,6 +139,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--no-upload", action="store_true", help="Do not upload the report"
     )
+    parser.add_argument(
+        "--mark-preview", action="store_true", help="Mark the report as a preview"
+    )
     return parser.parse_args()
 
 
@@ -181,6 +184,7 @@ def main():
         .replace(
             "<table>",
             f"""<h2>Table of Contents</h2>
+{'<p style="font-weight: bold;color: #F00;">This is a preview. FinishCheck has not completed.</p>' if args.mark_preview else ""}
 <ul>
     <li><a href="#ci-jobs-status">CI Jobs Status</a></li>
     <li><a href="#checks-fails">Checks Fails</a> ({len(fail_results['checks_fails'])})</li>

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -47,9 +47,10 @@ def get_regression_fails(client: Client, job_url: str):
                     job_url,
                     report_url as results_link
                FROM `gh-data`.clickhouse_regression_results
-               GROUP BY architecture, test_name, job_url, report_url) 
+               GROUP BY architecture, test_name, job_url, report_url
+            )
             WHERE job_url='{job_url}'
-            AND result IN ('Fail', 'Error')
+            AND status IN ('Fail', 'Error')
             """
     return client.query_dataframe(query)
 

--- a/.github/create_combined_ci_report.py
+++ b/.github/create_combined_ci_report.py
@@ -76,7 +76,7 @@ def format_results_as_html_table(results) -> str:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Create a combined CI report.")
     parser.add_argument(
-        "--actions-job-url", required=True, help="URL of the actions job"
+        "--actions-run-url", required=True, help="URL of the actions run"
     )
     parser.add_argument(
         "--pr-number", required=True, help="Pull request number for the S3 path"
@@ -120,13 +120,13 @@ def main():
 
     combined_report = f"""{ci_running_report.split("</body>")[0]}
 <h2>Checks Fails</h2>
-{format_results_as_html_table(get_checks_fails(db_client, args.actions_job_url))}
+{format_results_as_html_table(get_checks_fails(db_client, args.actions_run_url))}
 
 <h2>Checks Errors</h2>
-{format_results_as_html_table(get_checks_errors(db_client, args.actions_job_url))}
+{format_results_as_html_table(get_checks_errors(db_client, args.actions_run_url))}
 
 <h2>Regression Fails</h2>
-{format_results_as_html_table(get_regression_fails(db_client, args.actions_job_url))}
+{format_results_as_html_table(get_regression_fails(db_client, args.actions_run_url))}
 
 </body>
 </html>

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -174,6 +174,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run: EXITCODE=0;
               python3
               -u ${{ env.SUITE }}/regression.py
@@ -182,6 +183,20 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: "success",
+              context: "regression-${{ matrix.SUITE }}",
+              description: "Job for ${{ matrix.SUITE }} completed with status ${{ steps.run_suite.outcome }}",
+              target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            });
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -189,7 +189,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression ${{ matrix.SUITE }}"
+          SUITE_NAME: "Regression ${{ inputs.arch }} ${{ matrix.SUITE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -249,7 +249,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression Alter ${{ matrix.ONLY }} partition"
+          SUITE_NAME: "Regression ${{ inputs.arch }} Alter ${{ matrix.ONLY }} partition"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -316,7 +316,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression Benchmark ${{ matrix.STORAGE }}"
+          SUITE_NAME: "Regression ${{ inputs.arch }} Benchmark ${{ matrix.STORAGE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -372,7 +372,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression Clickhouse Keeper SSL"
+          SUITE_NAME: "Regression ${{ inputs.arch }} Clickhouse Keeper SSL"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -430,7 +430,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression LDAP ${{ matrix.SUITE }}"
+          SUITE_NAME: "Regression ${{ inputs.arch }} LDAP ${{ matrix.SUITE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -484,7 +484,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression Parquet"
+          SUITE_NAME: "Regression ${{ inputs.arch }} Parquet"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -548,7 +548,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression Parquet ${{ matrix.STORAGE }}"
+          SUITE_NAME: "Regression ${{ inputs.arch }} Parquet ${{ matrix.STORAGE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -618,7 +618,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression S3 ${{ matrix.STORAGE }}"
+          SUITE_NAME: "Regression ${{ inputs.arch }} S3 ${{ matrix.STORAGE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -684,7 +684,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
-          SUITE_NAME: "Regression Tiered Storage ${{ matrix.STORAGE }}"
+          SUITE_NAME: "Regression ${{ inputs.arch }} Tiered Storage ${{ matrix.STORAGE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -193,6 +193,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -253,6 +257,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -320,6 +328,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -376,6 +388,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -434,6 +450,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -488,6 +508,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -552,6 +576,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -622,6 +650,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -688,6 +720,10 @@ jobs:
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -193,9 +193,9 @@ jobs:
             github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: ${{ github.event.pull_request.head.sha || github.sha }},
+              sha: "${{ github.event.pull_request.head.sha || github.sha }}",
               state: "success",
-              context: "regression-${{ matrix.SUITE }}",
+              context: "Regression-${{ matrix.SUITE }}",
               description: "Job for ${{ matrix.SUITE }} completed with status ${{ steps.run_suite.outcome }}",
               target_url: process.env.SUITE_REPORT_INDEX_URL
             });

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -184,21 +184,12 @@ jobs:
               .github/add_link_to_logs.sh;
               exit $EXITCODE
       - name: Set Commit Status
-        uses: actions/github-script@v7
+        if: always()
+        run: python3 .github/set_regression_status.py
         env:
-            SUITE_REPORT_INDEX_URL: ${{ env.SUITE_REPORT_INDEX_URL }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: "${{ github.event.pull_request.head.sha || github.sha }}",
-              state: "success",
-              context: "Regression-${{ matrix.SUITE }}",
-              description: "Job for ${{ matrix.SUITE }} completed with status ${{ steps.run_suite.outcome }}",
-              target_url: process.env.SUITE_REPORT_INDEX_URL
-            });
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression ${{ matrix.SUITE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -242,6 +233,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run:  EXITCODE=0;
               python3
               -u alter/regression.py
@@ -251,6 +243,13 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_regression_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression Alter ${{ matrix.ONLY }} partition"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -294,6 +293,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run:  EXITCODE=0;
               python3
               -u ${{ env.SUITE }}/benchmark.py
@@ -310,6 +310,13 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_regression_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression Benchmark ${{ matrix.STORAGE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -349,6 +356,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run:  EXITCODE=0;
               python3
               -u ${{ env.SUITE }}/regression.py
@@ -358,6 +366,13 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_regression_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression Clickhouse Keeper SSL"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -400,6 +415,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run:  EXITCODE=0;
               python3
               -u ${{ env.SUITE }}/regression.py
@@ -408,6 +424,13 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_regression_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression LDAP ${{ matrix.SUITE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -446,6 +469,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run:  EXITCODE=0;
               python3
               -u ${{ env.SUITE }}/regression.py
@@ -454,6 +478,13 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_regression_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression Parquet"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -497,6 +528,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run:  EXITCODE=0;
               python3
               -u ${{ env.SUITE }}/regression.py
@@ -510,6 +542,13 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_regression_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression Parquet ${{ matrix.STORAGE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -553,6 +592,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run:  EXITCODE=0;
               python3
               -u ${{ env.SUITE }}/regression.py
@@ -572,6 +612,13 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_regression_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression S3 ${{ matrix.STORAGE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1
@@ -615,6 +662,7 @@ jobs:
       - name: Get deb url
         run: python3 .github/get-deb-url.py --reports-path ${{ env.REPORTS_PATH }} --github-env $GITHUB_ENV
       - name: Run ${{ env.SUITE }} suite
+        id: run_suite
         run:  EXITCODE=0;
               python3
               -u ${{ env.SUITE }}/regression.py
@@ -630,6 +678,13 @@ jobs:
               ${{ env.args }} || EXITCODE=$?;
               .github/add_link_to_logs.sh;
               exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_regression_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression Tiered Storage ${{ matrix.STORAGE }}"
       - name: Create and upload logs
         if: always()
         run: .github/create_and_upload_logs.sh 1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -185,17 +185,19 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         uses: actions/github-script@v7
+        env:
+            SUITE_REPORT_INDEX_URL: ${{ env.SUITE_REPORT_INDEX_URL }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.sha,
+              sha: ${{ github.event.pull_request.head.sha || github.sha }},
               state: "success",
               context: "regression-${{ matrix.SUITE }}",
               description: "Job for ${{ matrix.SUITE }} completed with status ${{ steps.run_suite.outcome }}",
-              target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              target_url: process.env.SUITE_REPORT_INDEX_URL
             });
       - name: Create and upload logs
         if: always()

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -185,7 +185,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
@@ -245,7 +245,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
@@ -312,7 +312,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
@@ -368,7 +368,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
@@ -426,7 +426,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
@@ -480,7 +480,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
@@ -544,7 +544,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
@@ -614,7 +614,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}
@@ -680,7 +680,7 @@ jobs:
               exit $EXITCODE
       - name: Set Commit Status
         if: always()
-        run: python3 .github/set_regression_status.py
+        run: python3 .github/set_builds_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_OUTCOME: ${{ steps.run_suite.outcome }}

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -539,7 +539,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-image-x86-app-docker-ce, altinity-setup-regression
-      commit: 28374af9e1e9e95836865550081e6a01bf33fe7f
+      commit: 126226ed61411aa7ad68bd6e470149da16ab1eba
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -550,7 +550,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-app-docker-ce, altinity-setup-regression
-      commit: 28374af9e1e9e95836865550081e6a01bf33fe7f
+      commit: 126226ed61411aa7ad68bd6e470149da16ab1eba
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -632,7 +632,7 @@ jobs:
           build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           pr_number: ${{ github.event.number }}
         run: |
-          pip install clickhouse-driver==0.2.8
+          pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.2.0
 
           python3 .github/create_combined_ci_report.py \
             --actions-job-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} \

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -539,7 +539,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-image-x86-app-docker-ce, altinity-setup-regression
-      commit: 914f1a5256fc987f230c7c8e9a9be595326267da
+      commit: 28374af9e1e9e95836865550081e6a01bf33fe7f
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -550,7 +550,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-app-docker-ce, altinity-setup-regression
-      commit: 914f1a5256fc987f230c7c8e9a9be595326267da
+      commit: 28374af9e1e9e95836865550081e6a01bf33fe7f
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -634,6 +634,6 @@ jobs:
         run: |
           pip install clickhouse-driver==0.2.8
 
-          python3 .github/create_combined_report.py \
+          python3 .github/create_combined_ci_report.py \
             --actions-job-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} \
             --ci-running-report-url https://s3.amazonaws.com/altinity-build-artifacts/${{ env.pr_number }}/${{ env.build_sha }}/ci_running.html

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -634,6 +634,6 @@ jobs:
         run: |
           pip install clickhouse-driver==0.2.8
 
-          python3 ./github/create_combined_report.py \
+          python3 .github/create_combined_report.py \
             --actions-job-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} \
             --ci-running-report-url https://s3.amazonaws.com/altinity-build-artifacts/${{ env.pr_number }}/${{ env.build_sha }}/ci_running.html

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -632,8 +632,6 @@ jobs:
           build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           pr_number: ${{ github.event.number }}
         run: |
-          python3 -m venv venv
-          source venv/bin/activate
           pip install clickhouse-driver==0.2.8
 
           python3 ./github/create_combined_report.py \

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -539,7 +539,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-image-x86-app-docker-ce, altinity-setup-regression
-      commit: 18c56fe46fae827748c557e9ebda0599c11b0a55
+      commit: 914f1a5256fc987f230c7c8e9a9be595326267da
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -550,7 +550,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-app-docker-ce, altinity-setup-regression
-      commit: 18c56fe46fae827748c557e9ebda0599c11b0a55
+      commit: 914f1a5256fc987f230c7c8e9a9be595326267da
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -637,6 +637,6 @@ jobs:
         run: |
           pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.2.0
 
-          python3 .github/create_combined_ci_report.py --pr-number ${{ env.pr_number }} --commit_sha ${{ env.build_sha }} \
+          python3 .github/create_combined_ci_report.py --pr-number ${{ env.pr_number }} --commit-sha ${{ env.build_sha }} \
           --actions-job-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} | tee report_link.txt
           echo "Combined CI Report: [View Report]($(cat report_link.txt))" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -637,6 +637,6 @@ jobs:
         run: |
           pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.2.0
 
-          python3 .github/create_combined_ci_report.py \
-            --actions-job-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} \
-            --ci-running-report-url https://s3.amazonaws.com/altinity-build-artifacts/${{ env.pr_number }}/${{ env.build_sha }}/ci_running.html
+          python3 .github/create_combined_ci_report.py --pr-number ${{ env.pr_number }} --commit_sha ${{ env.build_sha }} \
+          --actions-job-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} | tee report_link.txt
+          echo "Combined CI Report: [View Report]($(cat report_link.txt))" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -638,5 +638,5 @@ jobs:
           pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.2.0
 
           python3 .github/create_combined_ci_report.py --pr-number ${{ env.pr_number }} --commit-sha ${{ env.build_sha }} \
-          --actions-job-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} | tee report_link.txt
+          --actions-run-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} | tee report_link.txt
           echo "Combined CI Report: [View Report]($(cat report_link.txt))" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -626,3 +626,16 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           python3 ./tests/ci/ci_buddy.py --check-wf-status
+      - name: Create and upload combined report
+        if: ${{ !cancelled() }}
+        env:
+          build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          pr_number: ${{ github.event.number }}
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install clickhouse-driver==0.2.8
+
+          python3 ./github/create_combined_report.py \
+            --actions-job-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} \
+            --ci-running-report-url https://s3.amazonaws.com/altinity-build-artifacts/${{ env.pr_number }}/${{ env.build_sha }}/ci_running.html

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -539,7 +539,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-image-x86-app-docker-ce, altinity-setup-regression
-      commit: c99795a32358a8d60dd75b3615ae26a5f97df4ae
+      commit: a5b768e5aa5d634f17c5b0c960c1e79580058347
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -550,7 +550,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-app-docker-ce, altinity-setup-regression
-      commit: c99795a32358a8d60dd75b3615ae26a5f97df4ae
+      commit: a5b768e5aa5d634f17c5b0c960c1e79580058347
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -539,7 +539,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cpx51, altinity-image-x86-app-docker-ce, altinity-setup-regression
-      commit: 126226ed61411aa7ad68bd6e470149da16ab1eba
+      commit: c99795a32358a8d60dd75b3615ae26a5f97df4ae
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -550,7 +550,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-app-docker-ce, altinity-setup-regression
-      commit: 126226ed61411aa7ad68bd6e470149da16ab1eba
+      commit: c99795a32358a8d60dd75b3615ae26a5f97df4ae
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -632,11 +632,19 @@ jobs:
           CHECKS_DATABASE_HOST: ${{ secrets.CHECKS_DATABASE_HOST }}
           CHECKS_DATABASE_USER: ${{ secrets.CHECKS_DATABASE_USER }}
           CHECKS_DATABASE_PASSWORD: ${{ secrets.CHECKS_DATABASE_PASSWORD }}
-          build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          pr_number: ${{ github.event.number }}
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          PR_NUMBER: ${{ github.event.number }}
+          ACTIONS_RUN_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
+        shell: bash
         run: |
           pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.2.0
 
-          python3 .github/create_combined_ci_report.py --pr-number ${{ env.pr_number }} --commit-sha ${{ env.build_sha }} \
-          --actions-run-url ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }} | tee report_link.txt
-          echo "Combined CI Report: [View Report]($(cat report_link.txt))" >> $GITHUB_STEP_SUMMARY
+          REPORT_LINK=$(python3 .github/create_combined_ci_report.py --pr-number $PR_NUMBER --commit-sha $COMMIT_SHA --actions-run-url $ACTIONS_RUN_URL)
+
+          IS_VALID_URL=$(echo $REPORT_LINK | grep -E '^https?://')
+          if [[ -n $IS_VALID_URL ]]; then
+            echo "Combined CI Report: [View Report]($REPORT_LINK)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Error: $REPORT_LINK" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -629,6 +629,9 @@ jobs:
       - name: Create and upload combined report
         if: ${{ !cancelled() }}
         env:
+          CHECKS_DATABASE_HOST: ${{ secrets.CHECKS_DATABASE_HOST }}
+          CHECKS_DATABASE_USER: ${{ secrets.CHECKS_DATABASE_USER }}
+          CHECKS_DATABASE_PASSWORD: ${{ secrets.CHECKS_DATABASE_PASSWORD }}
           build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           pr_number: ${{ github.event.number }}
         run: |

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -414,6 +414,7 @@ class CI:
             required_builds=[BuildNames.PACKAGE_AARCH64],
             num_batches=6,
             runner_type=Runners.FUNC_TESTER_ARM,
+            timeout=9000,  # the job timed out with default value (7200)
         ),
         JobNames.INTEGRATION_TEST: CommonJobConfigs.INTEGRATION_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE],

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -403,11 +403,12 @@ class CI:
         JobNames.INTEGRATION_TEST_ASAN_OLD_ANALYZER: CommonJobConfigs.INTEGRATION_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_ASAN],
             num_batches=6,
+            timeout=12000,  # the job timed out with default value (7200)
         ),
         JobNames.INTEGRATION_TEST_TSAN: CommonJobConfigs.INTEGRATION_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_TSAN],
             num_batches=6,
-            timeout=9000,  # the job timed out with default value (7200)
+            timeout=12000,  # the job timed out with default value (7200)
         ),
         JobNames.INTEGRATION_TEST_ARM: CommonJobConfigs.INTEGRATION_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_AARCH64],
@@ -418,6 +419,7 @@ class CI:
             required_builds=[BuildNames.PACKAGE_RELEASE],
             num_batches=4,
             #release_only=True,
+            timeout=12000,  # the job timed out with default value (7200)
         ),
         JobNames.INTEGRATION_TEST_FLAKY: CommonJobConfigs.INTEGRATION_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_ASAN],

--- a/tests/ci/ci_config.py
+++ b/tests/ci/ci_config.py
@@ -414,7 +414,7 @@ class CI:
             required_builds=[BuildNames.PACKAGE_AARCH64],
             num_batches=6,
             runner_type=Runners.FUNC_TESTER_ARM,
-            timeout=9000,  # the job timed out with default value (7200)
+            timeout=12000,  # the job timed out with default value (7200)
         ),
         JobNames.INTEGRATION_TEST: CommonJobConfigs.INTEGRATION_TEST.with_properties(
             required_builds=[BuildNames.PACKAGE_RELEASE],


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

`ci_running.html` uses Github statuses as a data source. By uploading the necessary details from `regression.yml`, results should start appearing in `ci_running`. 

Progress:
- [x] Show that manually setting status from `regression.yml` appears in `ci_running.html`
- [x] Set the status fields to sensible values.
- [x] Make sure `ci_running.html` is regenerated after setting status
