### PR TITLE
24.8 CI/CD: Proper version for docker images

### DIFF
--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1212,7 +1212,7 @@ def main() -> int:
         # BUT if there is pre-computed version from `RunConfig` then we can reuse it.
         pre_configured_version = indata.get('version', None)
         git = Git(True)
-        if pre_configured_version is not None and git.latest_tag:
+        if pre_configured_version is not None and git.commits_since_latest == 0:
             print(f"Updating version in repo files from '{get_version_from_repo()}' to '{pre_configured_version}'")
 
             pre_configured_version = get_version_from_string(pre_configured_version, git)

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1209,12 +1209,13 @@ def main() -> int:
         )
 
         # NOTE (vnemkov) Job might have not checked out tags, hence can't properly compute version number.
-        # If there is pre-computed version number from `RunConfig` then reuse it
+        # BUT if there is pre-computed version from `RunConfig` then we can reuse it.
         pre_configured_version = indata.get('version', None)
-        if pre_configured_version is not None:
+        git = Git(True)
+        if pre_configured_version is not None and git.latest_tag:
             print(f"Updating version in repo files from '{get_version_from_repo()}' to '{pre_configured_version}'")
 
-            pre_configured_version = get_version_from_string(pre_configured_version, Git(True))
+            pre_configured_version = get_version_from_string(pre_configured_version, git)
             # need to set description, otherwise subsequent call to get_version_from_repo() fails
             pre_configured_version.with_description(pre_configured_version.flavour)
 

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -67,7 +67,11 @@ from ci_cache import CiCache
 from ci_settings import CiSettings
 from ci_buddy import CIBuddy
 from stopwatch import Stopwatch
-from version_helper import get_version_from_repo
+from version_helper import (
+    get_version_from_repo,
+    get_version_from_string,
+    update_cmake_version
+)
 
 # pylint: disable=too-many-lines
 
@@ -1203,6 +1207,14 @@ def main() -> int:
         print(
             f"Check if rerun for name: [{check_name}], extended name [{check_name_with_group}]"
         )
+
+        # NOTE (vnemkov) Job might have not checked out tags, hence can't properly compute version number.
+        # If there is pre-computed version number from `RunConfig` then reuse it
+        pre_configured_version = indata.get('version', None)
+        if pre_configured_version is not None:
+            print(f"Updating version in repo files from : {get_version_from_repo()} to {pre_configured_version}")
+            pre_configured_version = get_version_from_string(pre_configured_version)
+            update_cmake_version(pre_configured_version)
 
         if job_report.job_skipped and not args.force:
             print(

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1212,8 +1212,12 @@ def main() -> int:
         # If there is pre-computed version number from `RunConfig` then reuse it
         pre_configured_version = indata.get('version', None)
         if pre_configured_version is not None:
-            print(f"Updating version in repo files from : {get_version_from_repo()} to {pre_configured_version}")
-            pre_configured_version = get_version_from_string(pre_configured_version)
+            print(f"Updating version in repo files from '{get_version_from_repo()}' to '{pre_configured_version}'")
+
+            pre_configured_version = get_version_from_string(pre_configured_version, Git(True))
+            # need to set description, otherwise subsequent call to get_version_from_repo() fails
+            pre_configured_version.with_description(pre_configured_version.flavour)
+
             update_cmake_version(pre_configured_version)
 
         if job_report.job_skipped and not args.force:

--- a/tests/ci/ci.py
+++ b/tests/ci/ci.py
@@ -1208,7 +1208,7 @@ def main() -> int:
             f"Check if rerun for name: [{check_name}], extended name [{check_name_with_group}]"
         )
 
-        # NOTE (vnemkov) Job might have not checked out tags, hence can't properly compute version number.
+        # NOTE (vnemkov) Job might have not checked out git tags, so it can't properly compute version number.
         # BUT if there is pre-computed version from `RunConfig` then we can reuse it.
         pre_configured_version = indata.get('version', None)
         git = Git(True)
@@ -1216,7 +1216,7 @@ def main() -> int:
             print(f"Updating version in repo files from '{get_version_from_repo()}' to '{pre_configured_version}'")
 
             pre_configured_version = get_version_from_string(pre_configured_version, git)
-            # need to set description, otherwise subsequent call to get_version_from_repo() fails
+            # need to set description, otherwise subsequent call (perhaps from other script) to get_version_from_repo() fails
             pre_configured_version.with_description(pre_configured_version.flavour)
 
             update_cmake_version(pre_configured_version)

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -30,6 +30,7 @@ SET(VERSION_MINOR {minor})
 SET(VERSION_PATCH {patch})
 SET(VERSION_GITHASH {githash})
 SET(VERSION_TWEAK {tweak})
+SET(VERSION_FLAVOUR {flavour})
 SET(VERSION_DESCRIBE {describe})
 SET(VERSION_STRING {string})
 # end of autochange
@@ -154,6 +155,10 @@ class ClickHouseVersion:
         return self._description
 
     @property
+    def flavour(self) -> str:
+        return self._flavour
+
+    @property
     def string(self):
         version_as_string = ".".join(
             (str(self.major), str(self.minor), str(self.patch), str(self.tweak))
@@ -182,6 +187,7 @@ class ClickHouseVersion:
             "githash": self.githash,
             "describe": self.describe,
             "string": self.string,
+            "flavour": self.flavour
         }
 
     def as_tuple(self) -> Tuple[int, int, int, int]:


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Proper version for docker images

#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64--> All with Aarch64
- [ ] <!---ci_exclude_KEYWORD--> Add your option here