### PR TITLE
Fix s3 partition wildcard

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -89,7 +89,9 @@ StorageObjectStorageCluster::StorageObjectStorageCluster(
     metadata.setColumns(columns);
     metadata.setConstraints(constraints_);
 
-    if (sample_path.empty() && context_->getSettingsRef()[Setting::use_hive_partitioning])
+    if (sample_path.empty()
+            && context_->getSettingsRef()[Setting::use_hive_partitioning]
+            && !configuration->withPartitionWildcard())
         sample_path = getPathSample(metadata, context_);
 
     setInMemoryMetadata(metadata);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix s3 partition wildcard

### Documentation entry for user-facing changes
```
CREATE TABLE t_parquet_03262 (a UInt64)
ENGINE = S3(s3_conn, filename = 'test_03262_{_partition_id}', format = Parquet)
PARTITION BY a;
```
tries to et object with path `test_03262_{_partition_id` and gets 404 error.

