### PR TITLE
Antalya 25.6.5 - Backport of #85538 - Few fixes to hive reads & writes

### DIFF
--- a/src/Functions/keyvaluepair/impl/CHKeyValuePairExtractor.h
+++ b/src/Functions/keyvaluepair/impl/CHKeyValuePairExtractor.h
@@ -169,7 +169,7 @@ struct KeyValuePairExtractorReferenceMap : extractKV::KeyValuePairExtractor<extr
     explicit KeyValuePairExtractorReferenceMap(const extractKV::Configuration & configuration_, std::size_t max_number_of_pairs_)
         : KeyValuePairExtractor(configuration_, max_number_of_pairs_) {}
 
-    uint64_t extract(std::string_view data, absl::flat_hash_map<std::string_view, std::string_view> & map)
+    uint64_t extract(std::string_view data, std::map<std::string_view, std::string_view> & map)
     {
         auto pair_writer = typename StateHandler::PairWriter(map);
         return extractImpl(data, pair_writer);

--- a/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
+++ b/src/Functions/keyvaluepair/impl/StateHandlerImpl.h
@@ -13,7 +13,6 @@
 #include <string_view>
 #include <string>
 #include <vector>
-#include <absl/container/flat_hash_map.h>
 
 
 namespace DB
@@ -577,13 +576,13 @@ struct ReferencesMapStateHandler : public StateHandlerImpl<false>
      * */
     class PairWriter
     {
-        absl::flat_hash_map<std::string_view, std::string_view> & map;
+        std::map<std::string_view, std::string_view> & map;
 
         std::string_view key;
         std::string_view value;
 
     public:
-        explicit PairWriter(absl::flat_hash_map<std::string_view, std::string_view> & map_)
+        explicit PairWriter(std::map<std::string_view, std::string_view> & map_)
             : map(map_)
         {}
 

--- a/src/Storages/HivePartitioningUtils.cpp
+++ b/src/Storages/HivePartitioningUtils.cpp
@@ -3,6 +3,7 @@
 #include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/convertFieldToType.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <Functions/keyvaluepair/impl/KeyValuePairExtractorBuilder.h>
 #include <Functions/keyvaluepair/impl/DuplicateKeyFoundException.h>
 #include <Formats/EscapingRuleUtils.h>
@@ -20,6 +21,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int INCORRECT_DATA;
+    extern const int BAD_ARGUMENTS;
 }
 
 namespace HivePartitioningUtils
@@ -83,7 +85,14 @@ NamesAndTypesList extractHivePartitionColumnsFromPath(
         {
             if (const auto type = tryInferDataTypeByEscapingRule(value, format_settings ? *format_settings : getFormatSettings(context), FormatSettings::EscapingRule::Raw))
             {
-                hive_partition_columns_to_read_from_file_path.emplace_back(key, type);
+                if (type->canBeInsideLowCardinality())
+                {
+                    hive_partition_columns_to_read_from_file_path.emplace_back(key, std::make_shared<DataTypeLowCardinality>(type));
+                }
+                else
+                {
+                    hive_partition_columns_to_read_from_file_path.emplace_back(key, type);
+                }
             }
             else
             {
@@ -122,6 +131,29 @@ void addPartitionColumnsToChunk(
     }
 }
 
+void sanityCheckSchemaAndHivePartitionColumns(const NamesAndTypesList & hive_partition_columns_to_read_from_file_path, const ColumnsDescription & storage_columns)
+{
+    for (const auto & column : hive_partition_columns_to_read_from_file_path)
+    {
+        if (!storage_columns.has(column.name))
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "All hive partitioning columns must be present in the schema. Missing column: {}. "
+                "If you do not want to use hive partitioning, try `use_hive_partitioning=0` and/or `partition_strategy != hive`",
+                column.name);
+        }
+    }
+
+    if (storage_columns.size() == hive_partition_columns_to_read_from_file_path.size())
+    {
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "A hive partitioned file can't contain only partition columns. "
+            "Try reading it with `use_hive_partitioning=0` and/or `partition_strategy != hive`");
+    }
+}
+
 void extractPartitionColumnsFromPathAndEnrichStorageColumns(
     ColumnsDescription & storage_columns,
     NamesAndTypesList & hive_partition_columns_to_read_from_file_path,
@@ -144,13 +176,96 @@ void extractPartitionColumnsFromPathAndEnrichStorageColumns(
             }
         }
     }
+}
 
-    if (hive_partition_columns_to_read_from_file_path.size() == storage_columns.size())
+HivePartitionColumnsWithFileColumnsPair setupHivePartitioningForObjectStorage(
+    ColumnsDescription & columns,
+    const StorageObjectStorageConfigurationPtr & configuration,
+    const std::string & sample_path,
+    bool inferred_schema,
+    std::optional<FormatSettings> format_settings,
+    ContextPtr context)
+{
+    NamesAndTypesList hive_partition_columns_to_read_from_file_path;
+    NamesAndTypesList file_columns;
+
+    /*
+     * If `partition_strategy=hive`, the partition columns shall be extracted from the `PARTITION BY` expression.
+     * There is no need to read from the file's path.
+     *
+     * Otherwise, in case `use_hive_partitioning=1`, we can keep the old behavior of extracting it from the sample path.
+     * And if the schema was inferred (not specified in the table definition), we need to enrich it with the path partition columns
+     */
+     if (configuration->partition_strategy && configuration->partition_strategy_type == PartitionStrategyFactory::StrategyType::HIVE)
+     {
+         hive_partition_columns_to_read_from_file_path = configuration->partition_strategy->getPartitionColumns();
+     }
+     else if (context->getSettingsRef()[Setting::use_hive_partitioning])
+     {
+        extractPartitionColumnsFromPathAndEnrichStorageColumns(
+            columns,
+            hive_partition_columns_to_read_from_file_path,
+            sample_path,
+            inferred_schema,
+            format_settings,
+            context);
+     }
+
+     sanityCheckSchemaAndHivePartitionColumns(hive_partition_columns_to_read_from_file_path, columns);
+
+     if (configuration->partition_columns_in_data_file)
+     {
+         file_columns = columns.getAllPhysical();
+     }
+     else
+     {
+         std::unordered_set<String> hive_partition_columns_to_read_from_file_path_set;
+
+         for (const auto & [name, type] : hive_partition_columns_to_read_from_file_path)
+         {
+             hive_partition_columns_to_read_from_file_path_set.insert(name);
+         }
+
+         for (const auto & [name, type] : columns.getAllPhysical())
+         {
+             if (!hive_partition_columns_to_read_from_file_path_set.contains(name))
+             {
+                file_columns.emplace_back(name, type);
+             }
+         }
+     }
+
+     return {hive_partition_columns_to_read_from_file_path, file_columns};
+}
+
+HivePartitionColumnsWithFileColumnsPair setupHivePartitioningForFileURLLikeStorage(
+    ColumnsDescription & columns,
+    const std::string & sample_path,
+    bool inferred_schema,
+    std::optional<FormatSettings> format_settings,
+    ContextPtr context)
+{
+    NamesAndTypesList hive_partition_columns_to_read_from_file_path;
+    NamesAndTypesList file_columns;
+
+    if (context->getSettingsRef()[Setting::use_hive_partitioning])
     {
-        throw Exception(
-            ErrorCodes::INCORRECT_DATA,
-            "A hive partitioned file can't contain only partition columns. Try reading it with `use_hive_partitioning=0`");
+        extractPartitionColumnsFromPathAndEnrichStorageColumns(
+            columns,
+            hive_partition_columns_to_read_from_file_path,
+            sample_path,
+            inferred_schema,
+            format_settings,
+            context);
     }
+
+    sanityCheckSchemaAndHivePartitionColumns(hive_partition_columns_to_read_from_file_path, columns);
+
+    /// Partition strategy is not implemented for File/URL storages,
+    /// so there is no option to set whether hive partition columns are in the data file or not.
+    file_columns = columns.getAllPhysical();
+
+    return {hive_partition_columns_to_read_from_file_path, file_columns};
 }
 
 }

