### PR TITLE
Fix build

### DIFF
--- a/src/Common/mysqlxx/tests/CMakeLists.txt
+++ b/src/Common/mysqlxx/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 clickhouse_add_executable (mysqlxx_pool_test mysqlxx_pool_test.cpp)
-target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx dbms clickhouse_common_config loggers_no_text_log)
+target_link_libraries (mysqlxx_pool_test PRIVATE mysqlxx dbms clickhouse_common_config loggers_no_text_log clickhouse_functions_extractkeyvaluepairs)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix build

### Documentation entry for user-facing changes
After https://github.com/Altinity/ClickHouse/pull/734 full build a little bit broken with
```
[1262/1350] Linking CXX executable src/Common/mysqlxx/tests/mysqlxx_pool_test
FAILED: src/Common/mysqlxx/tests/mysqlxx_pool_test
…
ld.lld-19: error: undefined symbol: DB::KeyValuePairExtractorBuilder::withItemDelimiters(std::__1::vector<char, std::__1::allocator<char>>)
>>> referenced by VirtualColumnUtils.cpp:154 (/home/iantonspb/ch-build/./src/Storages/VirtualColumnUtils.cpp:154)
>>>               VirtualColumnUtils.cpp.o:(DB::VirtualColumnUtils::makeExtractor()) in archive src/libdbms.a

ld.lld-19: error: undefined symbol: DB::KeyValuePairExtractorBuilder::withKeyValueDelimiter(char)
>>> referenced by VirtualColumnUtils.cpp:154 (/home/iantonspb/ch-build/./src/Storages/VirtualColumnUtils.cpp:154)
>>>               VirtualColumnUtils.cpp.o:(DB::VirtualColumnUtils::makeExtractor()) in archive src/libdbms.a

ld.lld-19: error: undefined symbol: DB::extractKV::ConfigurationFactory::createWithoutEscaping(char, char, std::__1::vector<char, std::__1::allocator<char>>)
>>> referenced by KeyValuePairExtractorBuilder.h:41 (./src/Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h:41)
>>>               VirtualColumnUtils.cpp.o:(DB::KeyValuePairExtractorBuilder::buildWithReferenceMap() const) in archive src/libdbms.a
clang++-19: error: linker command failed with exit code 1 (use -v to see invocation)
```


