### PR TITLE
Fix flaky 03299_parquet_object_storage_metadata_cache

### DIFF
--- a/tests/queries/0_stateless/03299_parquet_object_storage_metadata_cache.sql
+++ b/tests/queries/0_stateless/03299_parquet_object_storage_metadata_cache.sql
@@ -10,11 +10,11 @@ INSERT INTO t_parquet_03262 SELECT number FROM numbers(10) SETTINGS s3_truncate_
 
 SELECT COUNT(*)
 FROM s3(s3_conn, filename = 'test_03262_*', format = Parquet)
-SETTINGS input_format_parquet_use_metadata_cache=1;
+SETTINGS input_format_parquet_use_metadata_cache=1, optimize_count_from_files=0;
 
 SELECT COUNT(*)
 FROM s3(s3_conn, filename = 'test_03262_*', format = Parquet)
-SETTINGS input_format_parquet_use_metadata_cache=1, log_comment='test_03262_parquet_metadata_cache';
+SETTINGS input_format_parquet_use_metadata_cache=1, optimize_count_from_files=0, log_comment='test_03262_parquet_metadata_cache';
 
 SYSTEM FLUSH LOGS;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flaky `03299_parquet_object_storage_metadata_cache` by setting `optimize_count_from_files` to 0

### Documentation entry for user-facing changes


