### PR TITLE
25.8 Add source code upload job

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4327,3 +4327,34 @@ jobs:
         with:
           workflow_config: ${{ needs.config_workflow.outputs.data }}
           final: true
+
+  SourceUpload:
+    needs: [config_workflow, build_amd_release]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
+    env:
+        COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+        VERSION: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+    steps:
+      - name: Check out repository code
+        uses: Altinity/checkout@19599efdf36c4f3f30eb55d5bb388896faea69f6
+        with:
+          clear-repository: true
+          ref: ${{ fromJson(needs.config_workflow.outputs.data).git_ref }}
+          submodules: true
+          fetch-depth: 0
+          filter: tree:0
+      - name: Create source tar
+        run: |
+          mkdir -p "$TEMP_PATH/build_check/package_release"
+          cd .. && tar czf $TEMP_PATH/build_source.src.tar.gz ClickHouse/
+      - name: Upload source tar
+        run: |
+          if [ "$PR_NUMBER" -eq 0 ]; then
+              S3_PATH="REFs/$GITHUB_REF_NAME/$COMMIT_SHA/build_amd_release"
+          else
+              S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
+          fi
+
+          aws s3 cp $TEMP_PATH/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4346,7 +4346,6 @@ jobs:
           fetch-depth: 0
           filter: tree:0
       - name: Install aws cli
-        if: ${{ env.NEEDS_BINARY_PROCESSING == 'true' }}
         uses: unfor19/install-aws-cli-action@v1
         with:
           version: 2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4345,6 +4345,12 @@ jobs:
           submodules: true
           fetch-depth: 0
           filter: tree:0
+      - name: Install aws cli
+        if: ${{ env.NEEDS_BINARY_PROCESSING == 'true' }}
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2
+          arch: arm64
       - name: Create source tar
         run: |
           cd .. && tar czf $RUNNER_TEMP/build_source.src.tar.gz ClickHouse/

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4347,8 +4347,7 @@ jobs:
           filter: tree:0
       - name: Create source tar
         run: |
-          sudo mkdir -p "/tmp/build_amd_release"
-          cd .. && tar czf /tmp/build_amd_release/build_source.src.tar.gz ClickHouse/
+          cd .. && tar czf $RUNNER_TEMP/build_source.src.tar.gz ClickHouse/
       - name: Upload source tar
         run: |
           if [ "$PR_NUMBER" -eq 0 ]; then
@@ -4357,4 +4356,4 @@ jobs:
               S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
           fi
 
-          aws s3 cp /tmp/build_amd_release/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+          aws s3 cp $RUNNER_TEMP/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4347,8 +4347,8 @@ jobs:
           filter: tree:0
       - name: Create source tar
         run: |
-          mkdir -p "$TEMP_PATH/build_check/package_release"
-          cd .. && tar czf $TEMP_PATH/build_source.src.tar.gz ClickHouse/
+          sudo mkdir -p "/tmp/build_amd_release"
+          cd .. && tar czf /tmp/build_amd_release/build_source.src.tar.gz ClickHouse/
       - name: Upload source tar
         run: |
           if [ "$PR_NUMBER" -eq 0 ]; then
@@ -4357,4 +4357,4 @@ jobs:
               S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
           fi
 
-          aws s3 cp $TEMP_PATH/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+          aws s3 cp /tmp/build_amd_release/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4261,3 +4261,34 @@ jobs:
         with:
           workflow_config: ${{ needs.config_workflow.outputs.data }}
           final: true
