### PR TITLE
Antalya: Fixed AST formatting hiccups that occured during merge

### DIFF
--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -487,15 +487,6 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     if (is_ordinary_view && aliases_list && !as_table_function)
     {
         ostr << (settings.one_line ? " (" : "\n(");
-        aliases_list->format(ostr, settings, state, frame);
-        ostr << (settings.one_line ? ")" : "\n)");
-    }
-
-    frame.expression_list_always_start_on_new_line = true;
-
-    if (is_ordinary_view && aliases_list && !as_table_function)
-    {
-        ostr << (settings.one_line ? " (" : "\n(");
         FormatStateStacked frame_nested = frame;
         aliases_list->format(ostr, settings, state, frame_nested);
         ostr << (settings.one_line ? ")" : "\n)");

--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -100,18 +100,6 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
         frame.expression_list_prepend_whitespace = prep_whitespace;
     }
 
-    if (aliases())
-    {
-        const bool prep_whitespace = frame.expression_list_prepend_whitespace;
-        frame.expression_list_prepend_whitespace = false;
-
-        ostr << (s.hilite ? hilite_none : "") << indent_str << " (";
-        aliases()->format(ostr, s, state, frame);
-        ostr << (s.hilite ? hilite_none : "") << indent_str << ")";
-
-        frame.expression_list_prepend_whitespace = prep_whitespace;
-    }
-
     if (prewhere())
     {
         ostr << (s.hilite ? hilite_keyword : "") << s.nl_or_ws << indent_str << "PREWHERE " << (s.hilite ? hilite_none : "");


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [x] <!---ci_exclude_asan--> Exclude: All with ASAN
- [x] <!---ci_exclude_tsan|msan|ubsan|coverage--> Exclude: All with TSAN, MSAN, UBSAN, Coverage
- [x] <!---ci_exclude_aarch64 --> Exclude:  aarch64
- [x] <!---ci_exclude_regression--> Exclude: All Regression