### PR TITLE
Patch 03299_parquet_object_storage_metadata_cache.sql

### DIFF
--- a/tests/queries/0_stateless/03299_parquet_object_storage_metadata_cache.sql
+++ b/tests/queries/0_stateless/03299_parquet_object_storage_metadata_cache.sql
@@ -18,7 +18,7 @@ SETTINGS input_format_parquet_use_metadata_cache=1, optimize_count_from_files=0,
 
 SELECT COUNT(*)
 FROM s3(s3_conn, filename = 'test_03262_*', format = ParquetMetadata)
-SETTINGS input_format_parquet_use_metadata_cache=1, log_comment='test_03262_parquet_metadata_format_metadata_cache';
+SETTINGS input_format_parquet_use_metadata_cache=1, optimize_count_from_files=0, log_comment='test_03262_parquet_metadata_format_metadata_cache';
 
 SYSTEM FLUSH LOGS;
 

--- a/tests/queries/0_stateless/03299_parquet_object_storage_metadata_cache.sql
+++ b/tests/queries/0_stateless/03299_parquet_object_storage_metadata_cache.sql
@@ -10,15 +10,15 @@ INSERT INTO t_parquet_03262 SELECT number FROM numbers(10) SETTINGS s3_truncate_
 
 SELECT COUNT(*)
 FROM s3(s3_conn, filename = 'test_03262_*', format = Parquet)
-SETTINGS input_format_parquet_use_metadata_cache=1, optimize_count_from_files=0;
+SETTINGS input_format_parquet_use_metadata_cache=1, use_query_condition_cache=0,optimize_count_from_files=0;
 
 SELECT COUNT(*)
 FROM s3(s3_conn, filename = 'test_03262_*', format = Parquet)
-SETTINGS input_format_parquet_use_metadata_cache=1, optimize_count_from_files=0, log_comment='test_03262_parquet_metadata_cache';
+SETTINGS input_format_parquet_use_metadata_cache=1, use_query_condition_cache=0, optimize_count_from_files=0, log_comment='test_03262_parquet_metadata_cache';
 
 SELECT COUNT(*)
 FROM s3(s3_conn, filename = 'test_03262_*', format = ParquetMetadata)
-SETTINGS input_format_parquet_use_metadata_cache=1, optimize_count_from_files=0, log_comment='test_03262_parquet_metadata_format_metadata_cache';
+SETTINGS input_format_parquet_use_metadata_cache=1, use_query_condition_cache=0, optimize_count_from_files=0, log_comment='test_03262_parquet_metadata_format_metadata_cache';
 
 SYSTEM FLUSH LOGS;
 
@@ -27,20 +27,20 @@ FROM system.query_log
 where log_comment = 'test_03262_parquet_metadata_cache'
 AND type = 'QueryFinish'
 ORDER BY event_time desc
-LIMIT 1;
+LIMIT 1 SETTINGS use_query_condition_cache=0;
 
 SELECT ProfileEvents['ParquetMetaDataCacheHits']
 FROM system.query_log
 where log_comment = 'test_03262_parquet_metadata_format_metadata_cache'
 AND type = 'QueryFinish'
 ORDER BY event_time desc
-LIMIT 1;
+LIMIT 1 SETTINGS use_query_condition_cache=0;
 
 SYSTEM DROP PARQUET METADATA CACHE;
 
 SELECT COUNT(*)
 FROM s3(s3_conn, filename = 'test_03262_*', format = Parquet)
-SETTINGS input_format_parquet_use_metadata_cache=1, optimize_count_from_files=0, log_comment='test_03262_parquet_metadata_cache_cache_empty';
+SETTINGS input_format_parquet_use_metadata_cache=1, use_query_condition_cache=0, optimize_count_from_files=0, log_comment='test_03262_parquet_metadata_cache_cache_empty';
 
 SYSTEM FLUSH LOGS;
 
@@ -49,13 +49,13 @@ FROM system.query_log
 where log_comment = 'test_03262_parquet_metadata_cache_cache_empty'
 AND type = 'QueryFinish'
 ORDER BY event_time desc
-LIMIT 1;
+LIMIT 1 SETTINGS use_query_condition_cache=0;
 
 SELECT ProfileEvents['ParquetMetaDataCacheMisses']
 FROM system.query_log
 where log_comment = 'test_03262_parquet_metadata_cache_cache_empty'
 AND type = 'QueryFinish'
 ORDER BY event_time desc
-LIMIT 1;
+LIMIT 1 SETTINGS use_query_condition_cache=0;
 
 DROP TABLE t_parquet_03262;

--- a/tests/queries/0_stateless/03299_parquet_object_storage_metadata_cache.sql
+++ b/tests/queries/0_stateless/03299_parquet_object_storage_metadata_cache.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel, no-fasttest
+-- Tags: no-parallel, no-fasttest, no-parallel-replicas
 
 DROP TABLE IF EXISTS t_parquet_03262;
 


### PR DESCRIPTION
Try to fix apparently flaky test

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
