### PR TITLE
Antalya 25.6.5 Partial backport of #83121 Revert "Revert "Reintroduce async logging""

### DIFF
--- a/tests/queries/0_stateless/02116_clickhouse_stderr.sh
+++ b/tests/queries/0_stateless/02116_clickhouse_stderr.sh
@@ -22,7 +22,8 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
     cd "$test_dir" || exit 1
 
     stderr=$(mktemp -t clickhouse.XXXXXX)
-    $CLICKHOUSE_SERVER_BINARY -- --logger.stderr="$stderr" 2>/dev/null
+    # It will fail to start because the port is already in use
+    $CLICKHOUSE_SERVER_BINARY -- --listen_host "${CLICKHOUSE_HOST}" --tcp_port "$CLICKHOUSE_PORT_TCP" --logger.stderr="$stderr" 2>/dev/null
     # -s -- check that stderr was created and is not empty
     test -s "$stderr" || exit 2
     rm "$stderr"


### PR DESCRIPTION
Make 02116_clickhouse_stderr more obvious and compatible with different configs

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


### Documentation entry for user-facing changes

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
