### PR TITLE
25.6 Fix clickhouse-server/keeper docker tag

### DIFF
--- a/tests/ci/ci_definitions.py
+++ b/tests/ci/ci_definitions.py
@@ -563,7 +563,7 @@ class CommonJobConfigs:
     DOCKER_SERVER = JobConfig(
         job_name_keyword="docker",
         required_on_release_branch=True,
-        run_command='docker_server.py --check-name "$CHECK_NAME" --tag-type head --allow-build-reuse --push',
+        run_command='docker_server.py --check-name "$CHECK_NAME" --tag-type head --allow-build-reuse --push --version $CLICKHOUSE_VERSION_STRING',
         digest=DigestConfig(
             include_paths=[
                 "tests/ci/docker_server.py",


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Pass version for clickhouse server docker image from env.

### Documentation entry for user-facing changes
...

#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache
