### PR TITLE
Allow specifying build type in crossouts

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -357,7 +357,7 @@ def main():
 
         # if not info.is_local_run:
         #     CH.stop_log_exports()
-        results.append(FTResultsProcessor(wd=temp_dir).run())
+        results.append(FTResultsProcessor(wd=temp_dir, test_options=test_options).run())
         test_result = results[-1]
 
         # invert result status for bugfix validation

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -56,10 +56,11 @@ class FTResultsProcessor:
         success_finish: bool = False
         test_end: bool = True
 
-    def __init__(self, wd):
+    def __init__(self, wd, test_options):
         self.tests_output_file = f"{wd}/test_result.txt"
         # self.test_results_parsed_file = f"{wd}/test_result.tsv"
         # self.status_file = f"{wd}/check_status.tsv"
+        self.test_options = test_options
 
     def _process_test_output(self):
         total = 0
@@ -137,6 +138,8 @@ class FTResultsProcessor:
                 if DATABASE_SIGN in line:
                     test_end = True
 
+        test_options_string = ", ".join(self.test_options)
+
         test_results_ = []
         for test in test_results:
             try:
@@ -153,14 +156,25 @@ class FTResultsProcessor:
                 if test[1] == "FAIL":
                     broken_message = None
                     if test[0] in known_broken_tests.keys():
-                        if known_broken_tests[test[0]].get("message"):
-                            if (
-                                known_broken_tests[test[0]]["message"]
-                                in test_results_[-1].info
-                            ):
-                                broken_message = f"\nMarked as broken, matched message: '{known_broken_tests[test[0]]['message']}'"
+                        message = known_broken_tests[test[0]].get("message")
+                        check_types = known_broken_tests[test[0]].get("check_types")
+                        if check_types and not any(
+                            check_type in test_options_string
+                            for check_type in check_types
+                        ):
+                            broken_message = None
+                        elif message:
+                            if message in test_results_[-1].info:
+                                broken_message = (
+                                    f"\nMarked as broken, matched message: '{message}'"
+                                )
                         else:
                             broken_message = f"\nMarked as broken, no message specified"
+
+                        if broken_message and check_types:
+                            broken_message += (
+                                f", matched one or more check types {check_types}"
+                            )
 
                     if broken_message:
                         broken += 1

--- a/tests/broken_tests.json
+++ b/tests/broken_tests.json
@@ -1,259 +1,338 @@
 {
     "02700_s3_part_INT_MAX": {
         "reason": "INVESTIGATE - Sometimes out of memory with msan",
-        "message": "DB::Exception: (total) memory limit exceeded"
+        "message": "DB::Exception: (total) memory limit exceeded",
+        "check_types": [
+            "msan"
+        ]
     },
     "00180_no_seek_avoiding_when_reading_from_cache": {
         "reason": "INVESTIGATE - Sometimes out of memory with msan",
-        "message": "DB::Exception: (total) memory limit exceeded"
+        "message": "DB::Exception: (total) memory limit exceeded",
+        "check_types": [
+            "msan"
+        ]
     },
     "01880_remote_ipv6": {
-        "reason": "INVESTIGATE - Fails on debug build"
+        "reason": "INVESTIGATE - Fails on debug build",
+        "check_types": [
+            "debug"
+        ]
     },
     "03315_executable_table_function_threads": {
-        "reason": "INVESTIGATE - Fails on coverage build"
-    },
-    "03403_read_in_order_streams_memory_usage": {
-        "reason": "INVESTIGATE - Unstable?"
-    },
-    "03008_deduplication_mv_generates_several_blocks_replicated": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
+        "reason": "INVESTIGATE - Timeout",
+        "message": "DB::Exception: Timeout exceeded"
     },
     "00988_expansion_aliases_limit": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
