### PR TITLE
[25.3] Update regression hash

### DIFF
--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -444,7 +444,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester
-      commit: 5723e20cbc49b347114c7b90c7316a44dafa5328
+      commit: dea64e67b7b3aca2b8c5b57cbd68266636202b29
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -455,7 +455,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester-aarch64
-      commit: 5723e20cbc49b347114c7b90c7316a44dafa5328
+      commit: dea64e67b7b3aca2b8c5b57cbd68266636202b29
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Update regression tests to `dea64e67b7b3aca2b8c5b57cbd68266636202b29` commit hash

#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache
