### PR TITLE
25.3.5 Backport of #79147: Remove guard pages from fibers and alternative stack for signals in threads

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -1,6 +1,7 @@
 #include "Keeper.h"
 
 #include <Common/ClickHouseRevision.h>
+#include <Common/formatReadable.h>
 #include <Common/getMultipleKeysFromConfig.h>
 #include <Common/DNSResolver.h>
 #include <Interpreters/DNSCacheUpdater.h>

--- a/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
+++ b/src/Client/BuzzHouse/Generator/FuzzConfig.cpp
@@ -3,6 +3,7 @@
 #include <ranges>
 #include <IO/copyData.h>
 #include <Common/Exception.h>
+#include <Common/formatReadable.h>
 
 namespace DB
 {

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -10,6 +10,7 @@
 #include <Core/Protocol.h>
 #include <Common/DateLUT.h>
 #include <Common/MemoryTracker.h>
+#include <Common/formatReadable.h>
 #include <Common/scope_guard_safe.h>
 #include <Common/Exception.h>
 #include <Common/ErrorCodes.h>

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -23,6 +23,7 @@
 #include <Common/DNSResolver.h>
 #include <Common/StringUtils.h>
 #include <Common/OpenSSLHelpers.h>
+#include <Common/formatReadable.h>
 #include <Common/randomSeed.h>
 #include <Core/Block.h>
 #include <Core/ProtocolDefines.h>

--- a/src/Common/AsyncTaskExecutor.cpp
+++ b/src/Common/AsyncTaskExecutor.cpp
@@ -1,5 +1,6 @@
 #include <Common/AsyncTaskExecutor.h>
 #include <base/scope_guard.h>
+#include <fmt/format.h>
 
 
 namespace DB

--- a/src/Common/AsyncTaskExecutor.h
+++ b/src/Common/AsyncTaskExecutor.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+#include <mutex>
+#include <base/types.h>
 #include <Common/Epoll.h>
 #include <Common/Fiber.h>
 #include <Common/FiberStack.h>

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -1,0 +1,79 @@
+#include <base/defines.h>
+#include <Common/formatReadable.h>
+#include <Common/CurrentMemoryTracker.h>
+#include <Common/Exception.h>
+#include <Common/memory.h>
+#include <base/getPageSize.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/mman.h>
+#include <Common/FiberStack.h>
+
+#if defined(BOOST_USE_VALGRIND)
+#include <valgrind/valgrind.h>
+#endif
+
+/// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_ALLOCATE_MEMORY;
+}
+
+
+FiberStack::FiberStack(size_t stack_size_)
+    : stack_size(stack_size_)
+    , page_size(getPageSize())
+{
+}
+
+boost::context::stack_context FiberStack::allocate() const
+{
+    size_t num_pages = 1 + (stack_size - 1) / page_size;
+    size_t num_bytes = (num_pages + 1) * page_size; /// Add one page at bottom that will be used as guard-page
+
+    void * vp = ::mmap(nullptr, num_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (MAP_FAILED == vp)
+        throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: Cannot mmap {}.", ReadableSize(num_bytes));
+
+    /// TODO: make reports on illegal guard page access more clear.
+    /// Currently we will see segfault and almost random stacktrace.
+    try
+    {
+        memoryGuardInstall(vp, page_size);
+    }
+    catch (...)
+    {
+        ::munmap(vp, num_bytes);
+        throw;
+    }
+
+    /// Do not count guard page in memory usage.
+    auto trace = CurrentMemoryTracker::alloc(num_pages * page_size);
+    trace.onAlloc(vp, num_pages * page_size);
+
+    boost::context::stack_context sctx;
+    sctx.size = num_bytes;
+    sctx.sp = static_cast< char * >(vp) + sctx.size;
+#if defined(BOOST_USE_VALGRIND)
+    sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, vp);
+#endif
+    return sctx;
+}
+
+void FiberStack::deallocate(boost::context::stack_context & sctx) const
+{
+#if defined(BOOST_USE_VALGRIND)
+    VALGRIND_STACK_DEREGISTER(sctx.valgrind_stack_id);
+#endif
+    void * vp = static_cast< char * >(sctx.sp) - sctx.size;
+    ::munmap(vp, sctx.size);
+
+    /// Do not count guard page in memory usage.
+    auto trace = CurrentMemoryTracker::free(sctx.size - page_size);
+    trace.onFree(vp, sctx.size - page_size);
+}

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -18,6 +18,17 @@
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+namespace
+{
+constexpr bool guardPagesEnabled()
+{
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    return true;
+#else
+    return false;
+#endif
+}
+}
 
 namespace DB::ErrorCodes
 {
@@ -34,33 +45,41 @@ FiberStack::FiberStack(size_t stack_size_)
 boost::context::stack_context FiberStack::allocate() const
 {
     size_t num_pages = 1 + (stack_size - 1) / page_size;
-    size_t num_bytes = (num_pages + 1) * page_size; /// Add one page at bottom that will be used as guard-page
 
-    void * vp = ::mmap(nullptr, num_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (MAP_FAILED == vp)
-        throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: Cannot mmap {}.", ReadableSize(num_bytes));
+    if constexpr (guardPagesEnabled())
+        /// Add one page at bottom that will be used as guard-page
+        num_pages += 1;
 
-    /// TODO: make reports on illegal guard page access more clear.
-    /// Currently we will see segfault and almost random stacktrace.
-    try
+    size_t num_bytes = num_pages * page_size;
+
+    void * data = aligned_alloc(page_size, num_bytes);
+
+    if (!data)
+        throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate FiberStack");
+
+    if constexpr (guardPagesEnabled())
     {
-        memoryGuardInstall(vp, page_size);
-    }
-    catch (...)
-    {
-        ::munmap(vp, num_bytes);
-        throw;
+        /// TODO: make reports on illegal guard page access more clear.
+        /// Currently we will see segfault and almost random stacktrace.
+        try
+        {
+            memoryGuardInstall(data, page_size);
+        }
+        catch (...)
+        {
+            free(data);
+            throw;
+        }
     }
 
-    /// Do not count guard page in memory usage.
-    auto trace = CurrentMemoryTracker::alloc(num_pages * page_size);
-    trace.onAlloc(vp, num_pages * page_size);
+    auto trace = CurrentMemoryTracker::alloc(num_bytes);
+    trace.onAlloc(data, num_bytes);
 
     boost::context::stack_context sctx;
     sctx.size = num_bytes;
-    sctx.sp = static_cast< char * >(vp) + sctx.size;
+    sctx.sp = static_cast< char * >(data) + sctx.size;
 #if defined(BOOST_USE_VALGRIND)
-    sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, vp);
+    sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, data);
 #endif
     return sctx;
 }
@@ -70,10 +89,14 @@ void FiberStack::deallocate(boost::context::stack_context & sctx) const
 #if defined(BOOST_USE_VALGRIND)
     VALGRIND_STACK_DEREGISTER(sctx.valgrind_stack_id);
 #endif
-    void * vp = static_cast< char * >(sctx.sp) - sctx.size;
-    ::munmap(vp, sctx.size);
+    void * data = static_cast< char * >(sctx.sp) - sctx.size;
+
+    if constexpr (guardPagesEnabled())
+        memoryGuardRemove(data, page_size);
+
+    free(data);
 
     /// Do not count guard page in memory usage.
-    auto trace = CurrentMemoryTracker::free(sctx.size - page_size);
-    trace.onFree(vp, sctx.size - page_size);
+    auto trace = CurrentMemoryTracker::free(sctx.size);
+    trace.onFree(data, sctx.size - page_size);
 }

--- a/src/Common/FiberStack.h
+++ b/src/Common/FiberStack.h
@@ -1,36 +1,11 @@
 #pragma once
-#include <base/defines.h>
 #include <boost/context/stack_context.hpp>
-#include <Common/formatReadable.h>
-#include <Common/CurrentMemoryTracker.h>
-#include <Common/Exception.h>
-#include <base/getPageSize.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/mman.h>
-
-#if defined(BOOST_USE_VALGRIND)
-#include <valgrind/valgrind.h>
-#endif
-
-/// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
-#ifndef MAP_ANONYMOUS
-#define MAP_ANONYMOUS MAP_ANON
-#endif
-
-namespace DB::ErrorCodes
-{
-    extern const int CANNOT_ALLOCATE_MEMORY;
-}
 
 /// This is an implementation of allocator for fiber stack.
 /// The reference implementation is protected_fixedsize_stack from boost::context.
 /// This implementation additionally track memory usage. It is the main reason why it is needed.
 class FiberStack
 {
-private:
-    size_t stack_size;
-    size_t page_size = 0;
 public:
     /// NOTE: If you see random segfaults in CI and stack starts from boost::context::...fiber...
     /// probably it worth to try to increase stack size for coroutines.
@@ -39,51 +14,12 @@ public:
     /// way. We will have 80 pages with 4KB page size.
     static constexpr size_t default_stack_size = 320 * 1024; /// 64KB was not enough for tests
 
-    explicit FiberStack(size_t stack_size_ = default_stack_size) : stack_size(stack_size_)
-    {
-        page_size = getPageSize();
-    }
+    explicit FiberStack(size_t stack_size_ = default_stack_size);
 
-    boost::context::stack_context allocate() const
-    {
-        size_t num_pages = 1 + (stack_size - 1) / page_size;
-        size_t num_bytes = (num_pages + 1) * page_size; /// Add one page at bottom that will be used as guard-page
+    boost::context::stack_context allocate() const;
+    void deallocate(boost::context::stack_context & sctx) const;
 
-        void * vp = ::mmap(nullptr, num_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (MAP_FAILED == vp)
-            throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: Cannot mmap {}.", ReadableSize(num_bytes));
-
-        /// TODO: make reports on illegal guard page access more clear.
-        /// Currently we will see segfault and almost random stacktrace.
-        if (-1 == ::mprotect(vp, page_size, PROT_NONE))
-        {
-            ::munmap(vp, num_bytes);
-            throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: cannot protect guard page");
-        }
-
-        /// Do not count guard page in memory usage.
-        auto trace = CurrentMemoryTracker::alloc(num_pages * page_size);
-        trace.onAlloc(vp, num_pages * page_size);
-
-        boost::context::stack_context sctx;
-        sctx.size = num_bytes;
-        sctx.sp = static_cast< char * >(vp) + sctx.size;
-#if defined(BOOST_USE_VALGRIND)
-        sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, vp);
-#endif
-        return sctx;
-    }
-
-    void deallocate(boost::context::stack_context & sctx) const
-    {
-#if defined(BOOST_USE_VALGRIND)
-        VALGRIND_STACK_DEREGISTER(sctx.valgrind_stack_id);
-#endif
-        void * vp = static_cast< char * >(sctx.sp) - sctx.size;
-        ::munmap(vp, sctx.size);
-
-        /// Do not count guard page in memory usage.
-        auto trace = CurrentMemoryTracker::free(sctx.size - page_size);
-        trace.onFree(vp, sctx.size - page_size);
-    }
+private:
+    const size_t stack_size;
+    const size_t page_size;
 };

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -29,6 +29,15 @@ namespace ErrorCodes
 namespace
 {
 
+constexpr bool guardPagesEnabled()
+{
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    return true;
+#else
+    return false;
+#endif
+}
+
 /// For aarch64 16K is not enough (likely due to tons of registers)
 constexpr size_t UNWIND_MINSIGSTKSZ = 32 << 10;
 
@@ -48,28 +57,42 @@ struct ThreadStack
 {
     ThreadStack()
     {
-        data = aligned_alloc(getPageSize(), getSize());
+        auto page_size = getPageSize();
+        data = aligned_alloc(page_size, getSize());
         if (!data)
             throw ErrnoException(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate ThreadStack");
 
-        try
+        if constexpr (guardPagesEnabled())
         {
-            /// Since the stack grows downward, we need to protect the first page
-            memoryGuardInstall(data, getPageSize());
-        }
-        catch (...)
-        {
-            free(data);
-            throw;
+            try
+            {
+                /// Since the stack grows downward, we need to protect the first page
+                memoryGuardInstall(data, page_size);
+            }
+            catch (...)
+            {
+                free(data);
+                throw;
+            }
         }
     }
     ~ThreadStack()
     {
-        memoryGuardRemove(data, getPageSize());
+        if constexpr (guardPagesEnabled())
+            memoryGuardRemove(data, getPageSize());
+
         free(data);
     }
 
-    static size_t getSize() { return std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ); }
+    static size_t getSize()
+    {
+        auto size = std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ);
+
+        if constexpr (guardPagesEnabled())
+            size += 1;
+
+        return size;
+    }
     void * getData() const { return data; }
 
 private:

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -89,7 +89,7 @@ struct ThreadStack
         auto size = std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ);
 
         if constexpr (guardPagesEnabled())