+
+  SourceUpload:
+    needs: [config_workflow, build_amd_release]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
+    env:
+        COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+        VERSION: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+    steps:
+      - name: Check out repository code
+        uses: Altinity/checkout@19599efdf36c4f3f30eb55d5bb388896faea69f6
+        with:
+          clear-repository: true
+          ref: ${{ fromJson(needs.config_workflow.outputs.data).git_ref }}
+          submodules: true
+          fetch-depth: 0
+          filter: tree:0
+      - name: Create source tar
+        run: |
+          mkdir -p "$TEMP_PATH/build_check/package_release"
+          cd .. && tar czf $TEMP_PATH/build_source.src.tar.gz ClickHouse/
+      - name: Upload source tar
+        run: |
+          if [ "$PR_NUMBER" -eq 0 ]; then
+              S3_PATH="REFs/$GITHUB_REF_NAME/$COMMIT_SHA/build_amd_release"
+          else
+              S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
+          fi
+
+          aws s3 cp $TEMP_PATH/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4280,7 +4280,6 @@ jobs:
           fetch-depth: 0
           filter: tree:0
       - name: Install aws cli
-        if: ${{ env.NEEDS_BINARY_PROCESSING == 'true' }}
         uses: unfor19/install-aws-cli-action@v1
         with:
           version: 2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4279,6 +4279,12 @@ jobs:
           submodules: true
           fetch-depth: 0
           filter: tree:0
+      - name: Install aws cli
+        if: ${{ env.NEEDS_BINARY_PROCESSING == 'true' }}
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2
+          arch: arm64
       - name: Create source tar
         run: |
           cd .. && tar czf $RUNNER_TEMP/build_source.src.tar.gz ClickHouse/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4281,8 +4281,7 @@ jobs:
           filter: tree:0
       - name: Create source tar
         run: |
-          sudo mkdir -p "/tmp/build_amd_release"
-          cd .. && tar czf /tmp/build_amd_release/build_source.src.tar.gz ClickHouse/
+          cd .. && tar czf $RUNNER_TEMP/build_source.src.tar.gz ClickHouse/
       - name: Upload source tar
         run: |
           if [ "$PR_NUMBER" -eq 0 ]; then
@@ -4291,4 +4290,4 @@ jobs:
               S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
           fi
 
-          aws s3 cp /tmp/build_amd_release/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+          aws s3 cp $RUNNER_TEMP/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4281,8 +4281,8 @@ jobs:
           filter: tree:0
       - name: Create source tar
         run: |
-          mkdir -p "$TEMP_PATH/build_check/package_release"
-          cd .. && tar czf $TEMP_PATH/build_source.src.tar.gz ClickHouse/
+          sudo mkdir -p "/tmp/build_amd_release"
+          cd .. && tar czf /tmp/build_amd_release/build_source.src.tar.gz ClickHouse/
       - name: Upload source tar
         run: |
           if [ "$PR_NUMBER" -eq 0 ]; then
@@ -4291,4 +4291,4 @@ jobs:
               S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
           fi
 
-          aws s3 cp $TEMP_PATH/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+          aws s3 cp /tmp/build_amd_release/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -1226,6 +1226,12 @@ jobs:
           submodules: true
           fetch-depth: 0
           filter: tree:0
+      - name: Install aws cli
+        if: ${{ env.NEEDS_BINARY_PROCESSING == 'true' }}
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2
+          arch: arm64
       - name: Create source tar
         run: |
           cd .. && tar czf $RUNNER_TEMP/build_source.src.tar.gz ClickHouse/

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -1228,8 +1228,8 @@ jobs:
           filter: tree:0
       - name: Create source tar
         run: |
-          mkdir -p "$TEMP_PATH/build_check/package_release"
-          cd .. && tar czf $TEMP_PATH/build_source.src.tar.gz ClickHouse/
+          sudo mkdir -p "/tmp/build_amd_release"
+          cd .. && tar czf /tmp/build_amd_release/build_source.src.tar.gz ClickHouse/
       - name: Upload source tar
         run: |
           if [ "$PR_NUMBER" -eq 0 ]; then
@@ -1238,4 +1238,4 @@ jobs:
               S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
           fi
 
-          aws s3 cp $TEMP_PATH/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+          aws s3 cp /tmp/build_amd_release/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -1208,3 +1208,34 @@ jobs:
         with:
           workflow_config: ${{ needs.config_workflow.outputs.data }}
           final: true
