### PR TITLE
25.3.5 Backport of #83607 Fix incorrect memory around max_untracked_memory

### DIFF
--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -68,17 +68,23 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory
         }
         current_thread->untracked_memory_blocker_level = blocker_level;
 
-        Int64 will_be = current_thread->untracked_memory + size;
-        if (will_be > current_thread->untracked_memory_limit)
+        Int64 previous_untracked_memory = current_thread->untracked_memory;
+        current_thread->untracked_memory += size;
+        if (current_thread->untracked_memory > current_thread->untracked_memory_limit)
         {
-            auto res = memory_tracker->allocImpl(will_be, throw_if_memory_exceeded);
+            Int64 current_untracked_memory = current_thread->untracked_memory;
             current_thread->untracked_memory = 0;
-            return res;
-        }
 
-        /// Update after successful allocations,
-        /// since failed allocations should not be take into account.
-        current_thread->untracked_memory = will_be;
+            try
+            {
+                return memory_tracker->allocImpl(current_untracked_memory, throw_if_memory_exceeded);
+            }
+            catch (...)
+            {
+                current_thread->untracked_memory += previous_untracked_memory;
+                throw;
+            }
+        }
 
         return AllocationTrace(memory_tracker->getSampleProbability(size));
     }

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -231,8 +231,9 @@ void ThreadStatus::flushUntrackedMemory()
         return;
 
     MemoryTrackerBlockerInThread blocker(untracked_memory_blocker_level);
-    memory_tracker.adjustWithUntrackedMemory(untracked_memory);
+    Int64 current_untracked_memory = current_thread->untracked_memory;
     untracked_memory = 0;
+    memory_tracker.adjustWithUntrackedMemory(current_untracked_memory);
 }
 
 bool ThreadStatus::isQueryCanceled() const


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect memory around max_untracked_memory (https://github.com/ClickHouse/ClickHouse/pull/83607 by @azat)

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache