### PR TITLE
24.3 UBSAN fixes

### DIFF
--- a/src/Interpreters/AggregationCommon.h
+++ b/src/Interpreters/AggregationCommon.h
@@ -11,6 +11,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnLowCardinality.h>
+#include <Common/logger_useful.h>
 
 #if defined(__SSSE3__) && !defined(MEMORY_SANITIZER)
 #include <tmmintrin.h>
@@ -132,6 +133,18 @@ static inline T ALWAYS_INLINE packFixed(
     {
         size_t index = i;
         const IColumn * column = key_columns[j];
+        auto column_possibly_converted = column->convertToFullColumnIfSparse()->convertToFullColumnIfConst();
+
+        // TODO(vnemkov): debug logging, remove before merging.
+        if (!checkColumn<const ColumnFixedSizeHelper>(column)) {
+            LOG_WARNING(::getLogger("AggregationCommon"), "column is of unsupported type: {}, trying unwrapping", column->getName());
+            if (!checkColumn<const ColumnFixedSizeHelper>(column_possibly_converted.get()))
+            {
+                LOG_ERROR(::getLogger("AggregationCommon"), "unwrapped column is of unsupported type too ({})... this will fail at later stage under UBSAN.", column_possibly_converted->getName());
+            }
+        }
+        column = column_possibly_converted.get();
+
         if constexpr (has_low_cardinality)
         {
             if (const IColumn * positions = (*low_cardinality_positions)[j])
@@ -224,26 +237,39 @@ static inline T ALWAYS_INLINE packFixed(
         if (is_null)
             continue;
 
+        const IColumn * key_column = key_columns[j];
+        auto column_possibly_converted = key_column->convertToFullColumnIfSparse()->convertToFullColumnIfConst();
+
+        // TODO(vnemkov): debug logging, remove before merging.
+        if (!checkColumn<const ColumnFixedSizeHelper>(key_column)) {
+            LOG_WARNING(::getLogger("AggregationCommon"), "column is of unsupported type: {}, trying unwrapping", key_column->getName());
+            if (!checkColumn<const ColumnFixedSizeHelper>(column_possibly_converted.get()))
+            {
+                LOG_ERROR(::getLogger("AggregationCommon"), "unwrapped column is of unsupported type too ({})... this will fail at later stage under UBSAN.", column_possibly_converted->getName());
+            }
+        }
+        key_column = column_possibly_converted.get();
+
         switch (key_sizes[j])
         {
             case 1:
-                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_columns[j])->getRawDataBegin<1>() + i, 1);
+                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_column)->getRawDataBegin<1>() + i, 1);
                 offset += 1;
                 break;
             case 2:
-                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_columns[j])->getRawDataBegin<2>() + i * 2, 2);
+                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_column)->getRawDataBegin<2>() + i * 2, 2);
                 offset += 2;
                 break;
             case 4:
-                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_columns[j])->getRawDataBegin<4>() + i * 4, 4);
+                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_column)->getRawDataBegin<4>() + i * 4, 4);
                 offset += 4;
                 break;
             case 8:
-                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_columns[j])->getRawDataBegin<8>() + i * 8, 8);
+                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_column)->getRawDataBegin<8>() + i * 8, 8);
                 offset += 8;
                 break;
             default:
-                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_columns[j])->getRawDataBegin<1>() + i * key_sizes[j], key_sizes[j]);
+                memcpy(bytes + offset, static_cast<const ColumnFixedSizeHelper *>(key_column)->getRawDataBegin<1>() + i * key_sizes[j], key_sizes[j]);
                 offset += key_sizes[j];
         }
     }

--- a/src/Interpreters/AggregationCommon.h
+++ b/src/Interpreters/AggregationCommon.h
@@ -11,7 +11,6 @@
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnLowCardinality.h>
-#include <Common/logger_useful.h>
 
 #if defined(__SSSE3__) && !defined(MEMORY_SANITIZER)
 #include <tmmintrin.h>
@@ -134,15 +133,6 @@ static inline T ALWAYS_INLINE packFixed(
         size_t index = i;
         const IColumn * column = key_columns[j];
         auto column_possibly_converted = column->convertToFullColumnIfSparse()->convertToFullColumnIfConst();
-
-        // TODO(vnemkov): debug logging, remove before merging.
-        if (!checkColumn<const ColumnFixedSizeHelper>(column)) {
-            LOG_WARNING(::getLogger("AggregationCommon"), "column is of unsupported type: {}, trying unwrapping", column->getName());
-            if (!checkColumn<const ColumnFixedSizeHelper>(column_possibly_converted.get()))
-            {
-                LOG_ERROR(::getLogger("AggregationCommon"), "unwrapped column is of unsupported type too ({})... this will fail at later stage under UBSAN.", column_possibly_converted->getName());
-            }
-        }
         column = column_possibly_converted.get();
 
         if constexpr (has_low_cardinality)
@@ -239,15 +229,6 @@ static inline T ALWAYS_INLINE packFixed(
 
         const IColumn * key_column = key_columns[j];
         auto column_possibly_converted = key_column->convertToFullColumnIfSparse()->convertToFullColumnIfConst();
-
-        // TODO(vnemkov): debug logging, remove before merging.
-        if (!checkColumn<const ColumnFixedSizeHelper>(key_column)) {
-            LOG_WARNING(::getLogger("AggregationCommon"), "column is of unsupported type: {}, trying unwrapping", key_column->getName());
-            if (!checkColumn<const ColumnFixedSizeHelper>(column_possibly_converted.get()))
-            {
-                LOG_ERROR(::getLogger("AggregationCommon"), "unwrapped column is of unsupported type too ({})... this will fail at later stage under UBSAN.", column_possibly_converted->getName());
-            }
-        }
         key_column = column_possibly_converted.get();
 
         switch (key_sizes[j])


### PR DESCRIPTION
### Changelog category (leave one):
- Bugfix


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Unwrap ColumnConst to actual column to avoid invalid cast (may result in incorrect hashes at some point) in `SELECT DISTINCT` in some cases.

### Documentation entry for user-facing changes
This fixes [stateless/02969_auto_format_detection.sh](https://s3.amazonaws.com/altinity-build-artifacts/825/a2bbe930e9455ff9cf11dff5f24080fe94371981/stateless_tests__ubsan__[1_2].html)

...

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
