### PR TITLE
Scheduled runs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,12 @@
+## Scheduled Build Run Results
+
+Results for **the latest** release_workflow scheduled runs.
+
+| Branch | Status |
+| ------------ | - |
+| **`project-antalya-24.12.2`**    | [![project-antalya-24.12.2](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml/badge.svg?branch=project-antalya-24.12.2&event=workflow_dispatch)](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml?query=branch%3Aproject-antalya-24.12.2) |
+| **`customizations/22.8.21`**     | [![customizations/22.8.21](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml/badge.svg?branch=customizations/22.8.21&event=workflow_dispatch)](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml?query=branch%3Acustomizations/22.8.21)     |
+| **`customizations/23.3.19`**     | [![customizations/23.3.19](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml/badge.svg?branch=customizations/23.3.19&event=workflow_dispatch)](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml?query=branch%3Acustomizations/23.3.19)     |
+| **`customizations/23.8.16`**     | [![customizations/23.8.16](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml/badge.svg?branch=customizations/23.8.16&event=workflow_dispatch)](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml?query=branch%3Acustomizations/23.8.16)     |
+| **`customizations/24.3.14`**     | [![customizations/24.3.14](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml/badge.svg?branch=customizations/24.3.14&event=workflow_dispatch)](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml?query=branch%3Acustomizations/24.3.14)     |
+| **`customizations/24.8.11`**     | [![customizations/24.8.11](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml/badge.svg?branch=customizations/24.8.11&event=workflow_dispatch)](https://github.com/Altinity/ClickHouse/actions/workflows/release_branches.yml?query=branch%3Acustomizations/24.8.11)     |

--- a/.github/workflows/scheduled_runs.yml
+++ b/.github/workflows/scheduled_runs.yml
@@ -1,0 +1,59 @@
+name: Scheduled Altinity Stable Builds
+
+on:
+  schedule:
+    - cron: '0 0 * * 6' #Weekly run for stable versions 
+    - cron: '0 0 * * *' #Daily run for antalya versions
+  # Make sure that any changes to this file is actually tested with PRs
+  pull_request:
+    types:
+      - synchronize
+      - reopened
+      - opened
+    paths:
+      - '**/scheduled_runs.yml'
+
+jobs:
+  DailyRuns:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: 
+          - project-antalya-24.12.2
+    name: ${{ matrix.branch }}
+    if: github.event.schedule != '0 0 * * 6'
+    runs-on: ubuntu-latest
+    steps:
+     - name: Run ${{ matrix.branch }} workflow
+       run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/Altinity/ClickHouse/actions/workflows/release_branches.yml/dispatches \
+          -d '{"ref":"${{ matrix.branch }}"}'
+
+  WeeklyRuns:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: 
+          - customizations/22.8.21
+          - customizations/23.3.19
+          - customizations/23.8.16
+          - customizations/24.3.14
+          - customizations/24.8.11
+    name: ${{ matrix.branch }}
+    if: github.event.schedule != '0 0 * * *'
+    runs-on: ubuntu-latest
+    steps:
+     - name: Run ${{ matrix.branch }} workflow
+       run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/Altinity/ClickHouse/actions/workflows/release_branches.yml/dispatches \
+          -d '{"ref":"${{ matrix.branch }}"}'


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Enable scheduled runs for 22.8, 23.3, 23.8, 24.3, 24.8, and altinityantalya
- Add README showing status of the latest runs of `release_workflow` across enabled branches.