--- a/src/Storages/HivePartitioningUtils.cpp
+++ b/src/Storages/HivePartitioningUtils.cpp
@@ -180,7 +180,7 @@ void extractPartitionColumnsFromPathAndEnrichStorageColumns(
 
 HivePartitionColumnsWithFileColumnsPair setupHivePartitioningForObjectStorage(
     ColumnsDescription & columns,
-    const StorageObjectStorageConfigurationPtr & configuration,
+    const StorageObjectStorage::ConfigurationPtr & configuration,
     const std::string & sample_path,
     bool inferred_schema,
     std::optional<FormatSettings> format_settings,

--- a/src/Storages/HivePartitioningUtils.h
+++ b/src/Storages/HivePartitioningUtils.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <absl/container/flat_hash_map.h>
 #include <Storages/ColumnsDescription.h>
+#include <Storages/ObjectStorage/StorageObjectStorageConfiguration.h>
+#include <Core/NamesAndTypes.h>
 
 namespace DB
 {
@@ -10,7 +11,7 @@ class Chunk;
 
 namespace HivePartitioningUtils
 {
-using HivePartitioningKeysAndValues = absl::flat_hash_map<std::string_view, std::string_view>;
+using HivePartitioningKeysAndValues = std::map<std::string_view, std::string_view>;
 
 HivePartitioningKeysAndValues parseHivePartitioningKeysAndValues(const std::string & path);
 
@@ -19,10 +20,20 @@ void addPartitionColumnsToChunk(
     const NamesAndTypesList & hive_partition_columns_to_read_from_file_path,
     const std::string & path);
 
-void extractPartitionColumnsFromPathAndEnrichStorageColumns(
-    ColumnsDescription & storage_columns,
-    NamesAndTypesList & hive_partition_columns_to_read_from_file_path,
-    const std::string & path,
+/// Hive partition columns and file columns (Note that file columns might not contain the hive partition columns)
+using HivePartitionColumnsWithFileColumnsPair = std::pair<NamesAndTypesList, NamesAndTypesList>;
+
+HivePartitionColumnsWithFileColumnsPair setupHivePartitioningForObjectStorage(
+    ColumnsDescription & columns,
+    const StorageObjectStorageConfigurationPtr & configuration,
+    const std::string & sample_path,
+    bool inferred_schema,
+    std::optional<FormatSettings> format_settings,
+    ContextPtr context);
+
+HivePartitionColumnsWithFileColumnsPair setupHivePartitioningForFileURLLikeStorage(
+    ColumnsDescription & columns,
+    const std::string & sample_path,
     bool inferred_schema,
     std::optional<FormatSettings> format_settings,
     ContextPtr context);

--- a/src/Storages/HivePartitioningUtils.h
+++ b/src/Storages/HivePartitioningUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Storages/ColumnsDescription.h>
-#include <Storages/ObjectStorage/StorageObjectStorageConfiguration.h>
+#include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Core/NamesAndTypes.h>
 
 namespace DB
@@ -25,7 +25,7 @@ using HivePartitionColumnsWithFileColumnsPair = std::pair<NamesAndTypesList, Nam
 
 HivePartitionColumnsWithFileColumnsPair setupHivePartitioningForObjectStorage(
     ColumnsDescription & columns,
-    const StorageObjectStorageConfigurationPtr & configuration,
+    const StorageObjectStorage::ConfigurationPtr & configuration,
     const std::string & sample_path,
     bool inferred_schema,
     std::optional<FormatSettings> format_settings,

--- a/src/Storages/IPartitionStrategy.cpp
+++ b/src/Storages/IPartitionStrategy.cpp
@@ -118,7 +118,7 @@ namespace
 
         if (file_format.empty() || file_format == "auto")
         {
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "File format can't be empty for hive style partitioning");
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "File format can't be empty for hive style partitioning");
         }
 
         const auto partition_key_description = KeyDescription::getKeyFromAST(partition_by, ColumnsDescription::fromNamesAndTypes(sample_block.getNamesAndTypes()), context);

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -172,56 +172,13 @@ StorageObjectStorage::StorageObjectStorage(
         }
     }
 
-    /*
-     * If `partition_strategy=hive`, the partition columns shall be extracted from the `PARTITION BY` expression.
-     * There is no need to read from the file's path.
-     *
-     * Otherwise, in case `use_hive_partitioning=1`, we can keep the old behavior of extracting it from the sample path.
-     * And if the schema was inferred (not specified in the table definition), we need to enrich it with the path partition columns
-     */
-    if (configuration->partition_strategy && configuration->partition_strategy_type == PartitionStrategyFactory::StrategyType::HIVE)
-    {
-        hive_partition_columns_to_read_from_file_path = configuration->partition_strategy->getPartitionColumns();
-    }
-    else if (context->getSettingsRef()[Setting::use_hive_partitioning])
-    {
-        HivePartitioningUtils::extractPartitionColumnsFromPathAndEnrichStorageColumns(
-           columns,
-           hive_partition_columns_to_read_from_file_path,
-           sample_path,
-           columns_in_table_or_function_definition.empty(),
-           format_settings,
-           context);
-    }
-
-    if (hive_partition_columns_to_read_from_file_path.size() == columns.size())
-    {
-        throw Exception(
-            ErrorCodes::INCORRECT_DATA,
-            "A hive partitioned file can't contain only partition columns. Try reading it with `partition_strategy=wildcard` and `use_hive_partitioning=0`");
-    }
-
-    if (configuration->partition_columns_in_data_file)
-    {
-        file_columns = columns;
-    }
-    else
-    {
-        std::unordered_set<String> hive_partition_columns_to_read_from_file_path_set;
-
-        for (const auto & [name, type] : hive_partition_columns_to_read_from_file_path)
-        {
-            hive_partition_columns_to_read_from_file_path_set.insert(name);
-        }
-
-        for (const auto & [name, type] : columns.getAllPhysical())
-        {
-            if (!hive_partition_columns_to_read_from_file_path_set.contains(name))
-            {
-                file_columns.add({name, type});
-            }
-        }
-    }
+    std::tie(hive_partition_columns_to_read_from_file_path, file_columns) = HivePartitioningUtils::setupHivePartitioningForObjectStorage(
+        columns,
+        configuration,
+        sample_path,
+        columns_in_table_or_function_definition.empty(),
+        format_settings,
+        context);
 
     // Assert file contains at least one column. The assertion only takes place if we were able to deduce the schema. The storage might be empty.
     if (!columns.empty() && file_columns.empty())
@@ -500,15 +457,13 @@ void StorageObjectStorage::read(
                         getName());
     }
 
-    auto all_file_columns = file_columns.getAll();
-
     auto read_from_format_info = configuration->prepareReadingFromFormat(
         object_storage,
         column_names,
         storage_snapshot,
         supportsSubsetOfColumns(local_context),
         local_context,
-        PrepareReadingFromFormatHiveParams { all_file_columns, hive_partition_columns_to_read_from_file_path.getNameToTypeMap() });
+        PrepareReadingFromFormatHiveParams { file_columns, hive_partition_columns_to_read_from_file_path.getNameToTypeMap() });
 
     const bool need_only_count = (query_info.optimize_trivial_count || read_from_format_info.requested_columns.empty())
                                  && local_context->getSettingsRef()[Setting::optimize_count_from_files];

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -177,7 +177,7 @@ protected:
     bool update_configuration_on_read_write = true;
 
     NamesAndTypesList hive_partition_columns_to_read_from_file_path;
-    ColumnsDescription file_columns;
+    NamesAndTypesList file_columns;
 
     LoggerPtr log;
 };

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -29,7 +29,6 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
-    extern const int INCORRECT_DATA;
 }
 
 String StorageObjectStorageCluster::getPathSample(ContextPtr context)
@@ -88,37 +87,14 @@ StorageObjectStorageCluster::StorageObjectStorageCluster(
     if (sample_path.empty() && context_->getSettingsRef()[Setting::use_hive_partitioning] && !configuration->isDataLakeConfiguration() && !configuration->partition_strategy)
         sample_path = getPathSample(context_);
 
-    /*
-     * If `partition_strategy=hive`, the partition columns shall be extracted from the `PARTITION BY` expression.
-     * There is no need to read from the filepath.
-     *
-     * Otherwise, in case `use_hive_partitioning=1`, we can keep the old behavior of extracting it from the sample path.
-     * And if the schema was inferred (not specified in the table definition), we need to enrich it with the path partition columns
-     */
-    if (configuration->partition_strategy && configuration->partition_strategy_type == PartitionStrategyFactory::StrategyType::HIVE)
-    {
-        hive_partition_columns_to_read_from_file_path = configuration->partition_strategy->getPartitionColumns();
-    }
-    else if (context_->getSettingsRef()[Setting::use_hive_partitioning])
-    {
-        HivePartitioningUtils::extractPartitionColumnsFromPathAndEnrichStorageColumns(
-            columns,
-            hive_partition_columns_to_read_from_file_path,
-            sample_path,
-            columns_in_table_or_function_definition.empty(),
-            std::nullopt,
-            context_
-        );
-    }
-
-    if (hive_partition_columns_to_read_from_file_path.size() == columns.size())
-    {
-        throw Exception(
-            ErrorCodes::INCORRECT_DATA,
-            "A hive partitioned file can't contain only partition columns. Try reading it with `partition_strategy=wildcard` and `use_hive_partitioning=0`");
-    }
-
-    /// Hive: Not building the file_columns like `StorageObjectStorage` does because it is not necessary to do it here.
+    /// Not grabbing the file_columns because it is not necessary to do it here.
+    std::tie(hive_partition_columns_to_read_from_file_path, std::ignore) = HivePartitioningUtils::setupHivePartitioningForObjectStorage(
+        columns,
+        configuration,
+        sample_path,
+        columns_in_table_or_function_definition.empty(),
+        std::nullopt,
+        context_);
 
     StorageInMemoryMetadata metadata;
     metadata.setColumns(columns);

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -275,6 +275,16 @@ Chunk StorageObjectStorageSource::generate()
 
             const auto path = getUniqueStoragePathIdentifier(*configuration, *object_info, false);
 
+            /// The order is important, hive partition columns must be added before virtual columns
+            /// because they are part of the schema
+            if (!read_from_format_info.hive_partition_columns_to_read_from_file_path.empty())
+            {
+                HivePartitioningUtils::addPartitionColumnsToChunk(
+                    chunk,
+                    read_from_format_info.hive_partition_columns_to_read_from_file_path,
+                    path);
+            }
+
             VirtualColumnUtils::addRequestedFileLikeStorageVirtualsToChunk(
                 chunk,
                 read_from_format_info.requested_virtual_columns,
@@ -284,15 +294,6 @@ Chunk StorageObjectStorageSource::generate()
                  .last_modified = object_info->metadata->last_modified,
                  .etag = &(object_info->metadata->etag)},
                 read_context);
