### PR TITLE
Antalya 25.6 - fix CI/CD - Better random database names for stateless tests

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1285,8 +1285,7 @@ class TestCase:
                     random.SystemRandom().choice(alphabet) for _ in range(length)
                 )
 
-            database = f"test_{random_str()}"
-
+            database = f"test_{os.getpid()}_{random_str(16)}"
             clickhouse_execute(
                 args,
                 "CREATE DATABASE IF NOT EXISTS "

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2615,6 +2615,8 @@ def run_tests_array(
         proc_name = multiprocessing.current_process().name
         print(f"Running {about}{num_tests} {test_suite.suite} tests ({proc_name}).")
 
+    print('!!!!!', multiprocessing.current_process().name, '\n'.join(all_tests))
+
     while True:
         if all_tests:
             try:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2956,11 +2956,14 @@ def do_run_tests(
 
         processes = []
         for _ in range(jobs):
+            tests_to_run = parallel_tests[:batch_size]
+            del parallel_tests[:batch_size]
+
             process = multiprocessing.Process(
                 target=run_tests_process,
                 args=(
                     (
-                        parallel_tests,
+                        tests_to_run,
                         batch_size,
                         test_suite,
                         True,
@@ -2973,6 +2976,9 @@ def do_run_tests(
             )
             processes.append(process)
             process.start()
+
+        # all of the tests are taken int account
+        assert(len(parallel_tests) == 0)
 
         while processes:
             sleep(0.1)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2949,7 +2949,7 @@ def do_run_tests(
         # TODO: add shuffle for sequential tests
         random.shuffle(test_suite.parallel_tests)
 
-        batch_size = len(test_suite.parallel_tests) // jobs
+        batch_size = math.ceil(len(test_suite.parallel_tests) / jobs)
         manager = multiprocessing.Manager()
         parallel_tests = manager.list()
         parallel_tests.extend(test_suite.parallel_tests)
@@ -3010,6 +3010,7 @@ def do_run_tests(
             for p in processes[:]:
                 if not p.is_alive():
                     processes.remove(p)
+
     if test_suite.sequential_tests:
         run_tests_array(
             (

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2615,7 +2615,7 @@ def run_tests_array(
         proc_name = multiprocessing.current_process().name
         print(f"Running {about}{num_tests} {test_suite.suite} tests ({proc_name}).")
 
-    print('!!!!!', multiprocessing.current_process().name, '\n'.join(all_tests))
+    print('!!!!!', multiprocessing.current_process().name, f'got {len(all_tests)} tests')
 
     while True:
         if all_tests:


### PR DESCRIPTION
Guarantee that DB names are unique for the job when there are multiple simultaneous jobs. 
Somewhat better chances that DB names for a single job are unique.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
