### PR TITLE
Fix S3 table function as table

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1918,8 +1918,7 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
         auto table_function_ast = create.as_table_function->ptr();
         auto table_function = TableFunctionFactory::instance().get(table_function_ast, getContext());
 
-        if (!table_function->canBeUsedToCreateTable())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table function '{}' cannot be used to create a table", table_function->getName());
+        table_function->validateUseToCreateTable();
 
         /// In case of CREATE AS table_function() query we should use global context
         /// in storage creation because there will be no query context on server startup

--- a/src/TableFunctions/ITableFunction.h
+++ b/src/TableFunctions/ITableFunction.h
@@ -78,7 +78,7 @@ public:
 
     virtual bool supportsReadingSubsetOfColumns(const ContextPtr &) { return true; }
 
-    virtual bool canBeUsedToCreateTable() const { return true; }
+    virtual void validateUseToCreateTable() const {}
 
     /// Create storage according to the query.
     StoragePtr

--- a/src/TableFunctions/ITableFunctionCluster.h
+++ b/src/TableFunctions/ITableFunctionCluster.h
@@ -15,6 +15,7 @@ namespace ErrorCodes
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int CLUSTER_DOESNT_EXIST;
     extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 /// Base class for *Cluster table functions that require cluster_name for the first argument.
@@ -35,7 +36,10 @@ public:
         args.insert(args.begin(), cluster_name_arg);
     }
 
-    bool canBeUsedToCreateTable() const override { return false; }
+    void validateUseToCreateTable() const override
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table function '{}' cannot be used to create a table", getName());
+    }
 
 protected:
     void parseArguments(const ASTPtr & ast, ContextPtr context) override

--- a/src/TableFunctions/TableFunctionObjectStorageClusterFallback.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorageClusterFallback.cpp
@@ -15,6 +15,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int BAD_ARGUMENTS;
 }
 
 struct S3ClusterFallbackDefinition
@@ -115,6 +116,16 @@ StoragePtr TableFunctionObjectStorageClusterFallback<Definition, Base>::executeI
     }
     else
         return BaseSimple::executeImpl(ast_function, context, table_name, cached_columns, is_insert_query);
+}
+
+template <typename Definition, typename Base>
+void TableFunctionObjectStorageClusterFallback<Definition, Base>::validateUseToCreateTable() const
+{
+    if (is_cluster_function)
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Table function '{}' cannot be used to create a table in cluster mode",
+            getName());
 }
 
 #if USE_AWS_S3

--- a/src/TableFunctions/TableFunctionObjectStorageClusterFallback.h
+++ b/src/TableFunctions/TableFunctionObjectStorageClusterFallback.h
@@ -26,6 +26,8 @@ public:
 
     String getName() const override { return name; }
 
+    void validateUseToCreateTable() const override;
+
 private:
     const char * getStorageTypeName() const override
     {


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix usage S3 table function as table

### Documentation entry for user-facing changes
Query
```
CREATE TABLE db.tablefunc06 (a int) AS s3('http://some_addr:9000/cloud-storage-01/data.tsv', 'M9O7o0SX5I4udXhWxI12', '9ijqzmVN83fzD9XDkEAAAAAAAA', 'TSV');
```
fails with
```
Code: 36. DB::Exception: Received from localhost:9000. DB::Exception: Table function 's3' cannot be used to create a table. (BAD_ARGUMENTS)
```

