### PR TITLE
25.3.6 Altinitystable: fix version tag

### DIFF
--- a/cmake/autogenerated_versions.txt
+++ b/cmake/autogenerated_versions.txt
@@ -10,7 +10,7 @@ SET(VERSION_GITHASH 14e08ead34a7900d75e3d378f87cabfba9f8c8d9)
 #10000 for altinitystable candidates
 #20000 for altinityedge candidates
 SET(VERSION_TWEAK 10000)
-SET(VERSION_FLAVOUR altinitytest)
-SET(VERSION_DESCRIBE v25.3.6.10000.altinitytest)
-SET(VERSION_STRING 25.3.6.10000.altinitytest)
+SET(VERSION_FLAVOUR altinitystable)
+SET(VERSION_DESCRIBE v25.3.6.10000.altinitystable)
+SET(VERSION_STRING 25.3.6.10000.altinitystable)
 # end of autochange


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
