### PR TITLE
Antalya 25.6.5 Cached builds report

### DIFF
--- a/.github/actions/create_workflow_report/ci_run_report.html.jinja
+++ b/.github/actions/create_workflow_report/ci_run_report.html.jinja
@@ -152,7 +152,7 @@
       </tr>
       <tr>
         <th class="hth no-sort">Build Report</th>
-        <td><a href="https://s3.amazonaws.com/{{ s3_bucket }}/{{ pr_number }}/{{ commit_sha }}/builds/report.html">Build Report</a></td>
+        <td>{% for job_name, link in build_report_links.items() %}<a href="{{ link }}">{{ job_name }} </a>{% endfor %}</td>
       </tr>
       <tr>
         <th class="hth no-sort">Date</th>

--- a/.github/actions/create_workflow_report/ci_run_report.html.jinja
+++ b/.github/actions/create_workflow_report/ci_run_report.html.jinja
@@ -152,7 +152,7 @@
       </tr>
       <tr>
         <th class="hth no-sort">Build Report</th>
-        <td>{% for job_name, link in build_report_links.items() %}<a href="{{ link }}">{{ job_name }} </a>{% endfor %}</td>
+        <td>{% for job_name, link in build_report_links.items() %}<a href="{{ link }}">[{{ job_name }}]</a> {% endfor %}</td>
       </tr>
       <tr>
         <th class="hth no-sort">Date</th>

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -549,7 +549,7 @@ def get_build_report_links(
     build_report_links = {}
 
     for job in job_statuses.itertuples():
-        if job.job_name not in build_job_names or job.status != "success":
+        if job.job_name not in build_job_names or job.job_status != "success":
             continue
 
         build_report_links[job.job_name] = job.results_link
@@ -574,7 +574,11 @@ def get_build_report_links(
         # Cache exists, get the status data
         status_data = response.json()
         for job in status_data["results"]:
-            if job["name"] in build_job_names and job["status"] == "skipped":
+            if (
+                job["name"] in build_job_names
+                and job["status"] == "skipped"
+                and len(job["links"]) > 0
+            ):
                 build_report_links[job["name"]] = job["links"][0]
 
     if len(build_report_links) > 0:

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -540,7 +540,7 @@ def get_build_report_links(pr_number: int, branch: str, commit_sha: str):
     Get the build report links for the given PR number, branch, and commit SHA.
     """
     build_job_names = ["Build (amd_release)", "Build (arm_release)"]
-    s3_prefix = "todo"
+
     if pr_number == 0:
         ref_param = f"REF={branch}"
         workflow_name = "MasterCI"

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -157,15 +157,19 @@ class Info:
 
         if pr_number:
             ref_param = f"PR={pr_number}"
+            # Hotfix for bug that is fixed properly in latest upstream
+            workflow_name = "PR"
         else:
             assert branch
             ref_param = f"REF={branch}"
+            # Hotfix for bug that is fixed properly in latest upstream
+            workflow_name = "MasterCI"
         path = Settings.HTML_S3_PATH
         for bucket, endpoint in Settings.S3_BUCKET_TO_HTTP_ENDPOINT.items():
             if bucket in path:
                 path = path.replace(bucket, endpoint)
                 break
-        res = f"https://{path}/{Path(Settings.HTML_PAGE_FILE).name}?{ref_param}&sha={sha}&name_0={urllib.parse.quote(self.env.WORKFLOW_NAME, safe='')}"
+        res = f"https://{path}/{Path(Settings.HTML_PAGE_FILE).name}?{ref_param}&sha={sha}&name_0={urllib.parse.quote(workflow_name, safe='')}"
         if job_name:
             res += f"&name_1={urllib.parse.quote(job_name, safe='')}"
         return res

--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -53,7 +53,7 @@ class Job:
 
         allow_merge_on_failure: bool = False
 
-        enable_commit_status: bool = False
+        enable_commit_status: bool = True
 
         # If a job Result contains multiple sub-results, and only a specific sub-result should be sent to CIDB, set its name here.
         result_name_for_cidb: str = ""

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -383,7 +383,9 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
 
             affected_artifacts = []
             unaffected_jobs_with_artifacts = {}
-            all_required_artifacts = set()
+            # NOTE (strtgbb): We always want the build artifacts for our report and regression tests.
+            # If we make FinishCIReport and regression tests into praktika jobs, we can remove this.
+            all_required_artifacts = set(["CH_AMD_RELEASE", "CH_ARM_RELEASE"])
 
             for job in workflow.jobs:
                 # Skip native Praktika jobs


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Summary
- Support cached build report in workflow report. Due to an upstream bug, these links are sometimes incorrect.
- Hotfix to prevent broken links in future builds. The hotfix assumes we are only using the PR and MasterCI workflows.
- Add links to binaries and docker images at the top of the report.

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
