### PR TITLE
24.8 Backport of #74534 - Fix UBSan error in ParquetDataBuffer

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
+++ b/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
@@ -60,7 +60,7 @@ public:
 	    auto offset = i * sizeof(ParquetType);
 
 	    // necessary to prevent memory alignment issues https://github.com/ClickHouse/ClickHouse/issues/74512#issuecomment-2587260001
-            std::memcpy(&temp, data + offset, sizeof(ParquetType));
+            memcpy(&temp, data + offset, sizeof(ParquetType));
             dst[i] = static_cast<TValue>(temp);
         }
 

--- a/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
+++ b/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
@@ -54,11 +54,14 @@ public:
         auto necessary_bytes = count * sizeof(ParquetType);
         checkAvaible(necessary_bytes);
 
-        const ParquetType* src = reinterpret_cast<const ParquetType*>(data);
-
         for (std::size_t i = 0; i < count; i++)
         {
-            dst[i] = static_cast<TValue>(src[i]);
+            ParquetType temp;
+	    auto offset = i * sizeof(ParquetType);
+
+	    // necessary to prevent memory alignment issues https://github.com/ClickHouse/ClickHouse/issues/74512#issuecomment-2587260001
+            std::memcpy(&temp, data + offset, sizeof(ParquetType));
+            dst[i] = static_cast<TValue>(temp);
         }
 
         consume(necessary_bytes);

--- a/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
+++ b/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
@@ -57,9 +57,9 @@ public:
         for (std::size_t i = 0; i < count; i++)
         {
             ParquetType temp;
-	    auto offset = i * sizeof(ParquetType);
+            auto offset = i * sizeof(ParquetType);
 
-	    // necessary to prevent memory alignment issues https://github.com/ClickHouse/ClickHouse/issues/74512#issuecomment-2587260001
+            // necessary to prevent memory alignment issues https://github.com/ClickHouse/ClickHouse/issues/74512#issuecomment-2587260001
             memcpy(&temp, data + offset, sizeof(ParquetType));
             dst[i] = static_cast<TValue>(temp);
         }

--- a/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
+++ b/src/Processors/Formats/Impl/Parquet/ParquetDataBuffer.h
@@ -56,12 +56,8 @@ public:
 
         for (std::size_t i = 0; i < count; i++)
         {
-            ParquetType temp;
             auto offset = i * sizeof(ParquetType);
-
-            // necessary to prevent memory alignment issues https://github.com/ClickHouse/ClickHouse/issues/74512#issuecomment-2587260001
-            memcpy(&temp, data + offset, sizeof(ParquetType));
-            dst[i] = static_cast<TValue>(temp);
+            dst[i] = unalignedLoad<TValue>(data + offset);
         }
 
         consume(necessary_bytes);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix mem alignment issue reported by UBSan https://github.com/ClickHouse/ClickHouse/issues/74512. Backport of https://github.com/ClickHouse/ClickHouse/pull/74534

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