+
+  SourceUpload:
+    needs: [config_workflow, build_amd_release]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
+    env:
+        COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+        VERSION: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+    steps:
+      - name: Check out repository code
+        uses: Altinity/checkout@19599efdf36c4f3f30eb55d5bb388896faea69f6
+        with:
+          clear-repository: true
+          ref: ${{ fromJson(needs.config_workflow.outputs.data).git_ref }}
+          submodules: true
+          fetch-depth: 0
+          filter: tree:0
+      - name: Create source tar
+        run: |
+          mkdir -p "$TEMP_PATH/build_check/package_release"
+          cd .. && tar czf $TEMP_PATH/build_source.src.tar.gz ClickHouse/
+      - name: Upload source tar
+        run: |
+          if [ "$PR_NUMBER" -eq 0 ]; then
+              S3_PATH="REFs/$GITHUB_REF_NAME/$COMMIT_SHA/build_amd_release"
+          else
+              S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
+          fi
+
+          aws s3 cp $TEMP_PATH/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -1228,8 +1228,7 @@ jobs:
           filter: tree:0
       - name: Create source tar
         run: |
-          sudo mkdir -p "/tmp/build_amd_release"
-          cd .. && tar czf /tmp/build_amd_release/build_source.src.tar.gz ClickHouse/
+          cd .. && tar czf $RUNNER_TEMP/build_source.src.tar.gz ClickHouse/
       - name: Upload source tar
         run: |
           if [ "$PR_NUMBER" -eq 0 ]; then
@@ -1238,4 +1237,4 @@ jobs:
               S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
           fi
 
-          aws s3 cp /tmp/build_amd_release/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+          aws s3 cp $RUNNER_TEMP/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -1227,7 +1227,6 @@ jobs:
           fetch-depth: 0
           filter: tree:0
       - name: Install aws cli
-        if: ${{ env.NEEDS_BINARY_PROCESSING == 'true' }}
         uses: unfor19/install-aws-cli-action@v1
         with:
           version: 2

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -142,6 +142,12 @@ class AltinityWorkflowTemplates:
           submodules: true
           fetch-depth: 0
           filter: tree:0
+      - name: Install aws cli
+        if: ${{ env.NEEDS_BINARY_PROCESSING == 'true' }}
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2
+          arch: arm64
       - name: Create source tar
         run: |
           cd .. && tar czf $RUNNER_TEMP/build_source.src.tar.gz ClickHouse/

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -124,6 +124,38 @@ class AltinityWorkflowTemplates:
           workflow_config: ${{ needs.config_workflow.outputs.data }}
           final: true
 """,
+        "SourceUpload": r"""
+  SourceUpload:
+    needs: [config_workflow, build_amd_release]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
+    env:
+        COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+        VERSION: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+    steps:
+      - name: Check out repository code
+        uses: Altinity/checkout@19599efdf36c4f3f30eb55d5bb388896faea69f6
+        with:
+          clear-repository: true
+          ref: ${{ fromJson(needs.config_workflow.outputs.data).git_ref }}
+          submodules: true
+          fetch-depth: 0
+          filter: tree:0
+      - name: Create source tar
+        run: |
+          mkdir -p "$TEMP_PATH/build_check/package_release"
+          cd .. && tar czf $TEMP_PATH/build_source.src.tar.gz ClickHouse/
+      - name: Upload source tar
+        run: |
+          if [ "$PR_NUMBER" -eq 0 ]; then
+              S3_PATH="REFs/$GITHUB_REF_NAME/$COMMIT_SHA/build_amd_release"
+          else
+              S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
+          fi
+
+          aws s3 cp $TEMP_PATH/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+""",
     }
     ADDITIONAL_JOBS_BANNER = r"""
 ##########################################################################################

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -143,7 +143,6 @@ class AltinityWorkflowTemplates:
           fetch-depth: 0
           filter: tree:0
       - name: Install aws cli
-        if: ${{ env.NEEDS_BINARY_PROCESSING == 'true' }}
         uses: unfor19/install-aws-cli-action@v1
         with:
           version: 2

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -144,8 +144,8 @@ class AltinityWorkflowTemplates:
           filter: tree:0
       - name: Create source tar
         run: |
-          mkdir -p "$TEMP_PATH/build_check/package_release"
-          cd .. && tar czf $TEMP_PATH/build_source.src.tar.gz ClickHouse/
+          sudo mkdir -p "/tmp/build_amd_release"
+          cd .. && tar czf /tmp/build_amd_release/build_source.src.tar.gz ClickHouse/
       - name: Upload source tar
         run: |
           if [ "$PR_NUMBER" -eq 0 ]; then
@@ -154,7 +154,7 @@ class AltinityWorkflowTemplates:
               S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
           fi
 
-          aws s3 cp $TEMP_PATH/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+          aws s3 cp /tmp/build_amd_release/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
 """,
     }
     ADDITIONAL_JOBS_BANNER = r"""

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -144,8 +144,7 @@ class AltinityWorkflowTemplates:
           filter: tree:0
       - name: Create source tar
         run: |
-          sudo mkdir -p "/tmp/build_amd_release"
-          cd .. && tar czf /tmp/build_amd_release/build_source.src.tar.gz ClickHouse/
+          cd .. && tar czf $RUNNER_TEMP/build_source.src.tar.gz ClickHouse/
       - name: Upload source tar
         run: |
           if [ "$PR_NUMBER" -eq 0 ]; then
@@ -154,7 +153,7 @@ class AltinityWorkflowTemplates:
               S3_PATH="PRs/$PR_NUMBER/$COMMIT_SHA/build_amd_release"
           fi
 
-          aws s3 cp /tmp/build_amd_release/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
+          aws s3 cp $RUNNER_TEMP/build_source.src.tar.gz s3://altinity-build-artifacts/$S3_PATH/clickhouse-$VERSION.src.tar.gz
 """,
     }
     ADDITIONAL_JOBS_BANNER = r"""

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -519,6 +519,9 @@ class PullRequestPushYamlGen:
             res += AltinityWorkflowTemplates.ALTINITY_JOBS["CIReport"].replace(
                 "{ALL_JOBS}", ALL_JOBS
             )
+        if "SourceUpload" in self.workflow_config.additional_jobs:
+            res += AltinityWorkflowTemplates.ALTINITY_JOBS["SourceUpload"]
+            ALL_JOBS += "\n      - SourceUpload"
 
         return res
 

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -40,7 +40,7 @@ workflow = Workflow.Config(
         # *JobConfigs.sqlancer_master_jobs,
         JobConfigs.sqltest_master_job,
     ],
-    additional_jobs=["GrypeScan", "Regression", "SignRelease", "CIReport"],
+    additional_jobs=["GrypeScan", "Regression", "SignRelease", "CIReport", "SourceUpload"],
     artifacts=[
         *ArtifactConfigs.unittests_binaries,
         *ArtifactConfigs.clickhouse_binaries,

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -106,7 +106,7 @@ workflow = Workflow.Config(
         #    for job in JobConfigs.performance_comparison_with_master_head_jobs
         # ], # NOTE (strtgbb): failed previously due to GH secrets not being handled properly, try again later
     ],
-    additional_jobs=["GrypeScan", "Regression", "CIReport"],
+    additional_jobs=["GrypeScan", "Regression", "CIReport", "SourceUpload"],
     artifacts=[
         *ArtifactConfigs.unittests_binaries,
         *ArtifactConfigs.clickhouse_binaries,

--- a/ci/workflows/release_builds.py
+++ b/ci/workflows/release_builds.py
@@ -39,7 +39,7 @@ workflow = Workflow.Config(
             if any(t in job.name for t in ("release", "binary"))
         ],
     ],
-    additional_jobs=["GrypeScan", "SignRelease", "CIReport"],
+    additional_jobs=["GrypeScan", "SignRelease", "CIReport", "SourceUpload"],
     artifacts=[
         *ArtifactConfigs.clickhouse_binaries,
         *ArtifactConfigs.clickhouse_stripped_binaries,


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Add a job to upload the source code of the build

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)