### PR TITLE
24.8.14 Backport of #79975 Allow to add `http_response_headers` in `http_handlers` of any kind

### DIFF
--- a/docs/en/interfaces/http.md
+++ b/docs/en/interfaces/http.md
@@ -791,7 +791,42 @@ $ curl -vv -H 'XXX:xxx' 'http://localhost:8123/get_relative_path_static_handler'
 * Connection #0 to host localhost left intact
 ```
 
-## Valid JSON/XML response on exception during HTTP streaming {valid-output-on-exception-http-streaming} 
+## HTTP Response Headers {#http-response-headers}
+
+ClickHouse allows you to configure custom HTTP response headers that can be applied to any kind of handler that can be configured. These headers can be set using the `http_response_headers` setting, which accepts key-value pairs representing header names and their values. This feature is particularly useful for implementing custom security headers, CORS policies, or any other HTTP header requirements across your ClickHouse HTTP interface.
+
+For example, you can configure headers for:
+- Regular query endpoints
+- Web UI
+- Health check.
+
+It is also possible to specify `common_http_response_headers`. These will be applied to all http handlers defined in the configuration.
+
+The headers will be included in the HTTP response for every configured handler.
+
+In the example below, every server response will contain two custom headers: `X-My-Common-Header` and `X-My-Custom-Header`.
+
+```xml
+<clickhouse>
+    <http_handlers>
+        <common_http_response_headers>
+            <X-My-Common-Header>Common header</X-My-Common-Header>
+        </common_http_response_headers>
+        <rule>
+            <methods>GET</methods>
+            <url>/ping</url>
+            <handler>
+                <type>ping</type>
+                <http_response_headers>
+                    <X-My-Custom-Header>Custom indeed</X-My-Custom-Header>
+                </http_response_headers>
+            </handler>
+        </rule>
+    </http_handlers>
+</clickhouse>
+```
+
+## Valid JSON/XML response on exception during HTTP streaming {#valid-output-on-exception-http-streaming}
 
 While query execution over HTTP an exception can happen when part of the data has already been sent. Usually an exception is sent to the client in plain text
 even if some specific data format was used to output data and the output may become invalid in terms of specified data format.

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -895,11 +895,14 @@ std::string PredefinedQueryHandler::getQuery(HTTPServerRequest & request, HTMLFo
 
 HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix)
+    const std::string & config_prefix,
+    std::unordered_map<String, String> & common_headers)
 {
     auto query_param_name = config.getString(config_prefix + ".handler.query_param_name", "query");
 
     HTTPResponseHeaderSetup http_response_headers_override = parseHTTPResponseHeaders(config, config_prefix);
+    if (http_response_headers_override.has_value())
+        http_response_headers_override.value().insert(common_headers.begin(), common_headers.end());
 
     auto creator = [&server, query_param_name, http_response_headers_override]() -> std::unique_ptr<DynamicQueryHandler>
     { return std::make_unique<DynamicQueryHandler>(server, query_param_name, http_response_headers_override); };
@@ -932,7 +935,8 @@ static inline CompiledRegexPtr getCompiledRegex(const std::string & expression)
 
 HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix)
+    const std::string & config_prefix,
+    std::unordered_map<String, String> & common_headers)
 {
     if (!config.has(config_prefix + ".handler.query"))
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "There is no path '{}.handler.query' in configuration file.", config_prefix);
@@ -958,6 +962,8 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
     }
 
     HTTPResponseHeaderSetup http_response_headers_override = parseHTTPResponseHeaders(config, config_prefix);
+    if (http_response_headers_override.has_value())
+        http_response_headers_override.value().insert(common_headers.begin(), common_headers.end());
 
     std::shared_ptr<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>> factory;
 

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -13,6 +13,7 @@
 #include "InterserverIOHTTPHandler.h"
 #include "WebUIRequestHandler.h"
 
+#include <iostream>
 
 namespace DB
 {
@@ -31,27 +32,35 @@ class RedirectRequestHandler : public HTTPRequestHandler
 {
 private:
     std::string url;
+    std::unordered_map<String, String> http_response_headers_override;
 
 public:
-    explicit RedirectRequestHandler(std::string url_)
-        : url(std::move(url_))
+    explicit RedirectRequestHandler(std::string url_, std::unordered_map<String, String> http_response_headers_override_ = {})
+        : url(std::move(url_)), http_response_headers_override(http_response_headers_override_)
     {
     }
 
     void handleRequest(HTTPServerRequest &, HTTPServerResponse & response, const ProfileEvents::Event &) override
     {
+        applyHTTPResponseHeaders(response, http_response_headers_override);
         response.redirect(url);
     }
 };
 
 HTTPRequestHandlerFactoryPtr createRedirectHandlerFactory(
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix)
+    const std::string & config_prefix,
+    std::unordered_map<String, String> common_headers)
 {
     std::string url = config.getString(config_prefix + ".handler.location");
 
+    auto headers = parseHTTPResponseHeadersWithCommons(config, config_prefix, common_headers);
+
     auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<RedirectRequestHandler>>(
-        [my_url = std::move(url)]() { return std::make_unique<RedirectRequestHandler>(my_url); });
+        [my_url = std::move(url), headers_override = std::move(headers)]()
+        {
+            return std::make_unique<RedirectRequestHandler>(my_url, headers_override);
+        });
 
     factory->addFiltersFromConfig(config, config_prefix);
     return factory;
@@ -78,6 +87,33 @@ static auto createPingHandlerFactory(IServer & server)
     return std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(std::move(creator));
 }
 
+static auto createPingHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const String & config_prefix,
+                                     std::unordered_map<String, String> common_headers)
+{
+    auto creator = [&server,&config,config_prefix,common_headers]() -> std::unique_ptr<StaticRequestHandler>
+    {
+        constexpr auto ping_response_expression = "Ok.\n";
+
+        auto headers = parseHTTPResponseHeadersWithCommons(config, config_prefix, "text/html; charset=UTF-8", common_headers);
+
+        return std::make_unique<StaticRequestHandler>(
+            server, ping_response_expression, headers);
+    };
+    return std::make_shared<HandlingRuleHTTPHandlerFactory<StaticRequestHandler>>(std::move(creator));
+}
+
+template <typename UIRequestHandler>
+static auto createWebUIHandlerFactory(IServer & server, const Poco::Util::AbstractConfiguration & config, const String & config_prefix,
+                                      std::unordered_map<String, String> common_headers)
+{
+    auto creator = [&server,&config,config_prefix,common_headers]() -> std::unique_ptr<UIRequestHandler>
+    {
+        auto headers = parseHTTPResponseHeadersWithCommons(config, config_prefix, "text/html; charset=UTF-8", common_headers);
+        return std::make_unique<UIRequestHandler>(server, headers);
+    };
+    return std::make_shared<HandlingRuleHTTPHandlerFactory<UIRequestHandler>>(std::move(creator));
+}
+
 static inline auto createHandlersFactoryFromConfig(
     IServer & server,
     const Poco::Util::AbstractConfiguration & config,
@@ -89,6 +125,19 @@ static inline auto createHandlersFactoryFromConfig(
 
     Poco::Util::AbstractConfiguration::Keys keys;
     config.keys(prefix, keys);
+
+    std::unordered_map<String, String> common_headers_override;
+
+    if (std::find(keys.begin(), keys.end(), "common_http_response_headers") != keys.end())
+    {
+        auto common_headers_prefix = prefix + ".common_http_response_headers";
+        Poco::Util::AbstractConfiguration::Keys headers_keys;
+        config.keys(common_headers_prefix, headers_keys);
+        for (const auto & header_key : headers_keys)
+        {
+            common_headers_override[header_key] = config.getString(common_headers_prefix + "." + header_key);
+        }
+    }
 
     for (const auto & key : keys)
     {
@@ -106,50 +155,73 @@ static inline auto createHandlersFactoryFromConfig(
 
             if (handler_type == "static")
             {
-                main_handler_factory->addHandler(createStaticHandlerFactory(server, config, prefix + "." + key));
+                main_handler_factory->addHandler(createStaticHandlerFactory(server, config, prefix + "." + key, common_headers_override));
             }
             else if (handler_type == "redirect")
             {
-                main_handler_factory->addHandler(createRedirectHandlerFactory(config, prefix + "." + key));
+                main_handler_factory->addHandler(createRedirectHandlerFactory(config, prefix + "." + key, common_headers_override));
             }
             else if (handler_type == "dynamic_query_handler")
             {
-                main_handler_factory->addHandler(createDynamicHandlerFactory(server, config, prefix + "." + key));
+                main_handler_factory->addHandler(createDynamicHandlerFactory(server, config, prefix + "." + key, common_headers_override));
             }
             else if (handler_type == "predefined_query_handler")
             {
-                main_handler_factory->addHandler(createPredefinedHandlerFactory(server, config, prefix + "." + key));
+                main_handler_factory->addHandler(createPredefinedHandlerFactory(server, config, prefix + "." + key, common_headers_override));
             }
             else if (handler_type == "prometheus")
             {
                 main_handler_factory->addHandler(
-                    createPrometheusHandlerFactoryForHTTPRule(server, config, prefix + "." + key, async_metrics));
+                    createPrometheusHandlerFactoryForHTTPRule(server, config, prefix + "." + key, async_metrics, common_headers_override));
             }
             else if (handler_type == "replicas_status")
             {
-                main_handler_factory->addHandler(createReplicasStatusHandlerFactory(server, config, prefix + "." + key));
+                main_handler_factory->addHandler(createReplicasStatusHandlerFactory(server, config, prefix + "." + key, common_headers_override));
             }
             else if (handler_type == "ping")
             {
-                auto handler = createPingHandlerFactory(server);
-                handler->addFiltersFromConfig(config, prefix + "." + key);
+                const String config_prefix = prefix + "." + key;
+                auto handler = createPingHandlerFactory(server, config, config_prefix, common_headers_override);
+                handler->addFiltersFromConfig(config, config_prefix);
                 main_handler_factory->addHandler(std::move(handler));
             }
             else if (handler_type == "play")
             {
-                auto handler = std::make_shared<HandlingRuleHTTPHandlerFactory<PlayWebUIRequestHandler>>(server);
+                auto handler = createWebUIHandlerFactory<PlayWebUIRequestHandler>(server, config, prefix + "." + key, common_headers_override);
                 handler->addFiltersFromConfig(config, prefix + "." + key);
                 main_handler_factory->addHandler(std::move(handler));
             }
             else if (handler_type == "dashboard")
             {
-                auto handler = std::make_shared<HandlingRuleHTTPHandlerFactory<DashboardWebUIRequestHandler>>(server);
+                auto handler = createWebUIHandlerFactory<DashboardWebUIRequestHandler>(server, config, prefix + "." + key, common_headers_override);
                 handler->addFiltersFromConfig(config, prefix + "." + key);
                 main_handler_factory->addHandler(std::move(handler));
             }
             else if (handler_type == "binary")
             {
-                auto handler = std::make_shared<HandlingRuleHTTPHandlerFactory<BinaryWebUIRequestHandler>>(server);
+                auto handler = createWebUIHandlerFactory<BinaryWebUIRequestHandler>(server, config, prefix + "." + key, common_headers_override);
+                handler->addFiltersFromConfig(config, prefix + "." + key);
+                main_handler_factory->addHandler(std::move(handler));
+            }
+            else if (handler_type == "merges")
+            {
+                auto handler = createWebUIHandlerFactory<MergesWebUIRequestHandler>(server, config, prefix + "." + key, common_headers_override);
+                handler->addFiltersFromConfig(config, prefix + "." + key);
+                main_handler_factory->addHandler(std::move(handler));
+            }
+            else if (handler_type == "js")
+            {
+                // NOTE: JavaScriptWebUIRequestHandler only makes sense for paths other then /js/uplot.js, /js/lz-string.js
+                // because these paths are hardcoded in dashboard.html
+                const auto & path = config.getString(prefix + "." + key + ".url", "");
+                if (path != "/js/uplot.js" && path != "/js/lz-string.js")
+                {
+                    throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER,
+                                    "Handler type 'js' is only supported for url '/js/'. "
+                                    "Configured path here: {}", path);
+                }
+
+                auto handler = createWebUIHandlerFactory<JavaScriptWebUIRequestHandler>(server, config, prefix + "." + key, common_headers_override);
                 handler->addFiltersFromConfig(config, prefix + "." + key);
                 main_handler_factory->addHandler(std::move(handler));
             }
@@ -157,7 +229,7 @@ static inline auto createHandlersFactoryFromConfig(
                 throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Unknown handler type '{}' in config here: {}.{}.handler.type",
                     handler_type, prefix, key);
         }
-        else
+        else if (key != "common_http_response_headers")
             throw Exception(ErrorCodes::UNKNOWN_ELEMENT_IN_CONFIG, "Unknown element in config: "
                 "{}.{}, must be 'rule' or 'defaults'", prefix, key);
     }

--- a/src/Server/HTTPHandlerFactory.cpp
+++ b/src/Server/HTTPHandlerFactory.cpp
@@ -203,12 +203,6 @@ static inline auto createHandlersFactoryFromConfig(
                 handler->addFiltersFromConfig(config, prefix + "." + key);
                 main_handler_factory->addHandler(std::move(handler));
             }
-            else if (handler_type == "merges")
-            {
-                auto handler = createWebUIHandlerFactory<MergesWebUIRequestHandler>(server, config, prefix + "." + key, common_headers_override);
-                handler->addFiltersFromConfig(config, prefix + "." + key);
-                main_handler_factory->addHandler(std::move(handler));
-            }
             else if (handler_type == "js")
             {
                 // NOTE: JavaScriptWebUIRequestHandler only makes sense for paths other then /js/uplot.js, /js/lz-string.js

--- a/src/Server/HTTPHandlerFactory.h
+++ b/src/Server/HTTPHandlerFactory.h
@@ -110,19 +110,23 @@ private:
 
 HTTPRequestHandlerFactoryPtr createStaticHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix);
+    const std::string & config_prefix,
+    std::unordered_map<String, String> & common_headers);
 
 HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix);
+    const std::string & config_prefix,
+    std::unordered_map<String, String> & common_headers);
 
 HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix);
+    const std::string & config_prefix,
+    std::unordered_map<String, String> & common_headers);
 
 HTTPRequestHandlerFactoryPtr createReplicasStatusHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix);
+    const std::string & config_prefix,
+    std::unordered_map<String, String> & common_headers);
 
 /// @param server - used in handlers to check IServer::isCancelled()
 /// @param config - not the same as server.config(), since it can be newer

--- a/src/Server/HTTPResponseHeaderWriter.cpp
+++ b/src/Server/HTTPResponseHeaderWriter.cpp
@@ -66,4 +66,25 @@ void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const std::uno
         response.set(header_name, header_value);
 }
 
+std::unordered_map<String, String> parseHTTPResponseHeadersWithCommons(
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix,
+    const std::string & default_content_type,
+    const std::unordered_map<String, String> & common_headers)
+{
+    auto headers = parseHTTPResponseHeaders(config, config_prefix, default_content_type);
+    headers.insert(common_headers.begin(), common_headers.end());
+    return headers;
+}
+
+std::unordered_map<String, String> parseHTTPResponseHeadersWithCommons(
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix,
+    const std::unordered_map<String, String> & common_headers)
+{
+    auto headers = parseHTTPResponseHeaders(config, config_prefix).value_or(std::unordered_map<String, String>{});
+    headers.insert(common_headers.begin(), common_headers.end());
+    return headers;
+}
+
 }

--- a/src/Server/HTTPResponseHeaderWriter.h
+++ b/src/Server/HTTPResponseHeaderWriter.h
@@ -22,4 +22,16 @@ std::unordered_map<String, String> parseHTTPResponseHeaders(const std::string & 
 void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const HTTPResponseHeaderSetup & setup);
 
 void applyHTTPResponseHeaders(Poco::Net::HTTPResponse & response, const std::unordered_map<String, String> & setup);
+
+std::unordered_map<String, String> parseHTTPResponseHeadersWithCommons(
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix,
+    const std::unordered_map<String, String> & common_headers);
+
+std::unordered_map<String, String> parseHTTPResponseHeadersWithCommons(
+    const Poco::Util::AbstractConfiguration & config,
+    const std::string & config_prefix,
+    const std::string & default_content_type,
+    const std::unordered_map<String, String> & common_headers);
+
 }

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -303,13 +303,15 @@ PrometheusRequestHandler::PrometheusRequestHandler(
     IServer & server_,
     const PrometheusRequestHandlerConfig & config_,
     const AsynchronousMetrics & async_metrics_,
-    std::shared_ptr<PrometheusMetricsWriter> metrics_writer_)
+    std::shared_ptr<PrometheusMetricsWriter> metrics_writer_,
+    std::unordered_map<String, String> response_headers_)
     : server(server_)
     , config(config_)
     , async_metrics(async_metrics_)
     , metrics_writer(metrics_writer_)
     , log(getLogger("PrometheusRequestHandler"))
 {
+    response_headers = response_headers_;
     createImpl();
 }
 
@@ -341,6 +343,7 @@ void PrometheusRequestHandler::createImpl()
 void PrometheusRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event_)
 {
     setThreadName("PrometheusHndlr");
+    applyHTTPResponseHeaders(response, response_headers);
 
     try
     {

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -3,6 +3,7 @@
 #include <Common/logger_useful.h>
 #include <Common/setThreadName.h>
 #include <IO/HTTPCommon.h>
+#include <Server/HTTPResponseHeaderWriter.h>
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
 #include <Server/HTTP/sendExceptionToHTTPClient.h>
 #include <Server/IServer.h>

--- a/src/Server/PrometheusRequestHandler.h
+++ b/src/Server/PrometheusRequestHandler.h
@@ -19,7 +19,8 @@ public:
         IServer & server_,
         const PrometheusRequestHandlerConfig & config_,
         const AsynchronousMetrics & async_metrics_,
-        std::shared_ptr<PrometheusMetricsWriter> metrics_writer_);
+        std::shared_ptr<PrometheusMetricsWriter> metrics_writer_,
+        std::unordered_map<String, String> response_headers_ = {});
     ~PrometheusRequestHandler() override;
 
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event_) override;
@@ -59,6 +60,7 @@ private:
     std::unique_ptr<WriteBufferFromHTTPServerResponse> write_buffer_from_response;
     bool response_finalized = false;
     ProfileEvents::Event write_event;
+    std::unordered_map<String, String> response_headers;
 };
 
 }

--- a/src/Server/PrometheusRequestHandlerFactory.cpp
+++ b/src/Server/PrometheusRequestHandlerFactory.cpp
@@ -131,14 +131,15 @@ namespace
         IServer & server,
         const AsynchronousMetrics & async_metrics,
         const PrometheusRequestHandlerConfig & config,
-        bool for_keeper)
+        bool for_keeper,
+        std::unordered_map<String, String> headers = {})
     {
         if (!canBeHandled(config, for_keeper))
             return nullptr;
         auto metric_writer = createPrometheusMetricWriter(for_keeper);
-        auto creator = [&server, &async_metrics, config, metric_writer]() -> std::unique_ptr<PrometheusRequestHandler>
+        auto creator = [&server, &async_metrics, config, metric_writer, headers_moved = std::move(headers)]() -> std::unique_ptr<PrometheusRequestHandler>
         {
-            return std::make_unique<PrometheusRequestHandler>(server, config, async_metrics, metric_writer);
+            return std::make_unique<PrometheusRequestHandler>(server, config, async_metrics, metric_writer, headers_moved);
         };
         return std::make_shared<HandlingRuleHTTPHandlerFactory<PrometheusRequestHandler>>(std::move(creator));
     }
@@ -200,10 +201,13 @@ HTTPRequestHandlerFactoryPtr createPrometheusHandlerFactoryForHTTPRule(
     IServer & server,
     const Poco::Util::AbstractConfiguration & config,
     const String & config_prefix,
-    const AsynchronousMetrics & asynchronous_metrics)
+    const AsynchronousMetrics & asynchronous_metrics,
+    std::unordered_map<String, String> & common_headers)
 {
+    auto headers = parseHTTPResponseHeadersWithCommons(config, config_prefix, common_headers);
+
     auto parsed_config = parseExposeMetricsConfig(config, config_prefix + ".handler");
-    auto handler = createPrometheusHandlerFactoryFromConfig(server, asynchronous_metrics, parsed_config, /* for_keeper= */ false);
+    auto handler = createPrometheusHandlerFactoryFromConfig(server, asynchronous_metrics, parsed_config, /* for_keeper= */ false, headers);
     chassert(handler);  /// `handler` can't be nullptr here because `for_keeper` is false.
     handler->addFiltersFromConfig(config, config_prefix);
     return handler;

--- a/src/Server/PrometheusRequestHandlerFactory.cpp
+++ b/src/Server/PrometheusRequestHandlerFactory.cpp
@@ -1,6 +1,7 @@
 #include <Server/PrometheusRequestHandlerFactory.h>
 
 #include <Server/HTTPHandlerFactory.h>
+#include <Server/HTTPResponseHeaderWriter.h>
 #include <Server/PrometheusMetricsWriter.h>
 #include <Server/PrometheusRequestHandler.h>
 #include <Server/PrometheusRequestHandlerConfig.h>

--- a/src/Server/PrometheusRequestHandlerFactory.h
+++ b/src/Server/PrometheusRequestHandlerFactory.h
@@ -93,7 +93,8 @@ HTTPRequestHandlerFactoryPtr createPrometheusHandlerFactoryForHTTPRule(
     IServer & server,
     const Poco::Util::AbstractConfiguration & config,
     const String & config_prefix, /// path to "http_handlers.my_handler_1"
-    const AsynchronousMetrics & asynchronous_metrics);
+    const AsynchronousMetrics & asynchronous_metrics,
+    std::unordered_map<String, String> & common_headers);
 
 /// Makes a HTTP Handler factory to handle requests for prometheus metrics as a part of the default HTTP rule in the <http_handlers> section.
 /// Expects a configuration like this:

--- a/src/Server/ReplicasStatusHandler.cpp
+++ b/src/Server/ReplicasStatusHandler.cpp
@@ -7,6 +7,7 @@
 #include <Server/HTTP/HTMLForm.h>
 #include <Server/HTTPHandlerFactory.h>
 #include <Server/HTTPHandlerRequestFilter.h>
+#include <Server/HTTPResponseHeaderWriter.h>
 #include <Server/IServer.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageReplicatedMergeTree.h>
@@ -28,6 +29,8 @@ void ReplicasStatusHandler::handleRequest(HTTPServerRequest & request, HTTPServe
 {
     try
     {
+        applyHTTPResponseHeaders(response, http_response_headers_override);
+
         HTMLForm params(getContext()->getSettingsRef(), request);
 
         const auto & config = getContext()->getConfigRef();
@@ -129,9 +132,16 @@ void ReplicasStatusHandler::handleRequest(HTTPServerRequest & request, HTTPServe
 
 HTTPRequestHandlerFactoryPtr createReplicasStatusHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix)
+    const std::string & config_prefix,
+    std::unordered_map<String, String> & common_headers)
 {
-    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<ReplicasStatusHandler>>(server);
+    std::unordered_map<String, String> http_response_headers_override
+        = parseHTTPResponseHeadersWithCommons(config, config_prefix, "text/plain; charset=UTF-8", common_headers);
+
+    auto creator = [&server, http_response_headers_override]() -> std::unique_ptr<ReplicasStatusHandler>
+    { return std::make_unique<ReplicasStatusHandler>(server, http_response_headers_override); };
+
+    auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<ReplicasStatusHandler>>(std::move(creator));
     factory->addFiltersFromConfig(config, config_prefix);
     return factory;
 }

--- a/src/Server/ReplicasStatusHandler.h
+++ b/src/Server/ReplicasStatusHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Server/HTTP/HTTPRequestHandler.h>
+#include <Poco/Util/LayeredConfiguration.h>
 
 namespace DB
 {
@@ -13,8 +14,17 @@ class ReplicasStatusHandler : public HTTPRequestHandler, WithContext
 {
 public:
     explicit ReplicasStatusHandler(IServer & server_);
+    explicit ReplicasStatusHandler(IServer & server_, const std::unordered_map<String, String> & http_response_headers_override_)
+        : ReplicasStatusHandler(server_)
+    {
+        http_response_headers_override = http_response_headers_override_;
+    }
 
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+
+private:
+    /// Overrides for response headers.
+    std::unordered_map<String, String> http_response_headers_override;
 };
 
 

--- a/src/Server/StaticRequestHandler.cpp
+++ b/src/Server/StaticRequestHandler.cpp
@@ -163,13 +163,14 @@ StaticRequestHandler::StaticRequestHandler(
 
 HTTPRequestHandlerFactoryPtr createStaticHandlerFactory(IServer & server,
     const Poco::Util::AbstractConfiguration & config,
-    const std::string & config_prefix)
+    const std::string & config_prefix,
+    std::unordered_map<String, String> & common_headers)
 {
     int status = config.getInt(config_prefix + ".handler.status", 200);
     std::string response_content = config.getRawString(config_prefix + ".handler.response_content", "Ok.\n");
 
     std::unordered_map<String, String> http_response_headers_override
-        = parseHTTPResponseHeaders(config, config_prefix, "text/plain; charset=UTF-8");
+        = parseHTTPResponseHeadersWithCommons(config, config_prefix, "text/plain; charset=UTF-8", common_headers);
 
     auto creator = [&server, http_response_headers_override, response_content, status]() -> std::unique_ptr<StaticRequestHandler>
     { return std::make_unique<StaticRequestHandler>(server, response_content, http_response_headers_override, status); };

--- a/src/Server/WebUIRequestHandler.cpp
+++ b/src/Server/WebUIRequestHandler.cpp
@@ -72,11 +72,6 @@ void BinaryWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPS
     handle(request, response, {reinterpret_cast<const char *>(gresource_binary_htmlData), gresource_binary_htmlSize}, http_response_headers_override);
 }
 
-void MergesWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event &)
-{
-    handle(request, response, {reinterpret_cast<const char *>(gresource_merges_htmlData), gresource_merges_htmlSize}, http_response_headers_override);
-}
-
 void JavaScriptWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event &)
 {
     if (request.getURI() == "/js/uplot.js")

--- a/src/Server/WebUIRequestHandler.cpp
+++ b/src/Server/WebUIRequestHandler.cpp
@@ -1,6 +1,7 @@
 #include "WebUIRequestHandler.h"
 #include "IServer.h"
 #include <Server/HTTP/WriteBufferFromHTTPServerResponse.h>
+#include <Server/HTTPResponseHeaderWriter.h>
 
 #include <Poco/Net/HTTPServerResponse.h>
 #include <Poco/Util/LayeredConfiguration.h>
@@ -30,8 +31,10 @@ DashboardWebUIRequestHandler::DashboardWebUIRequestHandler(IServer & server_) : 
 BinaryWebUIRequestHandler::BinaryWebUIRequestHandler(IServer & server_) : server(server_) {}
 JavaScriptWebUIRequestHandler::JavaScriptWebUIRequestHandler(IServer & server_) : server(server_) {}
 
-static void handle(HTTPServerRequest & request, HTTPServerResponse & response, std::string_view html)
+static void handle(HTTPServerRequest & request, HTTPServerResponse & response, std::string_view html,
+                   std::unordered_map<String, String> http_response_headers_override = {})
 {
+    applyHTTPResponseHeaders(response, http_response_headers_override);
     response.setContentType("text/html; charset=UTF-8");
     if (request.getVersion() == HTTPServerRequest::HTTP_1_1)
         response.setChunkedTransferEncoding(true);
@@ -43,7 +46,7 @@ static void handle(HTTPServerRequest & request, HTTPServerResponse & response, s
 
 void PlayWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event &)
 {
-    handle(request, response, {reinterpret_cast<const char *>(gresource_play_htmlData), gresource_play_htmlSize});
+    handle(request, response, {reinterpret_cast<const char *>(gresource_play_htmlData), gresource_play_htmlSize}, http_response_headers_override);
 }
 
 void DashboardWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event &)
@@ -61,23 +64,28 @@ void DashboardWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HT
     static re2::RE2 lz_string_url = R"(https://[^\s"'`]+lz-string[^\s"'`]*\.js)";
     RE2::Replace(&html, lz_string_url, "/js/lz-string.js");
 
-    handle(request, response, html);
+    handle(request, response, html, http_response_headers_override);
 }
 
 void BinaryWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event &)
 {
-    handle(request, response, {reinterpret_cast<const char *>(gresource_binary_htmlData), gresource_binary_htmlSize});
+    handle(request, response, {reinterpret_cast<const char *>(gresource_binary_htmlData), gresource_binary_htmlSize}, http_response_headers_override);
+}
+
+void MergesWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event &)
+{
+    handle(request, response, {reinterpret_cast<const char *>(gresource_merges_htmlData), gresource_merges_htmlSize}, http_response_headers_override);
 }
 
 void JavaScriptWebUIRequestHandler::handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event &)
 {
     if (request.getURI() == "/js/uplot.js")
     {
-        handle(request, response, {reinterpret_cast<const char *>(gresource_uplot_jsData), gresource_uplot_jsSize});
+        handle(request, response, {reinterpret_cast<const char *>(gresource_uplot_jsData), gresource_uplot_jsSize}, http_response_headers_override);
     }
     else if (request.getURI() == "/js/lz-string.js")
     {
-        handle(request, response, {reinterpret_cast<const char *>(gresource_lz_string_jsData), gresource_lz_string_jsSize});
+        handle(request, response, {reinterpret_cast<const char *>(gresource_lz_string_jsData), gresource_lz_string_jsSize}, http_response_headers_override);
     }
     else
     {
@@ -85,7 +93,7 @@ void JavaScriptWebUIRequestHandler::handleRequest(HTTPServerRequest & request, H
         *response.send() << "Not found.\n";
     }
 
-    handle(request, response, {reinterpret_cast<const char *>(gresource_binary_htmlData), gresource_binary_htmlSize});
+    handle(request, response, {reinterpret_cast<const char *>(gresource_binary_htmlData), gresource_binary_htmlSize}, http_response_headers_override);
 }
 
 }

