### PR TITLE
Debug 25.3 integration fails

### DIFF
--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -244,9 +244,9 @@ class ClickhouseIntegrationTestsRunner:
                 continue
         message = "Pulling images failed for 5 attempts. Will fail the worker."
         logging.error(message)
-        kill_ci_runner(message)
-        # We pass specific retcode to to ci/integration_test_check.py to skip status reporting and restart job
-        sys.exit(13)
+        # kill_ci_runner(message)
+        # # We pass specific retcode to to ci/integration_test_check.py to skip status reporting and restart job
+        # sys.exit(13)
 
     @staticmethod
     def _parse_report(


### PR DESCRIPTION
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression