### PR TITLE
24.3 Backport of #72304 - fix some of the postrgresql tests

### DIFF
--- a/tests/integration/helpers/postgres_utility.py
+++ b/tests/integration/helpers/postgres_utility.py
@@ -342,12 +342,22 @@ def assert_nested_table_is_created(
         table = schema_name + "." + table_name
 
     print(f"Checking table {table} exists in {materialized_database}")
-    database_tables = instance.query(f"SHOW TABLES FROM `{materialized_database}`")
 
-    while table not in database_tables:
-        time.sleep(0.2)
-        database_tables = instance.query(f"SHOW TABLES FROM `{materialized_database}`")
+    # Check based on `system.tables` is not enough, because tables appear there before they are loaded.
+    # It may lead to error `Unknown table expression identifier...`
+    while True:
+        try:
+            instance.query(
+                f"SELECT * FROM `{materialized_database}`.`{table}` LIMIT 1 FORMAT Null"
+            )
+            break
+        except Exception:
+            time.sleep(0.2)
+            continue
 
+    database_tables = instance.query(
+        f"SHOW TABLES FROM `{materialized_database}` WHERE name = '{table}'"
+    )
     assert table in database_tables
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix check in `test_postgresql_replica_database_engine_2`

### Documentation entry for user-facing changes
...

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