--- a/src/Server/WebUIRequestHandler.h
+++ b/src/Server/WebUIRequestHandler.h
@@ -61,21 +61,6 @@ private:
     std::unordered_map<String, String> http_response_headers_override;
 };
 
-class MergesWebUIRequestHandler : public HTTPRequestHandler
-{
-public:
-    explicit MergesWebUIRequestHandler(IServer &) {}
-    explicit MergesWebUIRequestHandler(IServer & server_, const std::unordered_map<String, String> & http_response_headers_override_)
-        : MergesWebUIRequestHandler(server_)
-    {
-        http_response_headers_override = http_response_headers_override_;
-    }
-    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
-private:
-    /// Overrides for response headers.
-    std::unordered_map<String, String> http_response_headers_override;
-};
-
 class JavaScriptWebUIRequestHandler : public HTTPRequestHandler
 {
 private:

--- a/src/Server/WebUIRequestHandler.h
+++ b/src/Server/WebUIRequestHandler.h
@@ -16,7 +16,15 @@ private:
     IServer & server;
 public:
     explicit PlayWebUIRequestHandler(IServer & server_);
+    explicit PlayWebUIRequestHandler(IServer & server_, const std::unordered_map<String, String> & http_response_headers_override_)
+        : PlayWebUIRequestHandler(server_)
+    {
+        http_response_headers_override = http_response_headers_override_;
+    }
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+private:
+    /// Overrides for response headers.
+    std::unordered_map<String, String> http_response_headers_override;
 };
 
 class DashboardWebUIRequestHandler : public HTTPRequestHandler