-            size += 1;
+            size += getPageSize();
 
         return size;
     }

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -5,6 +5,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/memory.h>
 #include <base/getPageSize.h>
 #include <base/errnoToString.h>
 #include <Interpreters/Context.h>
@@ -18,6 +19,11 @@
 namespace DB
 {
 thread_local ThreadStatus constinit * current_thread = nullptr;
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_ALLOCATE_MEMORY;
+}
 
 #if !defined(SANITIZER)
 namespace
@@ -41,15 +47,25 @@ constexpr size_t UNWIND_MINSIGSTKSZ = 32 << 10;
 struct ThreadStack
 {
     ThreadStack()
-        : data(aligned_alloc(getPageSize(), getSize()))
     {
-        /// Add a guard page
-        /// (and since the stack grows downward, we need to protect the first page).
-        mprotect(data, getPageSize(), PROT_NONE);
+        data = aligned_alloc(getPageSize(), getSize());
+        if (!data)
+            throw ErrnoException(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate ThreadStack");
+
+        try
+        {
+            /// Since the stack grows downward, we need to protect the first page
+            memoryGuardInstall(data, getPageSize());
+        }
+        catch (...)
+        {
+            free(data);
+            throw;
+        }
     }
     ~ThreadStack()
     {
-        mprotect(data, getPageSize(), PROT_WRITE|PROT_READ);
+        memoryGuardRemove(data, getPageSize());
         free(data);
     }
 
@@ -58,7 +74,7 @@ struct ThreadStack
 
 private:
     /// 16 KiB - not too big but enough to handle error.
-    void * data;
+    void * data = nullptr;
 };
 
 }

