### PR TITLE
Antalya 25.6.5 Try to support ipv6 in 03441_deltalake_clickhouse_public_datasets

### DIFF
--- a/.github/actions/docker_setup/action.yml
+++ b/.github/actions/docker_setup/action.yml
@@ -12,7 +12,7 @@ runs:
       shell: bash
       if: ${{ contains(inputs.test_name, 'Stateless') }}
       env:
-        ipv6_subnet: 2001:3984:3989::/64
+        ipv6_subnet: 2001:db8:1::/64
       run: |
         # make sure docker uses proper IPv6 config
         sudo touch /etc/docker/daemon.json

--- a/tests/broken_tests.json
+++ b/tests/broken_tests.json
@@ -44,10 +44,6 @@
     "02354_vector_search_expansion_search": {
         "reason": "INVESTIGATE - Timeout on TSAN. Unstable?"
     },
-    "03441_deltalake_clickhouse_public_datasets": {
-        "reason": "INVESTIGATE - S3 sometimes unreachable",
-        "message": "Error interacting with object store: Generic S3 error: Error performing GET"
-    },
     "03443_shared_storage_snapshots": {
         "reason": "INVESTIGATE - Unstable?"
     },

--- a/tests/queries/0_stateless/03441_deltalake_clickhouse_public_datasets.sql
+++ b/tests/queries/0_stateless/03441_deltalake_clickhouse_public_datasets.sql
@@ -3,4 +3,4 @@
 -- Tag no-msan: delta-kernel is not built with msan
 
 SELECT count()
-FROM deltaLake('https://s3.dualstack.eu-central-1.amazonaws.com/clickhouse-public-datasets/delta_lake/hits/', NOSIGN, SETTINGS allow_experimental_delta_kernel_rs = 1);
+FROM deltaLake('https://clickhouse-public-datasets.s3.amazonaws.com/delta_lake/hits/', NOSIGN, SETTINGS allow_experimental_delta_kernel_rs = 1);

--- a/tests/queries/0_stateless/03441_deltalake_clickhouse_public_datasets.sql
+++ b/tests/queries/0_stateless/03441_deltalake_clickhouse_public_datasets.sql
@@ -3,4 +3,4 @@
 -- Tag no-msan: delta-kernel is not built with msan
 
 SELECT count()
-FROM deltaLake('https://clickhouse-public-datasets.s3.amazonaws.com/delta_lake/hits/', NOSIGN, SETTINGS allow_experimental_delta_kernel_rs = 1);
+FROM deltaLake('https://s3.dualstack.eu-central-1.amazonaws.com/clickhouse-public-datasets/delta_lake/hits/', NOSIGN, SETTINGS allow_experimental_delta_kernel_rs = 1);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
