### PR TITLE
25.3.5 fixing 'path must be string' error

### DIFF
--- a/tests/ci/s3_helper.py
+++ b/tests/ci/s3_helper.py
@@ -144,7 +144,9 @@ class S3Helper:
                 logging.info("Processing file without compression")
             logging.info("File is too large, do not provide content type")
 
-        self.client.upload_file(file_path, bucket_name, s3_path, ExtraArgs=metadata)
+        self.client.upload_file(
+            str(file_path), bucket_name, s3_path, ExtraArgs=metadata
+        )
         url = self.s3_url(bucket_name, s3_path)
         logging.info("Upload %s to %s Meta: %s", file_path, url, metadata)
         return url
@@ -175,7 +177,7 @@ class S3Helper:
         if Path(local_file_path).is_dir():
             local_file_path = Path(local_file_path) / s3_path.split("/")[-1]
         try:
-            self.client.download_file(bucket, s3_path, local_file_path)
+            self.client.download_file(bucket, s3_path, str(local_file_path))
         except botocore.exceptions.ClientError as e:
             if e.response and e.response["ResponseMetadata"]["HTTPStatusCode"] == 404:
                 assert False, f"No such object [s3://{S3_BUILDS_BUCKET}/{s3_path}]"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

The new EC2 backup runners have a different version of boto3, which requires some tweaks to support.

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