@@ -25,7 +33,15 @@ private:
     IServer & server;
 public:
     explicit DashboardWebUIRequestHandler(IServer & server_);
+    explicit DashboardWebUIRequestHandler(IServer & server_, const std::unordered_map<String, String> & http_response_headers_override_)
+        : DashboardWebUIRequestHandler(server_)
+    {
+        http_response_headers_override = http_response_headers_override_;
+    }
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+private:
+    /// Overrides for response headers.
+    std::unordered_map<String, String> http_response_headers_override;
 };
 
 class BinaryWebUIRequestHandler : public HTTPRequestHandler
@@ -34,7 +50,30 @@ private:
     IServer & server;
 public:
     explicit BinaryWebUIRequestHandler(IServer & server_);
+    explicit BinaryWebUIRequestHandler(IServer & server_, const std::unordered_map<String, String> & http_response_headers_override_)
+        : BinaryWebUIRequestHandler(server_)
+    {
+        http_response_headers_override = http_response_headers_override_;
+    }
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+private:
+    /// Overrides for response headers.
+    std::unordered_map<String, String> http_response_headers_override;
+};
+
+class MergesWebUIRequestHandler : public HTTPRequestHandler
+{
+public:
+    explicit MergesWebUIRequestHandler(IServer &) {}
+    explicit MergesWebUIRequestHandler(IServer & server_, const std::unordered_map<String, String> & http_response_headers_override_)
+        : MergesWebUIRequestHandler(server_)
+    {
+        http_response_headers_override = http_response_headers_override_;
+    }
+    void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+private:
+    /// Overrides for response headers.
+    std::unordered_map<String, String> http_response_headers_override;
 };
 
 class JavaScriptWebUIRequestHandler : public HTTPRequestHandler