-
-            // The order is important, it must be added after virtual columns..
-            if (!read_from_format_info.hive_partition_columns_to_read_from_file_path.empty())
-            {
-                HivePartitioningUtils::addPartitionColumnsToChunk(
-                    chunk,
-                    read_from_format_info.hive_partition_columns_to_read_from_file_path,
-                    path);
-            }
 
             if (chunk_size && chunk.hasColumns())
             {

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -59,12 +59,16 @@ createStorageObjectStorage(const StorageFactory::Arguments & args, StorageObject
     if (args.storage_def->partition_by)
         partition_by = args.storage_def->partition_by->clone();
 
+    ContextMutablePtr context_copy = Context::createCopy(args.getContext());
+    Settings settings_copy = args.getLocalContext()->getSettingsCopy();
+    context_copy->setSettings(settings_copy);
+
     return std::make_shared<StorageObjectStorage>(
         configuration,
         // We only want to perform write actions (e.g. create a container in Azure) when the table is being created,
         // and we want to avoid it when we load the table after a server restart.
         configuration->createObjectStorage(context, /* is_readonly */ args.mode != LoadingStrictnessLevel::CREATE),
-        args.getContext(), /// Use global context.
+        context_copy,
         args.table_id,
         args.columns,
         args.constraints,

--- a/src/Storages/StorageFileCluster.cpp
+++ b/src/Storages/StorageFileCluster.cpp
@@ -67,19 +67,13 @@ StorageFileCluster::StorageFileCluster(
 
     auto & storage_columns = storage_metadata.columns;
 
-    if (context->getSettingsRef()[Setting::use_hive_partitioning])
-    {
-        const std::string sample_path = paths.empty() ? "" : paths.front();
-
-        HivePartitioningUtils::extractPartitionColumnsFromPathAndEnrichStorageColumns(
-            storage_columns,
-            hive_partition_columns_to_read_from_file_path,
-            sample_path,
-            columns_.empty(),
-            std::nullopt,
-            context
-        );
-    }
+    /// Not grabbing the file_columns because it is not necessary to do it here.
+    std::tie(hive_partition_columns_to_read_from_file_path, std::ignore) = HivePartitioningUtils::setupHivePartitioningForFileURLLikeStorage(
+        storage_columns,
+        paths.empty() ? "" : paths.front(),
+        columns_.empty(),
+        std::nullopt,
+        context);
 
     storage_metadata.setConstraints(constraints_);
     setVirtuals(VirtualColumnUtils::getVirtualsForFileLikeStorage(storage_metadata.columns));

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -189,19 +189,12 @@ IStorageURLBase::IStorageURLBase(
 
     auto & storage_columns = storage_metadata.columns;
 
-    if (context_->getSettingsRef()[Setting::use_hive_partitioning])
-    {
-        HivePartitioningUtils::extractPartitionColumnsFromPathAndEnrichStorageColumns(
-            storage_columns,
-            hive_partition_columns_to_read_from_file_path,
-            getSampleURI(uri, context_),
-            columns_.empty(),
-            format_settings,
-            context_);
-    }
-
-    /// If the `partition_strategy` argument is ever implemented for URL storage, this must be updated
-    file_columns = storage_columns.getAllPhysical();
+    std::tie(hive_partition_columns_to_read_from_file_path, file_columns) = HivePartitioningUtils::setupHivePartitioningForFileURLLikeStorage(
+        storage_columns,
+        getSampleURI(uri, context_),
+        columns_.empty(),
+        format_settings,
+        context_);
 
     auto virtual_columns_desc = VirtualColumnUtils::getVirtualsForFileLikeStorage(storage_metadata.columns);
     if (!storage_metadata.getColumns().has("_headers"))
@@ -476,16 +469,9 @@ Chunk StorageURLSource::generate()
                 chunk_size = input_format->getApproxBytesReadForChunk();
 
             progress(num_rows, chunk_size ? chunk_size : chunk.bytes());
-            VirtualColumnUtils::addRequestedFileLikeStorageVirtualsToChunk(
-                chunk,
-                requested_virtual_columns,
-                {
-                    .path = curr_uri.getPath(),
-                    .size = current_file_size,
-                },
-                getContext());
 
-            // The order is important, hive partition columns must be added after virtual columns
+            /// The order is important, hive partition columns must be added before virtual columns
+            /// because they are part of the schema
             if (!hive_partition_columns_to_read_from_file_path.empty())
             {
                 const auto path = curr_uri.getPath();
@@ -494,6 +480,15 @@ Chunk StorageURLSource::generate()
                     hive_partition_columns_to_read_from_file_path,
                     path);
             }
+
+            VirtualColumnUtils::addRequestedFileLikeStorageVirtualsToChunk(
+                chunk,
+                requested_virtual_columns,
+                {
+                    .path = curr_uri.getPath(),
+                    .size = current_file_size,
+                },
+                getContext());
 
             chassert(dynamic_cast<ReadWriteBufferFromHTTP *>(read_buf.get()));
             if (need_headers_virtual_column)
@@ -1689,6 +1684,7 @@ void registerStorageURL(StorageFactory & factory)
             ASTs & engine_args = args.engine_args;
             auto configuration = StorageURL::getConfiguration(engine_args, args.getLocalContext());
             auto format_settings = StorageURL::getFormatSettingsFromArgs(args);
+            auto context = args.getLocalContext();
 
             ASTPtr partition_by;
             if (args.storage_def->partition_by)
@@ -1702,7 +1698,7 @@ void registerStorageURL(StorageFactory & factory)
                 args.columns,
                 args.constraints,
                 args.comment,
-                args.getContext(),
+                context,
                 configuration.compression_method,
                 configuration.headers,
                 configuration.http_method,

--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -800,7 +800,7 @@ std::function<void(std::ostream &)> IStorageURLBase::getReadPOSTDataCallback(
     return nullptr;
 }
 
-namespace
+namespace internal
 {
     class ReadBufferIterator : public IReadBufferIterator, WithContext
     {
@@ -1049,7 +1049,7 @@ std::pair<ColumnsDescription, String> IStorageURLBase::getTableStructureAndForma
     else
         urls_to_check = {uri};
 
-    ReadBufferIterator read_buffer_iterator(urls_to_check, format, compression_method, headers, format_settings, context);
+    internal::ReadBufferIterator read_buffer_iterator(urls_to_check, format, compression_method, headers, format_settings, context);
     if (format)
         return {readSchemaFromFormat(*format, format_settings, read_buffer_iterator, context), *format};
     return detectFormatAndReadSchema(format_settings, read_buffer_iterator, context);

--- a/src/Storages/StorageURLCluster.cpp
+++ b/src/Storages/StorageURLCluster.cpp
@@ -84,16 +84,13 @@ StorageURLCluster::StorageURLCluster(
 
     auto & storage_columns = storage_metadata.columns;
 
-    if (context->getSettingsRef()[Setting::use_hive_partitioning])
-    {
-        HivePartitioningUtils::extractPartitionColumnsFromPathAndEnrichStorageColumns(
-            storage_columns,
-            hive_partition_columns_to_read_from_file_path,
-            getSampleURI(uri, context),
-            columns_.empty(),
-            std::nullopt,
-            context);
-    }
+    /// Not grabbing the file_columns because it is not necessary to do it here.
+    std::tie(hive_partition_columns_to_read_from_file_path, std::ignore) = HivePartitioningUtils::setupHivePartitioningForFileURLLikeStorage(
+        storage_columns,
+        getSampleURI(uri, context),
+        columns_.empty(),
+        std::nullopt,
+        context);
 
     auto virtual_columns_desc = VirtualColumnUtils::getVirtualsForFileLikeStorage(storage_metadata.columns);
     if (!storage_metadata.getColumns().has("_headers"))

--- a/src/TableFunctions/TableFunctionFile.cpp
+++ b/src/TableFunctions/TableFunctionFile.cpp
@@ -11,6 +11,7 @@
 #include <TableFunctions/TableFunctionFactory.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Formats/FormatFactory.h>
+#include <Storages/HivePartitioningUtils.h>
 
 
 namespace DB
@@ -114,9 +115,22 @@ ColumnsDescription TableFunctionFile::getActualTableStructure(ContextPtr context
             archive_info
                 = StorageFile::getArchiveInfo(path_to_archive, filename, context->getUserFilesPath(), context, total_bytes_to_read);
 
+        ColumnsDescription columns;
         if (format == "auto")
-            return StorageFile::getTableStructureAndFormatFromFile(paths, compression_method, std::nullopt, context, archive_info).first;
-        return StorageFile::getTableStructureFromFile(format, paths, compression_method, std::nullopt, context, archive_info);
+            columns = StorageFile::getTableStructureAndFormatFromFile(paths, compression_method, std::nullopt, context, archive_info).first;
+        else
+            columns = StorageFile::getTableStructureFromFile(format, paths, compression_method, std::nullopt, context, archive_info);
+
+        auto sample_path = paths.empty() ? String{} : paths.front();
+
+        HivePartitioningUtils::setupHivePartitioningForFileURLLikeStorage(
+            columns,
+            sample_path,
+            /* inferred_schema */ true,
+            /* format_settings */ std::nullopt,
+            context);
+
+        return columns;
     }
 
     return parseColumnsListFromString(structure, context);

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -25,7 +25,7 @@
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/ObjectStorage/StorageObjectStorageCluster.h>
 #include <Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h>
-
+#include <Storages/HivePartitioningUtils.h>
 
 namespace DB
 {
@@ -145,6 +145,14 @@ ColumnsDescription TableFunctionObjectStorage<
             configuration,
             /* format_settings */std::nullopt,
             sample_path,
+            context);
+
+        HivePartitioningUtils::setupHivePartitioningForObjectStorage(
+            columns,
+            configuration,
+            sample_path,
+            /* inferred_schema */ true,
+            /* format_settings */ std::nullopt,
             context);
 
         return columns;

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -18,6 +18,7 @@
 
 #include <IO/WriteHelpers.h>
 #include <IO/WriteBufferFromVector.h>
+#include <Storages/HivePartitioningUtils.h>
 
 
 namespace DB
@@ -113,7 +114,7 @@ StoragePtr TableFunctionURL::getStorage(
             format,
             compression_method,
             StorageID(getDatabaseName(), table_name),
-            getActualTableStructure(global_context, /* is_insert_query */ true),
+            columns,
             ConstraintsDescription{},
             configuration);
     }
@@ -140,19 +141,32 @@ ColumnsDescription TableFunctionURL::getActualTableStructure(ContextPtr context,
     {
         context->checkAccess(getSourceAccessType());
         if (format == "auto")
-            return StorageURL::getTableStructureAndFormatFromData(
-                       filename,
-                       chooseCompressionMethod(Poco::URI(filename).getPath(), compression_method),
-                       configuration.headers,
-                       std::nullopt,
-                       context).first;
+        {
+            columns = StorageURL::getTableStructureAndFormatFromData(
+                filename,
+                chooseCompressionMethod(Poco::URI(filename).getPath(), compression_method),
+                configuration.headers,
+                std::nullopt,
+                context).first;
+        }
+        else
+        {
+            columns = StorageURL::getTableStructureFromData(format,
+                filename,
+                chooseCompressionMethod(Poco::URI(filename).getPath(), compression_method),
+                configuration.headers,
+                std::nullopt,
+                context);
+        }
 
-        return StorageURL::getTableStructureFromData(format,
+        HivePartitioningUtils::setupHivePartitioningForFileURLLikeStorage(
+            columns,
             filename,
-            chooseCompressionMethod(Poco::URI(filename).getPath(), compression_method),
-            configuration.headers,
-            std::nullopt,
+            /* inferred_schema */ true,
+            /* format_settings */ std::nullopt,
             context);
+
+        return columns;
     }
 
     return parseColumnsListFromString(structure, context);

--- a/src/TableFunctions/TableFunctionURL.cpp
+++ b/src/TableFunctions/TableFunctionURL.cpp
@@ -139,6 +139,8 @@ ColumnsDescription TableFunctionURL::getActualTableStructure(ContextPtr context,
 {
     if (structure == "auto")
     {
+	ColumnsDescription columns;
+
         context->checkAccess(getSourceAccessType());
         if (format == "auto")
         {

--- a/src/TableFunctions/TableFunctionURLCluster.cpp
+++ b/src/TableFunctions/TableFunctionURLCluster.cpp
@@ -36,7 +36,7 @@ StoragePtr TableFunctionURLCluster::getStorage(
         format,
         compression_method,
         StorageID(getDatabaseName(), table_name),
-        getActualTableStructure(context, /* is_insert_query */ true),
+        getActualTableStructure(context, true),
         ConstraintsDescription{},
         configuration);
 }

--- a/tests/queries/0_stateless/01545_url_file_format_settings.sql
+++ b/tests/queries/0_stateless/01545_url_file_format_settings.sql
@@ -1,3 +1,7 @@
+-- Tags: no-parallel
+
+set use_hive_partitioning=0; -- required because of "?query=select"
+
 create table file_delim(a int, b int) engine File(CSV, '01545_url_file_format_settings.csv') settings format_csv_delimiter = '|';
 
 truncate table file_delim;

--- a/tests/queries/0_stateless/03203_hive_style_partitioning.reference
+++ b/tests/queries/0_stateless/03203_hive_style_partitioning.reference
@@ -31,7 +31,7 @@ Elizabeth	Delgado
 Elizabeth	Cross
 42	2020-01-01
 [1,2,3]	42.42
-Array(Int64)	Float64
+Array(Int64)	LowCardinality(Float64)
 101
 2071
 2071

--- a/tests/queries/0_stateless/03363_hive_style_partition.reference
+++ b/tests/queries/0_stateless/03363_hive_style_partition.reference
@@ -34,3 +34,4 @@ test/t_03363_function/year=2025/country=/<snowflakeid>.parquet	11
 1
 3
 USA	2022	1
+1

--- a/tests/queries/0_stateless/03363_hive_style_partition.sql
+++ b/tests/queries/0_stateless/03363_hive_style_partition.sql
@@ -1,6 +1,8 @@
 -- Tags: no-parallel, no-fasttest, no-random-settings
 
-DROP TABLE IF EXISTS t_03363_parquet, t_03363_csv;
+SET allow_suspicious_low_cardinality_types=1;
+
+DROP TABLE IF EXISTS t_03363_parquet, t_03363_csv, s3_table_half_schema_with_format;
 
 CREATE TABLE t_03363_parquet (year UInt16, country String, counter UInt8)
 ENGINE = S3(s3_conn, filename = 't_03363_parquet', format = Parquet, partition_strategy='hive')
@@ -71,6 +73,21 @@ select * from s3(s3_conn, filename='t_03363_function_write_down_partition_column
 -- only partition columns
 INSERT INTO FUNCTION s3(s3_conn, filename='t_03363_parquet', format=Parquet, partition_strategy='hive') PARTITION BY (year, country) SELECT 2020 as year, 'Brazil' as country; -- {serverError INCORRECT_DATA};
 
+-- Schema specified, but the hive partition column is missing in the schema (present in the data tho)
+INSERT INTO FUNCTION s3(s3_conn, filename='half_baked', format=Parquet, partition_strategy='hive') PARTITION BY year SELECT 1 AS key, 2020 AS year;
+
+-- Should fail because schema does not match since it is lacking the partition columns and `use_hive_partitioning=1`
+CREATE TABLE s3_table_half_schema_with_format (key UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=1; -- {serverError BAD_ARGUMENTS}
+
+-- Should succeed because hive is off
+CREATE TABLE s3_table_half_schema_with_format (key UInt64) engine=S3(s3_conn, filename='half_baked/**.parquet', format=Parquet) SETTINGS use_hive_partitioning=0;
+
+-- Should succeed and not return hive columns. Distinct because maybe MinIO isn't cleaned up
+SELECT DISTINCT * FROM s3_table_half_schema_with_format;
+
+-- Should fail because the column year does not exist
+SELECT year, * FROM s3_table_half_schema_with_format; -- {serverError UNKNOWN_IDENTIFIER}
+
 -- hive with partition id placeholder
 CREATE TABLE t_03363_s3_sink (year UInt16, country String, counter UInt8)
 ENGINE = S3(s3_conn, filename = 't_03363_parquet/{_partition_id}', format = Parquet, partition_strategy='hive')
@@ -121,4 +138,10 @@ CREATE TABLE t_invalid_expression (year UInt16, country String, counter Float64)
 CREATE TABLE t_03363_iceberg ENGINE=IcebergS3(s3_conn, filename = 'iceberg_data/default/t_iceberg/', format='parquet', url = 'http://minio1:9001/bucket/', partition_strategy='WILDCARD'); -- {serverError BAD_ARGUMENTS}
 CREATE TABLE t_03363_iceberg ENGINE=IcebergS3(s3_conn, filename = 'iceberg_data/default/t_iceberg/', format='parquet', url = 'http://minio1:9001/bucket/', partition_strategy='HIVE'); -- {serverError BAD_ARGUMENTS}
 
-DROP TABLE IF EXISTS t_03363_parquet, t_03363_csv;
+-- Should throw because format is not present and it is mandatory for hive strategy and it should not be a LOGICAL_ERROR
+CREATE TABLE t_03363_hive_requires_format (c0 Int) ENGINE = S3(s3_conn, partition_strategy = 'hive') PARTITION BY (c0); -- {serverError BAD_ARGUMENTS}
+
+-- Should throw because hive strategy does not allow partition columns to be the only columns
+CREATE TABLE t_03363_hive_only_partition_columns (country String, year UInt16) ENGINE = S3(s3_conn, partition_strategy='hive') PARTITION BY (year, country); -- {serverError BAD_ARGUMENTS};
+
+DROP TABLE IF EXISTS t_03363_parquet, t_03363_csv, s3_table_half_schema_with_format;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Backport of https://github.com/ClickHouse/ClickHouse/pull/85538

### Documentation entry for user-facing changes
1. LowCardinality for hive columns
2. Fill hive columns before virtual columns (required for https://github.com/ClickHouse/ClickHouse/pull/81040)
3. LOGICAL_ERROR on empty format for hive https://github.com/ClickHouse/ClickHouse/issues/85528
4. Fix check for hive partition columns being the only columns
5. Assert all hive columns are specified in the schema
6. Partial fix for parallel_replicas_cluster with hive
7. Use ordered container in extractkeyValuePairs for hive utils (required for https://github.com/ClickHouse/ClickHouse/pull/81040)

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