--- a/src/Common/memory.cpp
+++ b/src/Common/memory.cpp
@@ -1,0 +1,62 @@
+#include <sys/mman.h>
+#include <Poco/Environment.h>
+#include <Common/Exception.h>
+#include <Common/VersionNumber.h>
+#include <Common/memory.h>
+
+#ifdef OS_LINUX
+#if !defined(MADV_GUARD_INSTALL)
+#define MADV_GUARD_INSTALL 102
+#endif
+
+#if !defined(MADV_GUARD_REMOVE)
+#define MADV_GUARD_REMOVE 103
+#endif
+
+static bool supportsGuardPages()
+{
+    DB::VersionNumber madv_guard_minimal_version(6, 13, 0);
+    DB::VersionNumber linux_version(Poco::Environment::osVersion());
+    return (linux_version >= madv_guard_minimal_version);
+}
+static bool supports_guard_pages = supportsGuardPages();
+#endif // OS_LINUX
+
+namespace DB::ErrorCodes
+{
+    extern const int SYSTEM_ERROR;
+}
+
+/// Uses MADV_GUARD_INSTALL if available, or mprotect() if not
+void memoryGuardInstall(void *addr, size_t len)
+{
+#ifdef OS_LINUX
+    if (supports_guard_pages)
+    {
+        if (madvise(addr, len, MADV_GUARD_INSTALL))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot madvise(MADV_GUARD_INSTALL)");
+    }
+    else
+#endif
+    {
+        if (mprotect(addr, len, PROT_NONE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot mprotect(PROT_NONE)");
+    }
+}
+
+/// Uses MADV_GUARD_REMOVE if available, or mprotect() if not
+void memoryGuardRemove(void *addr, size_t len)
+{
+#ifdef OS_LINUX
+    if (supports_guard_pages)
+    {
+        if (madvise(addr, len, MADV_GUARD_REMOVE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot madvise(MADV_GUARD_INSTALL)");
+    }
+    else
+#endif
+    {
+        if (mprotect(addr, len, PROT_READ|PROT_WRITE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot mprotect(PROT_NONE)");
+    }
+}

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -17,12 +17,28 @@
 #    include <cstdlib>
 #endif
 
+#if defined(OS_LINUX)
+#    include <malloc.h>
+#elif defined(OS_DARWIN)
+#    include <malloc/malloc.h>
+#endif
+
 namespace ProfileEvents
 {
     extern const Event GWPAsanAllocateSuccess;
     extern const Event GWPAsanAllocateFailed;
     extern const Event GWPAsanFree;
 }
+
+/// Guard pages interface.
+///
+/// Uses MADV_GUARD_INSTALL/MADV_GUARD_REMOVE (since Linux 6.13+) which does
+/// not splits VMA (unlike mprotect()), or fallback to mprotect()
+///
+/// Uses MADV_GUARD_INSTALL if available, or mprotect() if not
+void memoryGuardInstall(void *addr, size_t len);
+/// Uses MADV_GUARD_REMOVE if available, or mprotect() if not
+void memoryGuardRemove(void *addr, size_t len);
 
 namespace Memory
 {
@@ -163,12 +179,6 @@ inline ALWAYS_INLINE void deleteSized(void * ptr, std::size_t size [[maybe_unuse
     free(ptr);
 }
 
-#endif
-
-#if defined(OS_LINUX)
-#    include <malloc.h>
-#elif defined(OS_DARWIN)
-#    include <malloc/malloc.h>
 #endif
 
 template <std::same_as<std::align_val_t>... TAlign>

--- a/src/Coordination/FourLetterCommand.h
+++ b/src/Coordination/FourLetterCommand.h
@@ -5,16 +5,14 @@
 #include <atomic>
 #include <memory>
 #include <unordered_map>
-#include <string>
 #include <vector>
+#include <base/types.h>
 #include <boost/noncopyable.hpp>
 
 namespace DB
 {
 
 class KeeperDispatcher;
-
-using String = std::string;
 
 struct IFourLetterCommand;
 using FourLetterCommandPtr = std::shared_ptr<DB::IFourLetterCommand>;

--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -7,6 +7,7 @@
 #include <QueryPipeline/RemoteInserter.h>
 #include <Common/Exception.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/formatReadable.h>
 #include <Common/quoteString.h>
 #include <base/defines.h>
 #include <IO/Operators.h>


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Remove guard pages for threads and async_socket_for_remote/use_hedge_requests. Change the allocation method in `FiberStack` from `mmap` to `aligned_alloc`. Since this splits VMAs and under heavy load vm.max_map_count can be reached. (https://github.com/ClickHouse/ClickHouse/pull/78423 by @azat, https://github.com/ClickHouse/ClickHouse/pull/79147 and https://github.com/ClickHouse/ClickHouse/pull/79533 by @CheSema)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)