@@ -43,7 +82,15 @@ private:
     IServer & server;
 public:
     explicit JavaScriptWebUIRequestHandler(IServer & server_);
+    explicit JavaScriptWebUIRequestHandler(IServer & server_, const std::unordered_map<String, String> & http_response_headers_override_)
+        : JavaScriptWebUIRequestHandler(server_)
+    {
+        http_response_headers_override = http_response_headers_override_;
+    }
     void handleRequest(HTTPServerRequest & request, HTTPServerResponse & response, const ProfileEvents::Event & write_event) override;
+private:
+    /// Overrides for response headers.
+    std::unordered_map<String, String> http_response_headers_override;
 };
 
 }

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -601,3 +601,31 @@ def test_replicas_status_handler():
                 "test_replicas_status", method="GET", headers={"XXX": "xxx"}
             ).content
         )
+
+
+def test_headers_in_response():
+    with contextlib.closing(
+            SimpleCluster(
+                ClickHouseCluster(__file__), "headers_in_response", "test_headers_in_response"
+            )
+    ) as cluster:
+        for endpoint in ("static", "ping", "replicas_status", "play", "dashboard", "binary", "merges", "metrics",
+                         "js/lz-string.js", "js/uplot.js", "?query=SELECT%201"):
+            response = cluster.instance.http_request(endpoint, method="GET")
+
+            assert "X-My-Answer" in response.headers
+            assert "X-My-Common-Header" in response.headers
+
+            assert response.headers["X-My-Common-Header"] == "Common header present"
+
+            if endpoint == "?query=SELECT%201":
+                assert response.headers["X-My-Answer"] == "Iam dynamic"
+            else:
+                assert response.headers["X-My-Answer"] == f"Iam {endpoint}"
+
+
+        # Handle predefined_query_handler separately because we need to pass headers there
+        response_predefined = cluster.instance.http_request(
+            "query_param_with_url", method="GET", headers={"PARAMS_XXX": "test_param"})
+        assert response_predefined.headers["X-My-Answer"] == f"Iam predefined"
+        assert response_predefined.headers["X-My-Common-Header"] == "Common header present"

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -609,7 +609,7 @@ def test_headers_in_response():
                 ClickHouseCluster(__file__), "headers_in_response", "test_headers_in_response"
             )
     ) as cluster:
