### PR TITLE
Exception when no active replicas for s3Cluster request

### DIFF
--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -42,6 +42,11 @@ namespace Setting
     extern const SettingsNonZeroUInt64 max_parallel_replicas;
 }
 
+namespace ErrorCodes
+{
+    extern const int NO_ACTIVE_REPLICAS;
+};
+
 IStorageCluster::IStorageCluster(
     const String & cluster_name_,
     const StorageID & table_id_,
@@ -238,6 +243,9 @@ void ReadFromCluster::initializePipeline(QueryPipelineBuilder & pipeline, const 
         pipe.addSimpleTransform([&](const Block & header) { return std::make_shared<UnmarshallBlocksTransform>(header); });
         pipes.emplace_back(std::move(pipe));
     }
+
+    if (pipes.size() == 0)
+        throw Exception(ErrorCodes::NO_ACTIVE_REPLICAS, "Can't find active replicas in cluster '{}'", cluster->getName());
 
     auto pipe = Pipe::unitePipes(std::move(pipes));
     if (pipe.empty())

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -537,3 +537,14 @@ def test_cluster_default_expression(started_cluster):
     )
 
     assert result == expected_result
+
+
+def test_dead_cluster(started_cluster):
+    node = started_cluster.instances["s0_1_0"]
+
+    with started_cluster.pause_container("s0_0_0"):
+        with started_cluster.pause_container("s0_0_1"):
+            result = node.query_and_get_error(
+                f"SELECT * FROM s3Cluster(first_shard, 'http://minio1:9001/root/data/clickhouse/part1.csv', 'minio', '{minio_secret_key}', 'CSV', 'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') order by name"
+            )
+            assert "Can't find active replicas in cluster" in result


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Exception if no active replicas in cluster request

### Documentation entry for user-facing changes
Solved #979.

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
