### PR TITLE
24.8 Backport of #72190 - Respect `prefer_locahost_replica` in `parallel_distributed_insert_select`

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -994,7 +994,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
     for (size_t shard_index : collections::range(0, shards_info.size()))
     {
         const auto & shard_info = shards_info[shard_index];
-        if (shard_info.isLocal())
+        if (shard_info.isLocal() && settings.prefer_localhost_replica)
         {
             InterpreterInsertQuery interpreter(
                 new_query,


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Respect `prefer_locahost_replica` when building plan for distributed `INSERT ... SELECT.` (#72190 by @filimonov)

### Documentation entry for user-facing changes