-        for endpoint in ("static", "ping", "replicas_status", "play", "dashboard", "binary", "merges", "metrics",
+        for endpoint in ("static", "ping", "replicas_status", "play", "dashboard", "binary", "metrics",
                          "js/lz-string.js", "js/uplot.js", "?query=SELECT%201"):
             response = cluster.instance.http_request(endpoint, method="GET")
 

--- a/tests/integration/test_http_handlers_config/test_headers_in_response/config.xml
+++ b/tests/integration/test_http_handlers_config/test_headers_in_response/config.xml
@@ -1,0 +1,146 @@
+<clickhouse>
+    <http_handlers>
+        <common_http_response_headers>
+            <X-My-Common-Header>Common header present</X-My-Common-Header>
+        </common_http_response_headers>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/static</url>
+            <handler>
+                <type>static</type>
+                <response_expression>config://http_server_default_response</response_expression>
+                <content_type>text/html; charset=UTF-8</content_type>
+                <http_response_headers>
+                    <X-My-Answer>Iam static</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/ping</url>
+            <handler>
+                <type>ping</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam ping</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/replicas_status</url>
+            <handler>
+                <type>replicas_status</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam replicas_status</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/play</url>
+            <handler>
+                <type>play</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam play</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/dashboard</url>
+            <handler>
+                <type>dashboard</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam dashboard</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/binary</url>
+            <handler>
+                <type>binary</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam binary</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/merges</url>
+            <handler>
+                <type>merges</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam merges</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/metrics</url>
+            <handler>
+                <type>prometheus</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam metrics</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <url>/js/lz-string.js</url>
+            <handler>
+                <type>js</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam js/lz-string.js</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,HEAD</methods>
+            <url>/js/uplot.js</url>
+            <handler>
+                <type>js</type>
+                <http_response_headers>
+                    <X-My-Answer>Iam js/uplot.js</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <url>/query_param_with_url</url>
+            <methods>GET,HEAD</methods>
+            <headers>
+                <PARAMS_XXX><![CDATA[regex:(?P<name_1>[^/]+)]]></PARAMS_XXX>
+            </headers>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>
+                    SELECT {name_1:String}
+                </query>
+                <http_response_headers>
+                    <X-My-Answer>Iam predefined</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,POST,HEAD,OPTIONS</methods>
+            <handler>
+                <type>dynamic_query_handler</type>
+                <query_param_name>query</query_param_name>
+                <http_response_headers>
+                    <X-My-Answer>Iam dynamic</X-My-Answer>
+                </http_response_headers>
+            </handler>
+        </rule>
+    </http_handlers>
+</clickhouse>

--- a/tests/integration/test_http_handlers_config/test_headers_in_response/config.xml
+++ b/tests/integration/test_http_handlers_config/test_headers_in_response/config.xml
@@ -74,17 +74,6 @@
 
         <rule>
             <methods>GET,HEAD</methods>
-            <url>/merges</url>
-            <handler>
-                <type>merges</type>
-                <http_response_headers>
-                    <X-My-Answer>Iam merges</X-My-Answer>
-                </http_response_headers>
-            </handler>
-        </rule>
-
-        <rule>
-            <methods>GET,HEAD</methods>
             <url>/metrics</url>
             <handler>
                 <type>prometheus</type>


### PR DESCRIPTION
Allow to add `http_response_headers` in `http_handlers` of any type

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to add `http_response_headers` in `http_handlers` of any kind (#79975 by @zvonand)