### PR TITLE
Convert functions with object_storage_cluster setting to cluster functions

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -268,6 +268,20 @@ void StorageObjectStorageCluster::updateQueryToSendIfNeeded(
     if (cluster_name_in_settings)
     {
         configuration->addStructureAndFormatToArgsIfNeeded(args, structure, configuration->format, context, /*with_structure=*/true);
+
+        auto * select_query = query->as<ASTSelectQuery>();
+        if (select_query)
+        {
+            auto settings = select_query->settings();
+            if (settings)
+            {
+                auto & settings_ast = settings->as<ASTSetQuery &>();
+                if (settings_ast.changes.removeSetting("object_storage_cluster") && settings_ast.changes.empty())
+                {
+                    select_query->setExpression(ASTSelectQuery::Expression::SETTINGS, {});
+                }
+            }
+        }
     }
     else
     {

--- a/src/Storages/extractTableFunctionArgumentsFromSelectQuery.cpp
+++ b/src/Storages/extractTableFunctionArgumentsFromSelectQuery.cpp
@@ -11,7 +11,7 @@
 namespace DB
 {
 
-ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query)
+ASTFunction * extractTableFunctionFromSelectQuery(ASTPtr & query)
 {
     auto * select_query = query->as<ASTSelectQuery>();
     if (!select_query || !select_query->tables())
@@ -23,6 +23,14 @@ ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query)
         return nullptr;
 
     auto * table_function = table_expression->table_function->as<ASTFunction>();
+    return table_function;
+}
+
+ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query)
+{
+    auto * table_function = extractTableFunctionFromSelectQuery(query);
+    if (!table_function)
+        return nullptr;
     return table_function->arguments->as<ASTExpressionList>();
 }
 

--- a/src/Storages/extractTableFunctionArgumentsFromSelectQuery.h
+++ b/src/Storages/extractTableFunctionArgumentsFromSelectQuery.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <Parsers/IAST_fwd.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/ASTExpressionList.h>
 
 namespace DB
 {
 
+ASTFunction * extractTableFunctionFromSelectQuery(ASTPtr & query);
 ASTExpressionList * extractTableFunctionArgumentsFromSelectQuery(ASTPtr & query);
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Convert functions with object_storage_cluster setting to cluster functions

### Documentation entry for user-facing changes
This allows to use old clickhouse version in swarm cluster. All logic with `object_storage_cluster` setting executed only on initiator, other nodes can work without it.

