### PR TITLE
25.3.6 Backport of #79743: Fix wrong results for grouping sets with ColumnConst

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -210,11 +210,11 @@ ActionsDAG::ActionsDAG(const NamesAndTypesList & inputs_)
         outputs.push_back(&addInput(input.name, input.type));
 }
 
-ActionsDAG::ActionsDAG(const ColumnsWithTypeAndName & inputs_)
+ActionsDAG::ActionsDAG(const ColumnsWithTypeAndName & inputs_, bool duplicate_const_columns)
 {
     for (const auto & input : inputs_)
     {
-        if (input.column && isColumnConst(*input.column))
+        if (input.column && isColumnConst(*input.column) && duplicate_const_columns)
         {
             addInput(input);
 

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -115,7 +115,7 @@ public:
     ActionsDAG & operator=(ActionsDAG &&) = default;
     ActionsDAG & operator=(const ActionsDAG &) = delete;
     explicit ActionsDAG(const NamesAndTypesList & inputs_);
-    explicit ActionsDAG(const ColumnsWithTypeAndName & inputs_);
+    explicit ActionsDAG(const ColumnsWithTypeAndName & inputs_, bool duplicate_const_columns = true);
 
     const Nodes & getNodes() const { return nodes; }
     static Nodes detachNodes(ActionsDAG && dag) { return std::move(dag.nodes); }

--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -125,7 +125,9 @@ std::optional<AggregationAnalysisResult> analyzeAggregation(const QueryTreeNodeP
     Names aggregation_keys;
 
     ActionsAndProjectInputsFlagPtr before_aggregation_actions = std::make_shared<ActionsAndProjectInputsFlag>();
-    before_aggregation_actions->dag = ActionsDAG(input_columns);
+    /// Here it is OK to materialize const columns: if column is used in GROUP BY, it may be expected to become non-const
+    /// See https://github.com/ClickHouse/ClickHouse/issues/70655 for example
+    before_aggregation_actions->dag = ActionsDAG(input_columns, false);
     before_aggregation_actions->dag.getOutputs().clear();
 
     std::unordered_set<std::string_view> before_aggregation_actions_output_node_names;

--- a/tests/queries/0_stateless/00757_enum_defaults_const_analyzer.reference
+++ b/tests/queries/0_stateless/00757_enum_defaults_const_analyzer.reference
@@ -3,4 +3,4 @@ iphone	1
 iphone	1
 iphone	1
 
-iphone	1
+\N	1

--- a/tests/queries/0_stateless/03447_grouping_sets_analyzer_const_columns.reference
+++ b/tests/queries/0_stateless/03447_grouping_sets_analyzer_const_columns.reference
@@ -1,0 +1,27 @@
+Const column in grouping set, analyzer on:
+0	0	value	0	1
+0	0	value	1	1
+0	0	value	2	1
+0	0	value	3	1
+1	0		0	1
+1	0		1	1
+1	0		2	1
+1	0		3	1
+Non-const column in grouping set, analyzer on:
+0	0	value	0	1
+0	0	value	1	1
+0	0	value	2	1
+0	0	value	3	1
+1	0		0	1
+1	0		1	1
+1	0		2	1
+1	0		3	1
+Const column in grouping set, analyzer off:
+0	0	value	0	1
+0	0	value	1	1
+0	0	value	2	1
+0	0	value	3	1
+1	0		0	1
+1	0		1	1
+1	0		2	1
+1	0		3	1

--- a/tests/queries/0_stateless/03447_grouping_sets_analyzer_const_columns.sql
+++ b/tests/queries/0_stateless/03447_grouping_sets_analyzer_const_columns.sql
@@ -1,0 +1,26 @@
+SET enable_analyzer=1;
+
+SELECT 'Const column in grouping set, analyzer on:';
+
+SELECT grouping(key_a), grouping(key_b), key_a, key_b, count()  FROM (
+    SELECT 'value' as key_a, number as key_b FROM numbers(4)
+)
+GROUP BY GROUPING SETS((key_b), (key_a, key_b))
+ORDER BY (grouping(key_a), grouping(key_b), key_a, key_b);
+
+SELECT 'Non-const column in grouping set, analyzer on:';
+
+SELECT grouping(key_a), grouping(key_b), key_a, key_b, count() FROM (
+    SELECT materialize('value') as key_a, number as key_b FROM numbers(4)
+)
+GROUP BY GROUPING SETS((key_b), (key_a, key_b))
+ORDER BY (grouping(key_a), grouping(key_b), key_a, key_b);
+
+SELECT 'Const column in grouping set, analyzer off:';
+
+SELECT grouping(key_a), grouping(key_b), key_a, key_b, count() FROM (
+    SELECT 'value' as key_a, number as key_b FROM numbers(4)
+)
+GROUP BY GROUPING SETS((key_b), (key_a, key_b))
+ORDER BY (grouping(key_a), grouping(key_b), key_a, key_b)
+SETTINGS allow_experimental_analyzer=0;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong results for grouping sets with ColumnConst and Analyzer (https://github.com/ClickHouse/ClickHouse/pull/79743 by @zvonand)


#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