-    },
-    "03404_read_in_order_streams_memory_usage": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
+        "reason": "INVESTIGATE - Timeout. Unstable?",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03532_crash_in_aggregation_because_of_lost_exception": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
+        "reason": "INVESTIGATE - Timeout. Unstable?",
+        "check_types": [
+            "tsan",
+            "msan"
+        ]
     },
     "03403_read_in_order_streams_memory_usage": {
-        "reason": "INVESTIGATE - Unstable?"
+        "reason": "INVESTIGATE - Unstable"
     },
     "02483_elapsed_time": {
-        "reason": "INVESTIGATE - Unstable?"
+        "reason": "INVESTIGATE - Fail on msan, unstable on tsan",
+        "message": "result differs with reference",
+        "check_types": [
+            "msan",
+            "tsan"
+        ]
     },
     "03223_analyzer_with_cube_fuzz": {
         "reason": "INVESTIGATE - Sometimes QUERY_WAS_CANCELLED",
         "message": "is killed in pending state."
     },
-    "02967_parallel_replicas_join_algo_and_analyzer_2": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
-    },
-    "03008_deduplication_mv_generates_several_blocks_replicated": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
-    },
     "00111_shard_external_sort_distributed": {
-        "reason": "INVESTIGATE - Timeout in ClickHouse query"
+        "reason": "INVESTIGATE - Timeout in ClickHouse query",
+        "message": "DB::Exception: Timeout exceeded",
+        "check_types": [
+            "tsan",
+            "msan"
+        ]
     },
     "02479_race_condition_between_insert_and_droppin_mv": {
-        "reason": "INVESTIGATE - Timeout in ClickHouse query"
+        "reason": "INVESTIGATE - Timeout in ClickHouse query",
+        "message": "Timeout exceeded while receiving data from server.",
+        "check_types": [
+            "tsan"
+        ]
     },
     "01037_polygon_dicts_correctness_fast": {
-        "reason": "INVESTIGATE - Timeout in ClickHouse query"
+        "reason": "INVESTIGATE - Timeout in ClickHouse query",
+        "message": "DB::Exception: Timeout exceeded",
+        "check_types": [
+            "tsan",
+            "msan"
+        ]
     },
     "02354_vector_search_expansion_search": {
-        "reason": "INVESTIGATE - Timeout on TSAN. Unstable?"
+        "reason": "INVESTIGATE - Timeout on TSAN. Unstable?",
+        "check_types": [
+            "tsan"
+        ]
     },
     "02760_dictionaries_memory": {
         "reason": "INVESTIGATE - Timeout on TSAN.",
-        "message": "Timeout exceeded while receiving data from server."
+        "message": "Timeout exceeded while receiving data from server.",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03441_deltalake_clickhouse_public_datasets": {
         "reason": "INVESTIGATE - S3 sometimes unreachable",
         "message": "Error interacting with object store: Generic S3 error: Error performing GET"
     },
     "03443_shared_storage_snapshots": {
-        "reason": "INVESTIGATE - Unstable?"
+        "reason": "INVESTIGATE - Unstable on tsan",
+        "message": "All iterations has been failed. Unable to test snapshot sharing disabled.",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03321_clickhouse_local_initialization_not_too_slow_even_under_sanitizers": {
-        "reason": "INVESTIGATE - Unstable?"
+        "reason": "INVESTIGATE - Unstable?",
+        "check_types": [
+            "tsan",
+            "msan"
+        ]
     },
     "02915_input_table_function_in_subquery": {
         "reason": "INVESTIGATE - Unstable? Sometimes Access Denied.",
         "message": "DB::Exception: Message: Access Denied., bucket test"
     },
     "00984_parser_stack_overflow": {
-        "reason": "INVESTIGATE - Timeout in ClickHouse query"
-    },
-    "00804_test_alter_compression_codecs": {
-        "reason": "INVESTIGATE - Timeout in ClickHouse query"
+        "reason": "INVESTIGATE - Unstable on tsan",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03357_join_pk_sharding": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
+        "reason": "INVESTIGATE - Timeout. Unstable?",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03002_part_log_rmt_fetch_merge_error": {
-        "reason": "INVESTIGATE - Unstable?"
+        "reason": "INVESTIGATE - Unstable?",
+        "check_types": [
+            "tsan"
+        ]
     },
     "01630_simple_aggregate_all_functions_in_summing_merge_tree": {
-        "reason": "INVESTIGATE - Unstable?"
-    },
-    "02841_parallel_replicas_summary": {
-        "reason": "INVESTIGATE - ClickHouse timeout",
-        "message": "Timeout exceeded (180 s) while flushing system log"
+        "reason": "INVESTIGATE - Unstable?",
+        "check_types": [
+            "tsan"
+        ]
     },
     "00090_thread_pool_deadlock": {
-        "reason": "INVESTIGATE - Unstable?"
+        "reason": "INVESTIGATE - Unstable on msan",
+        "check_types": [
+            "msan"
+        ]
     },
     "03271_ghdata_object_to_json_alter": {
-        "reason": "INVESTIGATE - Unstable?"
+        "reason": "INVESTIGATE - Unstable on tsan",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03396_s3_do_not_retry_dns_errors": {
         "reason": "INVESTIGATE - Unstable?"
     },
-    "01810_max_part_removal_threads_long": {
-        "reason": "INVESTIGATE - ClickHouse timeout",
-        "message": "Timeout exceeded (180 s) while flushing system log"
-    },
-    "03148_async_queries_in_query_log_errors": {
-        "reason": "INVESTIGATE - ClickHouse timeout",
-        "message": "Timeout exceeded (180 s) while flushing system log"
-    },
     "01283_max_threads_simple_query_optimization": {
         "reason": "INVESTIGATE - ClickHouse timeout",
-        "message": "Timeout exceeded (180 s) while flushing system log"
+        "message": "Timeout exceeded (180 s) while flushing system log",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03514_grace_hash_join_logical_error": {
         "reason": "INVESTIGATE - timeout",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "00024_random_counters": {
         "reason": "INVESTIGATE - timeout",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "msan"
+        ]
     },
     "03127_system_unload_primary_key_table": {
         "reason": "INVESTIGATE - timeout",
-        "message": "Timeout! Killing process group"
-    },
-    "02969_auto_format_detection": {
-        "reason": "INVESTIGATE - timeout",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "01926_order_by_desc_limit": {
         "reason": "INVESTIGATE - timeout",
-        "message": "Timeout! Killing process group"
-    },
-    "02751_multiquery_with_argument": {
-        "reason": "INVESTIGATE - timeout",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "02003_memory_limit_in_client": {
         "reason": "INVESTIGATE - timeout",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "00377_shard_group_uniq_array_of_string_array": {
         "reason": "INVESTIGATE - timeout on tsan",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03237_insert_sparse_columns_mem": {
         "reason": "INVESTIGATE - timeout on tsan",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03401_normal_projection_with_part_offset": {
         "reason": "INVESTIGATE - timeout on tsan",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "02437_drop_mv_restart_replicas": {
         "reason": "INVESTIGATE - random fail?",
-        "message": "`slog` doesn't exist.: Cannot create table from metadata file"
+        "message": "`slog` doesn't exist.: Cannot create table from metadata file",
+        "check_types": [
+            "asan"
+        ]
     },
     "03549_system_query_metric_log_with_queries_with_same_query_id": {
         "reason": "INVESTIGATE - random fail?",
-        "message": "The query succeeded but the server error '394' was expected"
+        "message": "The query succeeded but the server error '394' was expected",
+        "check_types": [
+            "tsan"
+        ]
     },
     "02098_hashed_array_dictionary_simple_key": {
         "reason": "INVESTIGATE - timeout, unstable",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "00596_limit_on_expanded_ast": {
         "reason": "INVESTIGATE - timeout, unstable",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "01513_optimize_aggregation_in_order_memory_long": {
         "reason": "INVESTIGATE - timeout, unstable",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "03305_mergine_aggregated_filter_push_down": {
         "reason": "INVESTIGATE - timeout on tsan, unstable",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "02455_one_row_from_csv_memory_usage": {
         "reason": "INVESTIGATE - timeout on tsan, unstable",
-        "message": "Timeout! Killing process group"
-    },
-    "01651_lc_insert_tiny_log_2": {
-        "reason": "INVESTIGATE - timeout",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "00167_read_bytes_from_fs": {
         "reason": "INVESTIGATE - Memory limit exceeded",
-        "message": "DB::Exception: (total) memory limit exceeded:"
+        "message": "DB::Exception: (total) memory limit exceeded:",
+        "check_types": [
+            "msan"
+        ]
     },
     "02477_single_value_data_string_regression": {
         "reason": "INVESTIGATE - Memory limit exceeded",
-        "message": "DB::Exception: (total) memory limit exceeded:"
-    },
-    "02241_filesystem_cache_on_write_operations": {
-        "reason": "INVESTIGATE - Unstable?"
+        "message": "DB::Exception: (total) memory limit exceeded:",
+        "check_types": [
+            "asan"
+        ]
     },
     "02443_detach_attach_partition": {
-        "reason": "INVESTIGATE - Unstable? (msan)"
+        "reason": "INVESTIGATE - Unstable? (msan, tsan)",
+        "check_types": [
+            "tsan",
+            "msan"
+        ]
     },
     "01903_correct_block_size_prediction_with_default": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
-    },
-    "02345_filesystem_local": {
-        "reason": "INVESTIGATE - Occasional statvfs error",
-        "message": "Could not calculate available disk space (statvfs)"
+        "reason": "INVESTIGATE - Timeout. Unstable?",
+        "check_types": [
+            "tsan"
+        ]
     },
     "00157_cache_dictionary": {
-        "reason": "INVESTIGATE - Timeout in ClickHouse query"
+        "reason": "INVESTIGATE - Timeout in ClickHouse query",
+        "check_types": [
+            "coverage"
+        ]
     },
     "00284_external_aggregation": {
-        "reason": "INVESTIGATE - Timeout in ClickHouse query"
+        "reason": "INVESTIGATE - Timeout in ClickHouse query",
+        "check_types": [
+            "tsan"
+        ]
     },
     "01655_plan_optimizations_optimize_read_in_window_order_long": {
         "reason": "INVESTIGATE - Timeout. Unstable?",
-        "message": "Timeout! Killing process group"
-    },
-    "02760_dictionaries_memory": {
-        "reason": "INVESTIGATE - Timeout. Unstable?",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout! Killing process group",
+        "check_types": [
+            "tsan"
+        ]
     },
     "02435_rollback_cancelled_queries": {
         "reason": "INVESTIGATE - Unstable?",
-        "message": "There is no current transaction. (INVALID_TRANSACTION)"
-    },
-    "02963_remote_read_small_buffer_size_bug": {
-        "reason": "INVESTIGATE - Timeout. Unstable?"
+        "message": "There is no current transaction. (INVALID_TRANSACTION)",
+        "check_types": [
+            "tsan"
+        ]
     },
     "02473_optimize_old_parts": {
-        "reason": "INVESTIGATE - Unstable?"
-    },
-    "02916_glogal_in_cancel_queries": {
-        "reason": "INVESTIGATE - Unstable? All attempts to get table structure failed.",
-        "message": "All attempts to get table structure failed."
-    },
-    "03216_arrayWithConstant_limits": {
-        "reason": "INVESTIGATE - Timeout. Unstable?",
-        "message": "Timeout! Killing process group"
-    },
-    "02675_sparse_columns_clear_column": {
-        "reason": "INVESTIGATE - Timeout in ClickHouse query",
-        "message": "Timeout exceeded (180 s) while flushing system log"
+        "reason": "INVESTIGATE - Unstable?",
+        "check_types": [
+            "tsan",
+            "asan"
+        ]
     },
     "02585_query_status_deadlock": {
         "reason": "INVESTIGATE - Timeout in ClickHouse query",
-        "message": "Timeout exceeded (180 s) while flushing system log"
-    },
-    "02099_hashed_array_dictionary_complex_key": {
-        "reason": "INVESTIGATE - Timeout. Unstable?",
-        "message": "Timeout! Killing process group"
+        "message": "Timeout exceeded (180 s) while flushing system log",
+        "check_types": [
+            "tsan"
+        ]
     },
     "test_library_bridge/test.py::test_ssrf": {
         "reason": "INVESTIGATE - Unstable?",
-        "message": "DB::NetException: Connection refused"
+        "message": "DB::NetException: Connection refused",
+        "check_types": [
+            "tsan"
+        ]
     },
     "test_grpc_protocol/test.py::test_ipv6_select_one": {
         "reason": "INVESTIGATE - Internal test timeout",
@@ -264,7 +343,10 @@
     },
     "test_storage_rabbitmq/test.py::test_rabbitmq_mv_combo": {
         "reason": "INVESTIGATE - Timeout on tsan",
-        "message": "Failed: Time limit of 60 seconds reached. The result did not match the expected value."
+        "message": "Failed: Time limit of 60 seconds reached. The result did not match the expected value.",
+        "check_types": [
+            "tsan"
+        ]
     },
     "test_backup_restore_on_cluster/test_different_versions.py::test_different_versions": {
         "reason": "INVESTIGATE - NETLINK_ERROR",
@@ -279,7 +361,10 @@
         "message": "NETLINK_ERROR"
     },
     "test_overcommit_tracker/test.py::test_user_overcommit": {
-        "reason": "INVESTIGATE - Unstable?"
+        "reason": "INVESTIGATE - Unstable on tsan",
+        "check_types": [
+            "tsan"
+        ]
     },
     "test_database_hms/test.py::test_list_tables": {
         "reason": "INVESTIGATE - Strange fail sometimes",

--- a/tests/ci/integration_tests_runner.py
+++ b/tests/ci/integration_tests_runner.py
@@ -474,6 +474,8 @@ class ClickhouseIntegrationTestsRunner:
         log_paths: Union[Dict[str, List[str]], List[str]],
     ) -> None:
 
+        context_name = self.params["context_name"]
+
         def get_log_paths(test_name):
             """Could be a list of logs for all tests or a dict with test name as a key"""
             if isinstance(log_paths, dict):
@@ -496,36 +498,39 @@ class ClickhouseIntegrationTestsRunner:
                         log_file.write(
                             f"Test {failed_test} is not in known broken tests\n"
                         )
+                        continue
+
+                    check_types = known_broken_tests[failed_test].get("check_types")
+                    fail_message = known_broken_tests[failed_test].get("message")
+
+                    if check_types and not any(
+                        check_type in context_name for check_type in check_types
+                    ):
+                        log_file.write(
+                            f"Test {context_name} {failed_test} is only known to be broken for check types {check_types}\n"
+                        )
+                        mark_as_broken = False
+                    elif not fail_message:
+                        log_file.write("No fail message specified, marking as broken\n")
+                        mark_as_broken = True
                     else:
-                        fail_message = known_broken_tests[failed_test].get("message")
+                        log_file.write(f"Looking for fail message: {fail_message}\n")
+                        mark_as_broken = False
+                        for log_path in get_log_paths(failed_test):
+                            if log_path.endswith(".log"):
+                                log_file.write(f"Checking log file: {log_path}\n")
+                                with open(log_path) as test_log:
+                                    if fail_message in test_log.read():
+                                        log_file.write("Found fail message in logs\n")
+                                        mark_as_broken = True
+                                        break
 
-                        if not fail_message:
-                            log_file.write(
-                                "No fail message specified, marking as broken\n"
-                            )
-                            mark_as_broken = True
-                        else:
-                            log_file.write(
-                                f"Looking for fail message: {fail_message}\n"
-                            )
-                            mark_as_broken = False
-                            for log_path in get_log_paths(failed_test):
-                                if log_path.endswith(".log"):
-                                    log_file.write(f"Checking log file: {log_path}\n")
-                                    with open(log_path) as test_log:
-                                        if fail_message in test_log.read():
-                                            log_file.write(
-                                                "Found fail message in logs\n"
-                                            )
-                                            mark_as_broken = True
-                                            break
-
-                        if mark_as_broken:
-                            log_file.write(f"Moving test to BROKEN state\n")
-                            counters[fail_status].remove(failed_test)
-                            counters["BROKEN"].append(failed_test)
-                        else:
-                            log_file.write("Test not marked as broken\n")
+                    if mark_as_broken:
+                        log_file.write(f"Moving test to BROKEN state\n")
+                        counters[fail_status].remove(failed_test)
+                        counters["BROKEN"].append(failed_test)
+                    else:
+                        log_file.write("Test not marked as broken\n")
 
             for status, tests in counters.items():
                 log_file.write(f"Total tests in {status} state: {len(tests)}\n")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Added field `check_types` which takes a list of test options to be matched.

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
