### PR TITLE
Allow to read Iceberg data from any location

### DIFF
--- a/src/Databases/DataLake/GlueCatalog.cpp
+++ b/src/Databases/DataLake/GlueCatalog.cpp
@@ -594,7 +594,7 @@ String GlueCatalog::resolveMetadataPathFromTableLocation(const String & table_lo
                 return "";
 
             // List all files in metadata directory
-            DB::RelativePathsWithMetadata files;
+            DB::PathsWithMetadata files;
             object_storage->listObjects(metadata_dir_path, files, 0);
 
             // Filter for .metadata.json files and find the most recent one

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -73,7 +73,7 @@ public:
     }
 
 private:
-    bool getBatchAndCheckNext(RelativePathsWithMetadata & batch) override
+    bool getBatchAndCheckNext(PathsWithMetadata & batch) override
     {
         ProfileEvents::increment(ProfileEvents::AzureListObjects);
         if (client->IsClientForDisk())
@@ -87,7 +87,7 @@ private:
 
         for (const auto & blob : blobs_list)
         {
-            batch.emplace_back(std::make_shared<RelativePathWithMetadata>(
+            batch.emplace_back(std::make_shared<PathWithMetadata>(
                 blob.Name,
                 ObjectMetadata{
                     static_cast<uint64_t>(blob.BlobSize),
@@ -169,7 +169,7 @@ ObjectStorageIteratorPtr AzureObjectStorage::iterate(const std::string & path_pr
     return std::make_shared<AzureIteratorAsync>(path_prefix, client_ptr, max_keys ? max_keys : settings_ptr->list_object_keys_size);
 }
 
-void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const
+void AzureObjectStorage::listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const
 {
     auto client_ptr = client.get();
 
@@ -195,7 +195,7 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
 
         for (const auto & blob : blobs_list)
         {
-            children.emplace_back(std::make_shared<RelativePathWithMetadata>(
+            children.emplace_back(std::make_shared<PathWithMetadata>(
                 blob.Name,
                 ObjectMetadata{
                     static_cast<uint64_t>(blob.BlobSize),

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -37,7 +37,7 @@ public:
 
     bool supportsListObjectsCache() override { return true; }
 
-    void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
+    void listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const override;
 
     /// Sanitizer build may crash with max_keys=1; this looks like a false positive.
     ObjectStorageIteratorPtr iterate(const std::string & path_prefix, size_t max_keys) const override;

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -193,7 +193,7 @@ void CachedObjectStorage::copyObject( // NOLINT
     object_storage->copyObject(object_from, object_to, read_settings, write_settings, object_to_attributes);
 }
 
-void CachedObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const
+void CachedObjectStorage::listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const
 {
     object_storage->listObjects(path, children, max_keys);
 }

--- a/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
+++ b/src/Disks/ObjectStorages/Cached/CachedObjectStorage.h
@@ -64,7 +64,7 @@ public:
         IObjectStorage & object_storage_to,
         std::optional<ObjectAttributes> object_to_attributes = {}) override;
 
-    void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
+    void listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const override;
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
 

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.cpp
@@ -167,7 +167,7 @@ ObjectMetadata HDFSObjectStorage::getObjectMetadata(const std::string & path) co
     return metadata;
 }
 
-void HDFSObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const
+void HDFSObjectStorage::listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const
 {
     initializeHDFSFS();
     LOG_TEST(log, "Trying to list files for {}", path);
@@ -203,7 +203,7 @@ void HDFSObjectStorage::listObjects(const std::string & path, RelativePathsWithM
         }
         else
         {
-            children.emplace_back(std::make_shared<RelativePathWithMetadata>(
+            children.emplace_back(std::make_shared<PathWithMetadata>(
                 String(file_path),
                 ObjectMetadata{
                     static_cast<uint64_t>(ls.file_info[i].mSize),

--- a/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
+++ b/src/Disks/ObjectStorages/HDFS/HDFSObjectStorage.h
@@ -92,7 +92,7 @@ public:
         const WriteSettings & write_settings,
         std::optional<ObjectAttributes> object_to_attributes = {}) override;
 
-    void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
+    void listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const override;
 
     String getObjectsNamespace() const override { return ""; }
 

--- a/src/Disks/ObjectStorages/IObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/IObjectStorage.cpp
@@ -148,10 +148,7 @@ void PathWithMetadata::loadMetadata(ObjectStoragePtr object_storage, bool ignore
     {
         const auto & path = isArchive() ? getPathToArchive() : getPath();
 
-        auto storage_to_use = object_storage;
-
-        if (auto storage_for_file = getObjectStorage(); storage_for_file.has_value())
-            storage_to_use = storage_for_file.value();
+        auto storage_to_use = object_storage_to_use.value_or(object_storage);
 
         if (ignore_non_existent_file)
             metadata = storage_to_use->tryGetObjectMetadata(path);

--- a/src/Disks/ObjectStorages/IObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/IObjectStorage.cpp
@@ -148,7 +148,7 @@ void PathWithMetadata::loadMetadata(ObjectStoragePtr object_storage, bool ignore
     {
         const auto & path = isArchive() ? getPathToArchive() : getPath();
 
-        auto storage_to_use = object_storage_to_use.value_or(object_storage);
+        auto storage_to_use = object_storage_to_use ? object_storage_to_use : object_storage;
 
         if (ignore_non_existent_file)
             metadata = storage_to_use->tryGetObjectMetadata(path);

--- a/src/Disks/ObjectStorages/IObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/IObjectStorage.cpp
@@ -30,12 +30,12 @@ const MetadataStorageMetrics & IObjectStorage::getMetadataStorageMetrics() const
 
 bool IObjectStorage::existsOrHasAnyChild(const std::string & path) const
 {
-    RelativePathsWithMetadata files;
+    PathsWithMetadata files;
     listObjects(path, files, 1);
     return !files.empty();
 }
 
-void IObjectStorage::listObjects(const std::string &, RelativePathsWithMetadata &, size_t) const
+void IObjectStorage::listObjects(const std::string &, PathsWithMetadata &, size_t) const
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "listObjects() is not supported");
 }
@@ -43,7 +43,7 @@ void IObjectStorage::listObjects(const std::string &, RelativePathsWithMetadata 
 
 ObjectStorageIteratorPtr IObjectStorage::iterate(const std::string & path_prefix, size_t max_keys) const
 {
-    RelativePathsWithMetadata files;
+    PathsWithMetadata files;
     listObjects(path_prefix, files, max_keys);
 
     return std::make_shared<ObjectStorageIteratorFromList>(std::move(files));
@@ -102,21 +102,14 @@ WriteSettings IObjectStorage::patchSettings(const WriteSettings & write_settings
     return write_settings;
 }
 
-RelativePathWithMetadata::RelativePathWithMetadata(const DataFileInfo & info, std::optional<ObjectMetadata> metadata_)
-    : metadata(std::move(metadata_))
-{
-    relative_path = info.file_path;
-    file_meta_info = info.file_meta_info;
-}
-
-std::string RelativePathWithMetadata::getPathOrPathToArchiveIfArchive() const
+std::string PathWithMetadata::getPathOrPathToArchiveIfArchive() const
 {
     if (isArchive())
         return getPathToArchive();
     return getPath();
 }
 
-RelativePathWithMetadata::CommandInTaskResponse::CommandInTaskResponse(const std::string & task)
+PathWithMetadata::CommandInTaskResponse::CommandInTaskResponse(const std::string & task)
 {
     Poco::JSON::Parser parser;
     try
@@ -136,7 +129,7 @@ RelativePathWithMetadata::CommandInTaskResponse::CommandInTaskResponse(const std
     }
 }
 
-std::string RelativePathWithMetadata::CommandInTaskResponse::to_string() const
+std::string PathWithMetadata::CommandInTaskResponse::to_string() const
 {
     Poco::JSON::Object json;
     if (retry_after_us.has_value())
@@ -149,16 +142,21 @@ std::string RelativePathWithMetadata::CommandInTaskResponse::to_string() const
 }
 
 
-void RelativePathWithMetadata::loadMetadata(ObjectStoragePtr object_storage, bool ignore_non_existent_file)
+void PathWithMetadata::loadMetadata(ObjectStoragePtr object_storage, bool ignore_non_existent_file)
 {
     if (!metadata)
     {
         const auto & path = isArchive() ? getPathToArchive() : getPath();
 
+        auto storage_to_use = object_storage;
+
+        if (auto storage_for_file = getObjectStorage(); storage_for_file.has_value())
+            storage_to_use = storage_for_file.value();
+
         if (ignore_non_existent_file)
-            metadata = object_storage->tryGetObjectMetadata(path);
+            metadata = storage_to_use->tryGetObjectMetadata(path);
         else
-            metadata = object_storage->getObjectMetadata(path);
+            metadata = storage_to_use->getObjectMetadata(path);
     }
 }
 

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -108,13 +108,12 @@ struct ObjectMetadata
 };
 
 
-struct DataFileInfo;
 class DataFileMetaInfo;
 using DataFileMetaInfoPtr = std::shared_ptr<DataFileMetaInfo>;
 
 struct DataLakeObjectMetadata;
 
-struct RelativePathWithMetadata
+struct PathWithMetadata
 {
     class CommandInTaskResponse
     {
@@ -143,28 +142,35 @@ struct RelativePathWithMetadata
     std::optional<DataFileMetaInfoPtr> file_meta_info;
     /// Retry request after short pause
     CommandInTaskResponse command;
+    std::optional<String> absolute_path;
+    std::optional<ObjectStoragePtr> object_storage_to_use = std::nullopt;
 
-    RelativePathWithMetadata() = default;
+    PathWithMetadata() = default;
 
-    explicit RelativePathWithMetadata(String command_or_path, std::optional<ObjectMetadata> metadata_ = std::nullopt)
+    explicit PathWithMetadata(
+        const String & command_or_path,
+        std::optional<ObjectMetadata> metadata_ = std::nullopt,
+        std::optional<String> absolute_path_ = std::nullopt,
+        std::optional<ObjectStoragePtr> object_storage_to_use_ = std::nullopt)
         : relative_path(std::move(command_or_path))
         , metadata(std::move(metadata_))
         , command(relative_path)
+        , absolute_path(absolute_path_)
+        , object_storage_to_use(object_storage_to_use_)
     {
         if (command.is_parsed())
             relative_path = "";
     }
 
-    explicit RelativePathWithMetadata(const DataFileInfo & info, std::optional<ObjectMetadata> metadata_ = std::nullopt);
+    PathWithMetadata(const PathWithMetadata & other) = default;
 
-    RelativePathWithMetadata(const RelativePathWithMetadata & other) = default;
-
-    virtual ~RelativePathWithMetadata() = default;
+    virtual ~PathWithMetadata() = default;
 
     virtual std::string getFileName() const { return std::filesystem::path(relative_path).filename(); }
     virtual std::string getFileNameWithoutExtension() const { return std::filesystem::path(relative_path).stem(); }
 
     virtual std::string getPath() const { return relative_path; }
+    virtual std::optional<std::string> getAbsolutePath() const { return absolute_path; }
     virtual bool isArchive() const { return false; }
     virtual std::string getPathToArchive() const { throw Exception(ErrorCodes::LOGICAL_ERROR, "Not an archive"); }
     virtual size_t fileSizeInArchive() const { throw Exception(ErrorCodes::LOGICAL_ERROR, "Not an archive"); }
@@ -176,6 +182,8 @@ struct RelativePathWithMetadata
     const CommandInTaskResponse & getCommand() const { return command; }
 
     void loadMetadata(ObjectStoragePtr object_storage, bool ignore_non_existent_file = true);
+
+    std::optional<ObjectStoragePtr> getObjectStorage() const { return object_storage_to_use; }
 };
 
 struct ObjectKeyWithMetadata
@@ -191,8 +199,8 @@ struct ObjectKeyWithMetadata
     {}
 };
 
-using RelativePathWithMetadataPtr = std::shared_ptr<RelativePathWithMetadata>;
-using RelativePathsWithMetadata = std::vector<RelativePathWithMetadataPtr>;
+using PathWithMetadataPtr = std::shared_ptr<PathWithMetadata>;
+using PathsWithMetadata = std::vector<PathWithMetadataPtr>;
 using ObjectKeysWithMetadata = std::vector<ObjectKeyWithMetadata>;
 
 class IObjectStorageIterator;
@@ -233,7 +241,7 @@ public:
     virtual bool existsOrHasAnyChild(const std::string & path) const;
 
     /// List objects recursively by certain prefix.
-    virtual void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const;
+    virtual void listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const;
 
     /// List objects recursively by certain prefix. Use it instead of listObjects, if you want to list objects lazily.
     virtual ObjectStorageIteratorPtr iterate(const std::string & path_prefix, size_t max_keys) const;

--- a/src/Disks/ObjectStorages/IObjectStorage.h
+++ b/src/Disks/ObjectStorages/IObjectStorage.h
@@ -143,7 +143,7 @@ struct PathWithMetadata
     /// Retry request after short pause
     CommandInTaskResponse command;
     std::optional<String> absolute_path;
-    std::optional<ObjectStoragePtr> object_storage_to_use = std::nullopt;
+    ObjectStoragePtr object_storage_to_use = nullptr;
 
     PathWithMetadata() = default;
 
@@ -151,11 +151,11 @@ struct PathWithMetadata
         const String & command_or_path,
         std::optional<ObjectMetadata> metadata_ = std::nullopt,
         std::optional<String> absolute_path_ = std::nullopt,
-        std::optional<ObjectStoragePtr> object_storage_to_use_ = std::nullopt)
+        ObjectStoragePtr object_storage_to_use_ = nullptr)
         : relative_path(std::move(command_or_path))
         , metadata(std::move(metadata_))
         , command(relative_path)
-        , absolute_path(absolute_path_)
+        , absolute_path((absolute_path_.has_value() && !absolute_path_.value().empty()) ? absolute_path_ : std::nullopt)
         , object_storage_to_use(object_storage_to_use_)
     {
         if (command.is_parsed())
@@ -183,7 +183,7 @@ struct PathWithMetadata
 
     void loadMetadata(ObjectStoragePtr object_storage, bool ignore_non_existent_file = true);
 
-    std::optional<ObjectStoragePtr> getObjectStorage() const { return object_storage_to_use; }
+    ObjectStoragePtr getObjectStorage() const { return object_storage_to_use; }
 };
 
 struct ObjectKeyWithMetadata

--- a/src/Disks/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -151,7 +151,7 @@ ObjectMetadata LocalObjectStorage::getObjectMetadata(const std::string & path) c
     return object_metadata;
 }
 
-void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t/* max_keys */) const
+void LocalObjectStorage::listObjects(const std::string & path, PathsWithMetadata & children, size_t/* max_keys */) const
 {
     if (!fs::exists(path) || !fs::is_directory(path))
         return;
@@ -164,7 +164,7 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
             continue;
         }
 
-        children.emplace_back(std::make_shared<RelativePathWithMetadata>(entry.path(), getObjectMetadata(entry.path())));
+        children.emplace_back(std::make_shared<PathWithMetadata>(entry.path(), getObjectMetadata(entry.path())));
     }
 }
 

--- a/src/Disks/ObjectStorages/Local/LocalObjectStorage.h
+++ b/src/Disks/ObjectStorages/Local/LocalObjectStorage.h
@@ -62,7 +62,7 @@ public:
 
     ObjectMetadata getObjectMetadata(const std::string & path) const override;
 
-    void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
+    void listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const override;
 
     bool existsOrHasAnyChild(const std::string & path) const override;
 

--- a/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromPlainObjectStorage.cpp
@@ -124,7 +124,7 @@ std::vector<std::string> MetadataStorageFromPlainObjectStorage::listDirectory(co
 {
     auto key_prefix = object_storage->generateObjectKeyForPath(path, std::nullopt /* key_prefix */).serialize();
 
-    RelativePathsWithMetadata files;
+    PathsWithMetadata files;
     std::string absolute_key = key_prefix;
     if (!absolute_key.ends_with('/'))
         absolute_key += '/';

--- a/src/Disks/ObjectStorages/ObjectStorageIterator.cpp
+++ b/src/Disks/ObjectStorages/ObjectStorageIterator.cpp
@@ -9,7 +9,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-RelativePathWithMetadataPtr ObjectStorageIteratorFromList::current()
+PathWithMetadataPtr ObjectStorageIteratorFromList::current()
 {
     if (!isValid())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to access invalid iterator");

--- a/src/Disks/ObjectStorages/ObjectStorageIterator.h
+++ b/src/Disks/ObjectStorages/ObjectStorageIterator.h
@@ -16,10 +16,10 @@ public:
     virtual bool isValid() = 0;
 
     /// Return the current element.
-    virtual RelativePathWithMetadataPtr current() = 0;
+    virtual PathWithMetadataPtr current() = 0;
 
     /// This will initiate prefetching the next batch in background, so it can be obtained faster when needed.
-    virtual std::optional<RelativePathsWithMetadata> getCurrentBatchAndScheduleNext() = 0;
+    virtual std::optional<PathsWithMetadata> getCurrentBatchAndScheduleNext() = 0;
 
     /// Returns the number of elements in the batches that were fetched so far.
     virtual size_t getAccumulatedSize() const = 0;
@@ -36,7 +36,7 @@ private:
     /// Return the current batch of elements.
     /// It is unspecified how batches are formed.
     /// But this method can be used for more efficient processing.
-    virtual RelativePathsWithMetadata currentBatch() = 0;
+    virtual PathsWithMetadata currentBatch() = 0;
 };
 
 using ObjectStorageIteratorPtr = std::shared_ptr<IObjectStorageIterator>;
@@ -45,7 +45,7 @@ class ObjectStorageIteratorFromList : public IObjectStorageIterator
 {
 public:
     /// Everything is represented by just a single batch.
-    explicit ObjectStorageIteratorFromList(RelativePathsWithMetadata && batch_)
+    explicit ObjectStorageIteratorFromList(PathsWithMetadata && batch_)
         : batch(std::move(batch_))
         , batch_iterator(batch.begin()) {}
 
@@ -59,11 +59,11 @@ public:
 
     bool isValid() override { return batch_iterator != batch.end(); }
 
-    RelativePathWithMetadataPtr current() override;
+    PathWithMetadataPtr current() override;
 
-    RelativePathsWithMetadata currentBatch() override { return batch; }
+    PathsWithMetadata currentBatch() override { return batch; }
 
-    std::optional<RelativePathsWithMetadata> getCurrentBatchAndScheduleNext() override
+    std::optional<PathsWithMetadata> getCurrentBatchAndScheduleNext() override
     {
         if (batch.empty())
             return {};
@@ -76,8 +76,8 @@ public:
     size_t getAccumulatedSize() const override { return batch.size(); }
 
 private:
-    RelativePathsWithMetadata batch;
-    RelativePathsWithMetadata::iterator batch_iterator;
+    PathsWithMetadata batch;
+    PathsWithMetadata::iterator batch_iterator;
 };
 
 }

--- a/src/Disks/ObjectStorages/ObjectStorageIteratorAsync.cpp
+++ b/src/Disks/ObjectStorages/ObjectStorageIteratorAsync.cpp
@@ -112,7 +112,7 @@ bool IObjectStorageIteratorAsync::isValid()
     return !is_finished;
 }
 
-RelativePathWithMetadataPtr IObjectStorageIteratorAsync::current()
+PathWithMetadataPtr IObjectStorageIteratorAsync::current()
 {
     std::lock_guard lock(mutex);
 
@@ -123,7 +123,7 @@ RelativePathWithMetadataPtr IObjectStorageIteratorAsync::current()
 }
 
 
-RelativePathsWithMetadata IObjectStorageIteratorAsync::currentBatch()
+PathsWithMetadata IObjectStorageIteratorAsync::currentBatch()
 {
     std::lock_guard lock(mutex);
 
@@ -133,7 +133,7 @@ RelativePathsWithMetadata IObjectStorageIteratorAsync::currentBatch()
     return current_batch;
 }
 
-std::optional<RelativePathsWithMetadata> IObjectStorageIteratorAsync::getCurrentBatchAndScheduleNext()
+std::optional<PathsWithMetadata> IObjectStorageIteratorAsync::getCurrentBatchAndScheduleNext()
 {
     std::lock_guard lock(mutex);
 

--- a/src/Disks/ObjectStorages/ObjectStorageIteratorAsync.h
+++ b/src/Disks/ObjectStorages/ObjectStorageIteratorAsync.h
@@ -23,24 +23,24 @@ public:
 
     bool isValid() override;
 
-    RelativePathWithMetadataPtr current() override;
-    RelativePathsWithMetadata currentBatch() override;
+    PathWithMetadataPtr current() override;
+    PathsWithMetadata currentBatch() override;
 
     void next() override;
     void nextBatch() override;
 
     size_t getAccumulatedSize() const override;
-    std::optional<RelativePathsWithMetadata> getCurrentBatchAndScheduleNext() override;
+    std::optional<PathsWithMetadata> getCurrentBatchAndScheduleNext() override;
 
     void deactivate();
 
 protected:
     /// This method fetches the next batch, and returns true if there are more batches after it.
-    virtual bool getBatchAndCheckNext(RelativePathsWithMetadata & batch) = 0;
+    virtual bool getBatchAndCheckNext(PathsWithMetadata & batch) = 0;
 
     struct BatchAndHasNext
     {
-        RelativePathsWithMetadata batch;
+        PathsWithMetadata batch;
         bool has_next;
     };
 
@@ -55,8 +55,8 @@ protected:
     ThreadPool list_objects_pool;
     ThreadPoolCallbackRunnerUnsafe<BatchAndHasNext> list_objects_scheduler;
     std::future<BatchAndHasNext> outcome_future;
-    RelativePathsWithMetadata current_batch;
-    RelativePathsWithMetadata::iterator current_batch_iterator;
+    PathsWithMetadata current_batch;
+    PathsWithMetadata::iterator current_batch_iterator;
     std::atomic<size_t> accumulated_size = 0;
 };
 

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -134,7 +134,7 @@ public:
     }
 
 private:
-    bool getBatchAndCheckNext(RelativePathsWithMetadata & batch) override
+    bool getBatchAndCheckNext(PathsWithMetadata & batch) override
     {
         ProfileEvents::increment(ProfileEvents::S3ListObjects);
         ProfileEvents::increment(ProfileEvents::DiskS3ListObjects);
@@ -155,7 +155,7 @@ private:
             for (const auto & object : objects)
             {
                 ObjectMetadata metadata{static_cast<uint64_t>(object.GetSize()), Poco::Timestamp::fromEpochTime(object.GetLastModified().Seconds()), object.GetETag(), {}};
-                batch.emplace_back(std::make_shared<RelativePathWithMetadata>(object.GetKey(), std::move(metadata)));
+                batch.emplace_back(std::make_shared<PathWithMetadata>(object.GetKey(), std::move(metadata)));
             }
 
             /// It returns false when all objects were returned
@@ -253,7 +253,7 @@ ObjectStorageIteratorPtr S3ObjectStorage::iterate(const std::string & path_prefi
     return std::make_shared<S3IteratorAsync>(uri.bucket, path_prefix, client.get(), max_keys);
 }
 
-void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const
+void S3ObjectStorage::listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const
 {
     auto settings_ptr = s3_settings.get();
 
@@ -285,7 +285,7 @@ void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMet
             break;
 
         for (const auto & object : objects)
-            children.emplace_back(std::make_shared<RelativePathWithMetadata>(
+            children.emplace_back(std::make_shared<PathWithMetadata>(
                 object.GetKey(),
                 ObjectMetadata{
                     static_cast<uint64_t>(object.GetSize()),

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.h
@@ -79,7 +79,7 @@ public:
         size_t buf_size = DBMS_DEFAULT_BUFFER_SIZE,
         const WriteSettings & write_settings = {}) override;
 
-    void listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t max_keys) const override;
+    void listObjects(const std::string & path, PathsWithMetadata & children, size_t max_keys) const override;
 
     ObjectStorageIteratorPtr iterate(const std::string & path_prefix, size_t max_keys) const override;
 

--- a/src/Interpreters/ClusterFunctionReadTask.cpp
+++ b/src/Interpreters/ClusterFunctionReadTask.cpp
@@ -35,6 +35,7 @@ ClusterFunctionReadTaskResponse::ClusterFunctionReadTaskResponse(ObjectInfoPtr o
 
     const bool send_over_whole_archive = !context->getSettingsRef()[Setting::cluster_function_process_archive_on_multiple_nodes];
     path = send_over_whole_archive ? object->getPathOrPathToArchiveIfArchive() : object->getPath();
+    absolute_path = object->getAbsolutePath();
 }
 
 ClusterFunctionReadTaskResponse::ClusterFunctionReadTaskResponse(const std::string & path_)
@@ -50,6 +51,7 @@ ObjectInfoPtr ClusterFunctionReadTaskResponse::getObjectInfo() const
     auto object = std::make_shared<ObjectInfo>(path);
     object->data_lake_metadata = data_lake_metadata;
     object->file_meta_info = file_meta_info;
+    object->absolute_path = absolute_path;
     return object;
 }
 

--- a/src/Interpreters/ClusterFunctionReadTask.cpp
+++ b/src/Interpreters/ClusterFunctionReadTask.cpp
@@ -51,7 +51,9 @@ ObjectInfoPtr ClusterFunctionReadTaskResponse::getObjectInfo() const
     auto object = std::make_shared<ObjectInfo>(path);
     object->data_lake_metadata = data_lake_metadata;
     object->file_meta_info = file_meta_info;
-    object->absolute_path = absolute_path;
+    if (absolute_path.has_value() && !absolute_path.value().empty())
+        object->absolute_path = absolute_path;
+    
     return object;
 }
 

--- a/src/Interpreters/ClusterFunctionReadTask.h
+++ b/src/Interpreters/ClusterFunctionReadTask.h
@@ -18,6 +18,8 @@ struct ClusterFunctionReadTaskResponse
 
     /// Data path (object path, in case of object storage).
     String path;
+    /// Absolute path (including storage type prefix).
+    std::optional<String> absolute_path;
     /// Object metadata path, in case of data lake object.
     DataLakeObjectMetadata data_lake_metadata;
     /// File's columns info

--- a/src/Storages/ObjectStorage/DataLakes/Common.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Common.cpp
@@ -14,7 +14,7 @@ std::vector<String> listFiles(
     const String & prefix, const String & suffix)
 {
     auto key = std::filesystem::path(configuration.getPathForRead().path) / prefix;
-    RelativePathsWithMetadata files_with_metadata;
+    PathsWithMetadata files_with_metadata;
     object_storage.listObjects(key, files_with_metadata, 0);
     Strings res;
     for (const auto & file_with_metadata : files_with_metadata)

--- a/src/Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h
@@ -70,6 +70,7 @@ struct DataFileInfo
 {
     std::string file_path;
     std::optional<DataFileMetaInfoPtr> file_meta_info;
+    std::optional<std::string> absolute_uri;
 
     explicit DataFileInfo(const std::string & file_path_)
         : file_path(file_path_) {}

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -112,7 +112,7 @@ Plan getPlan(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     ObjectStoragePtr object_storage,
-    std::map<String, DB::ObjectStoragePtr> & secondary_storages,
+    SecondaryStorages & secondary_storages,
     StorageObjectStorageConfigurationPtr configuration,
     ContextPtr context,
     CompressionMethod compression_method)
@@ -239,14 +239,16 @@ void writeDataFiles(
     ContextPtr context,
     StorageObjectStorageConfigurationPtr configuration,
     const String & table_location,
-    std::map<String, ObjectStoragePtr> & secondary_storages)
+    SecondaryStorages & secondary_storages)
 {
     for (auto & [_, data_file] : initial_plan.path_to_data_file)
     {
         auto delete_file_transform = std::make_shared<IcebergBitmapPositionDeleteTransform>(
             sample_block, data_file->data_object_info, object_storage, format_settings, context, table_location, secondary_storages);
 
-        ObjectStoragePtr storage_to_use = data_file->data_object_info->getObjectStorage().value_or(object_storage);
+        ObjectStoragePtr storage_to_use = data_file->data_object_info->getObjectStorage();
+        if (!storage_to_use)
+            storage_to_use = object_storage;
         StorageObjectStorage::ObjectInfo object_info(data_file->data_object_info->getPath());
         auto read_buffer = createReadBuffer(object_info, storage_to_use, context, getLogger("IcebergCompaction"));
 
@@ -536,7 +538,7 @@ void compactIcebergTable(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     ObjectStoragePtr object_storage_,
-    std::map<String, DB::ObjectStoragePtr> & secondary_storages_,
+    SecondaryStorages & secondary_storages_,
     StorageObjectStorageConfigurationPtr configuration_,
     const std::optional<FormatSettings> & format_settings_,
     SharedHeader sample_block_,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -69,6 +69,7 @@ struct Plan
     IcebergHistory history;
     std::unordered_map<String, Int64> manifest_file_to_first_snapshot;
     std::unordered_map<String, std::vector<String>> manifest_list_to_manifest_files;
+    std::unordered_map<String, std::unordered_set<Int64>> manifest_file_to_snapshots;
     std::unordered_map<Int64, std::vector<std::shared_ptr<DataFilePlan>>> snapshot_id_to_data_files;
     std::unordered_map<String, std::shared_ptr<DataFilePlan>> path_to_data_file;
     FileNamesGenerator generator;
@@ -111,7 +112,7 @@ Plan getPlan(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     ObjectStoragePtr object_storage,
-    std::map<String, DB::ObjectStoragePtr> secondary_storages,
+    std::map<String, DB::ObjectStoragePtr> & secondary_storages,
     StorageObjectStorageConfigurationPtr configuration,
     ContextPtr context,
     CompressionMethod compression_method)
@@ -156,7 +157,9 @@ Plan getPlan(
         {
             plan.manifest_list_to_manifest_files[snapshot.manifest_list_absolute_path].push_back(manifest_file.manifest_file_absolute_path);
             if (!plan.manifest_file_to_first_snapshot.contains(manifest_file.manifest_file_absolute_path))
+            {
                 plan.manifest_file_to_first_snapshot[manifest_file.manifest_file_absolute_path] = snapshot.snapshot_id;
+            }
             auto manifest_file_content = getManifestFile(
                 object_storage,
                 configuration,
@@ -174,6 +177,8 @@ Plan getPlan(
                 manifest_files[manifest_file.manifest_file_absolute_path]->path = manifest_file.manifest_file_absolute_path;
             }
             manifest_files[manifest_file.manifest_file_absolute_path]->manifest_lists_path.push_back(snapshot.manifest_list_path);
+            // Track which snapshots this manifest file belongs to
+            plan.manifest_file_to_snapshots[manifest_file.manifest_file_absolute_path].insert(snapshot.snapshot_id);
             auto data_files = manifest_file_content->getFilesWithoutDeleted(FileContentType::DATA);
             auto positional_delete_files = manifest_file_content->getFilesWithoutDeleted(FileContentType::POSITION_DELETE);
             for (const auto & pos_delete_file : positional_delete_files)
@@ -185,19 +190,24 @@ Plan getPlan(
                 if (plan.partitions.size() <= partition_index)
                     plan.partitions.push_back({});
 
-                IcebergDataObjectInfoPtr data_object_info = std::make_shared<IcebergDataObjectInfo>(data_file);
+                auto [resolved_storage, resolved_key] = resolveObjectStorageForPath(
+                    persistent_table_components.table_location, data_file.file_path, object_storage, secondary_storages, context);
+
+                IcebergDataObjectInfoPtr data_object_info = std::make_shared<IcebergDataObjectInfo>(data_file, resolved_storage, resolved_key);
                 std::shared_ptr<DataFilePlan> data_file_ptr;
-                if (!plan.path_to_data_file.contains(manifest_file.manifest_file_absolute_path))
+                std::string storage_identifier = resolved_storage->getDescription() + ":" + resolved_storage->getObjectsNamespace();
+                std::string composite_key = storage_identifier + "|" + resolved_key;
+                if (!plan.path_to_data_file.contains(composite_key))
                 {
                     data_file_ptr = std::make_shared<DataFilePlan>(DataFilePlan{
                         .data_object_info = data_object_info,
                         .manifest_list = manifest_files[manifest_file.manifest_file_absolute_path],
                         .patched_path = plan.generator.generateDataFileName()});
-                    plan.path_to_data_file[manifest_file.manifest_file_absolute_path] = data_file_ptr;
+                    plan.path_to_data_file[composite_key] = data_file_ptr;
                 }
                 else
                 {
-                    data_file_ptr = plan.path_to_data_file[manifest_file.manifest_file_absolute_path];
+                    data_file_ptr = plan.path_to_data_file[composite_key];
                 }
                 plan.partitions[partition_index].push_back(data_file_ptr);
                 plan.snapshot_id_to_data_files[snapshot.snapshot_id].push_back(plan.partitions[partition_index].back());
@@ -229,15 +239,18 @@ void writeDataFiles(
     ObjectStoragePtr object_storage,
     const std::optional<FormatSettings> & format_settings,
     ContextPtr context,
-    StorageObjectStorageConfigurationPtr configuration)
+    StorageObjectStorageConfigurationPtr configuration,
+    const String & table_location,
+    std::map<String, ObjectStoragePtr> & secondary_storages)
 {
     for (auto & [_, data_file] : initial_plan.path_to_data_file)
     {
         auto delete_file_transform = std::make_shared<IcebergBitmapPositionDeleteTransform>(
-            sample_block, data_file->data_object_info, object_storage, format_settings, context);
+            sample_block, data_file->data_object_info, object_storage, format_settings, context, table_location, secondary_storages);
 
+        ObjectStoragePtr storage_to_use = data_file->data_object_info->getObjectStorage().value_or(object_storage);
         StorageObjectStorage::ObjectInfo object_info(data_file->data_object_info->getPath());
-        auto read_buffer = createReadBuffer(object_info, object_storage, context, getLogger("IcebergCompaction"));
+        auto read_buffer = createReadBuffer(object_info, storage_to_use, context, getLogger("IcebergCompaction"));
 
         const Settings & settings = context->getSettingsRef();
         auto parser_shared_resources = std::make_shared<FormatParserSharedResources>(
@@ -395,6 +408,9 @@ void writeMetadataFiles(
         {
             manifest_entry->patched_path = plan.generator.generateManifestEntryName();
             manifest_file_renamings[manifest_entry->path] = manifest_entry->patched_path.path_in_metadata;
+
+            std::vector<String> unique_data_filenames(data_filenames.begin(), data_filenames.end());
+
             auto buffer_manifest_entry = object_storage->writeObject(
                 StoredObject(manifest_entry->patched_path.path_in_storage),
                 WriteMode::Rewrite,
@@ -412,7 +428,7 @@ void writeMetadataFiles(
                 partition_columns,
                 plan.partition_encoder.getPartitionValue(grouped_by_manifest_files_partitions[manifest_entry]),
                 ChunkPartitioner(fields_from_partition_spec, current_schema, context, sample_block_).getResultTypes(),
-                std::vector(data_filenames.begin(), data_filenames.end()),
+                unique_data_filenames,
                 manifest_entry->statistics,
                 sample_block_,
                 snapshot,
@@ -441,16 +457,25 @@ void writeMetadataFiles(
         if (plan.history[i].added_files == 0)
             continue;
 
-        auto initial_manifest_list_name = plan.history[i].manifest_list_path;
+        auto initial_manifest_list_name = plan.history[i].manifest_list_absolute_path;
         auto initial_manifest_entries = plan.manifest_list_to_manifest_files[initial_manifest_list_name];
-        auto renamed_manifest_list = manifest_list_renamings[initial_manifest_list_name];
+        auto renamed_manifest_list = manifest_list_renamings[plan.history[i].manifest_list_path];
         std::vector<String> renamed_manifest_entries;
+        std::unordered_set<String> seen_manifest_entries; // Deduplicate manifest entries
         Int32 total_manifest_file_sizes = 0;
         for (const auto & initial_manifest_entry : initial_manifest_entries)
         {
             auto renamed_manifest_entry = manifest_file_renamings[initial_manifest_entry];
             if (!renamed_manifest_entry.empty())
             {
+                auto it = plan.manifest_file_to_snapshots.find(initial_manifest_entry);
+                if (it != plan.manifest_file_to_snapshots.end() && !it->second.contains(plan.history[i].snapshot_id))
+                    continue;
+
+                if (seen_manifest_entries.contains(renamed_manifest_entry))
+                    continue;
+
+                seen_manifest_entries.insert(renamed_manifest_entry);
                 renamed_manifest_entries.push_back(renamed_manifest_entry);
                 total_manifest_file_sizes += manifest_file_sizes[renamed_manifest_entry];
             }
@@ -513,7 +538,7 @@ void compactIcebergTable(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     ObjectStoragePtr object_storage_,
-    std::map<String, DB::ObjectStoragePtr> secondary_storages_,
+    std::map<String, DB::ObjectStoragePtr> & secondary_storages_,
     StorageObjectStorageConfigurationPtr configuration_,
     const std::optional<FormatSettings> & format_settings_,
     SharedHeader sample_block_,
@@ -525,7 +550,7 @@ void compactIcebergTable(
     if (plan.need_optimize)
     {
         auto old_files = getOldFiles(object_storage_, configuration_);
-        writeDataFiles(plan, sample_block_, object_storage_, format_settings_, context_, configuration_);
+        writeDataFiles(plan, sample_block_, object_storage_, format_settings_, context_, configuration_, persistent_table_components.table_location, secondary_storages_);
         writeMetadataFiles(plan, object_storage_, configuration_, context_, sample_block_);
         clearOldFiles(object_storage_, old_files);
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -111,6 +111,7 @@ Plan getPlan(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     ObjectStoragePtr object_storage,
+    std::map<String, DB::ObjectStoragePtr> secondary_storages,
     StorageObjectStorageConfigurationPtr configuration,
     ContextPtr context,
     CompressionMethod compression_method)
@@ -146,29 +147,33 @@ Plan getPlan(
     std::unordered_map<String, std::shared_ptr<ManifestFilePlan>> manifest_files;
     for (const auto & snapshot : snapshots_info)
     {
+        auto [manifest_list_storage, key_in_storage] = resolveObjectStorageForPath(persistent_table_components.table_location, snapshot.manifest_list_path, object_storage, secondary_storages, context);
+
         auto manifest_list
-            = getManifestList(object_storage, configuration, persistent_table_components, context, snapshot.manifest_list_path, log);
+            = getManifestList(manifest_list_storage, configuration, persistent_table_components, context, key_in_storage, snapshot.manifest_list_path, log);
+
         for (const auto & manifest_file : manifest_list)
         {
-            plan.manifest_list_to_manifest_files[snapshot.manifest_list_path].push_back(manifest_file.manifest_file_path);
-            if (!plan.manifest_file_to_first_snapshot.contains(manifest_file.manifest_file_path))
-                plan.manifest_file_to_first_snapshot[manifest_file.manifest_file_path] = snapshot.snapshot_id;
+            plan.manifest_list_to_manifest_files[snapshot.manifest_list_absolute_path].push_back(manifest_file.manifest_file_absolute_path);
+            if (!plan.manifest_file_to_first_snapshot.contains(manifest_file.manifest_file_absolute_path))
+                plan.manifest_file_to_first_snapshot[manifest_file.manifest_file_absolute_path] = snapshot.snapshot_id;
             auto manifest_file_content = getManifestFile(
                 object_storage,
                 configuration,
                 persistent_table_components,
                 context,
                 log,
-                manifest_file.manifest_file_path,
+                manifest_file.manifest_file_absolute_path,
                 manifest_file.added_sequence_number,
-                manifest_file.added_snapshot_id);
+                manifest_file.added_snapshot_id,
+                secondary_storages);
 
-            if (!manifest_files.contains(manifest_file.manifest_file_path))
+            if (!manifest_files.contains(manifest_file.manifest_file_absolute_path))
             {
-                manifest_files[manifest_file.manifest_file_path] = std::make_shared<ManifestFilePlan>(current_schema);
-                manifest_files[manifest_file.manifest_file_path]->path = manifest_file.manifest_file_path;
+                manifest_files[manifest_file.manifest_file_absolute_path] = std::make_shared<ManifestFilePlan>(current_schema);
+                manifest_files[manifest_file.manifest_file_absolute_path]->path = manifest_file.manifest_file_absolute_path;
             }
-            manifest_files[manifest_file.manifest_file_path]->manifest_lists_path.push_back(snapshot.manifest_list_path);
+            manifest_files[manifest_file.manifest_file_absolute_path]->manifest_lists_path.push_back(snapshot.manifest_list_path);
             auto data_files = manifest_file_content->getFilesWithoutDeleted(FileContentType::DATA);
             auto positional_delete_files = manifest_file_content->getFilesWithoutDeleted(FileContentType::POSITION_DELETE);
             for (const auto & pos_delete_file : positional_delete_files)
@@ -182,17 +187,17 @@ Plan getPlan(
 
                 IcebergDataObjectInfoPtr data_object_info = std::make_shared<IcebergDataObjectInfo>(data_file);
                 std::shared_ptr<DataFilePlan> data_file_ptr;
-                if (!plan.path_to_data_file.contains(manifest_file.manifest_file_path))
+                if (!plan.path_to_data_file.contains(manifest_file.manifest_file_absolute_path))
                 {
                     data_file_ptr = std::make_shared<DataFilePlan>(DataFilePlan{
                         .data_object_info = data_object_info,
-                        .manifest_list = manifest_files[manifest_file.manifest_file_path],
+                        .manifest_list = manifest_files[manifest_file.manifest_file_absolute_path],
                         .patched_path = plan.generator.generateDataFileName()});
-                    plan.path_to_data_file[manifest_file.manifest_file_path] = data_file_ptr;
+                    plan.path_to_data_file[manifest_file.manifest_file_absolute_path] = data_file_ptr;
                 }
                 else
                 {
-                    data_file_ptr = plan.path_to_data_file[manifest_file.manifest_file_path];
+                    data_file_ptr = plan.path_to_data_file[manifest_file.manifest_file_absolute_path];
                 }
                 plan.partitions[partition_index].push_back(data_file_ptr);
                 plan.snapshot_id_to_data_files[snapshot.snapshot_id].push_back(plan.partitions[partition_index].back());
@@ -508,6 +513,7 @@ void compactIcebergTable(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     ObjectStoragePtr object_storage_,
+    std::map<String, DB::ObjectStoragePtr> secondary_storages_,
     StorageObjectStorageConfigurationPtr configuration_,
     const std::optional<FormatSettings> & format_settings_,
     SharedHeader sample_block_,
@@ -515,7 +521,7 @@ void compactIcebergTable(
     CompressionMethod compression_method_)
 {
     auto plan
-        = getPlan(std::move(snapshots_info), persistent_table_components, object_storage_, configuration_, context_, compression_method_);
+        = getPlan(std::move(snapshots_info), persistent_table_components, object_storage_, secondary_storages_, configuration_, context_, compression_method_);
     if (plan.need_optimize)
     {
         auto old_files = getOldFiles(object_storage_, configuration_);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -177,7 +177,6 @@ Plan getPlan(
                 manifest_files[manifest_file.manifest_file_absolute_path]->path = manifest_file.manifest_file_absolute_path;
             }
             manifest_files[manifest_file.manifest_file_absolute_path]->manifest_lists_path.push_back(snapshot.manifest_list_path);
-            // Track which snapshots this manifest file belongs to
             plan.manifest_file_to_snapshots[manifest_file.manifest_file_absolute_path].insert(snapshot.snapshot_id);
             auto data_files = manifest_file_content->getFilesWithoutDeleted(FileContentType::DATA);
             auto positional_delete_files = manifest_file_content->getFilesWithoutDeleted(FileContentType::POSITION_DELETE);
@@ -195,19 +194,18 @@ Plan getPlan(
 
                 IcebergDataObjectInfoPtr data_object_info = std::make_shared<IcebergDataObjectInfo>(data_file, resolved_storage, resolved_key);
                 std::shared_ptr<DataFilePlan> data_file_ptr;
-                std::string storage_identifier = resolved_storage->getDescription() + ":" + resolved_storage->getObjectsNamespace();
-                std::string composite_key = storage_identifier + "|" + resolved_key;
-                if (!plan.path_to_data_file.contains(composite_key))
+                std::string path_identifier = resolved_storage->getDescription() + ":" + resolved_storage->getObjectsNamespace() + "|" + resolved_key;
+                if (!plan.path_to_data_file.contains(path_identifier))
                 {
                     data_file_ptr = std::make_shared<DataFilePlan>(DataFilePlan{
                         .data_object_info = data_object_info,
                         .manifest_list = manifest_files[manifest_file.manifest_file_absolute_path],
                         .patched_path = plan.generator.generateDataFileName()});
-                    plan.path_to_data_file[composite_key] = data_file_ptr;
+                    plan.path_to_data_file[path_identifier] = data_file_ptr;
                 }
                 else
                 {
-                    data_file_ptr = plan.path_to_data_file[composite_key];
+                    data_file_ptr = plan.path_to_data_file[path_identifier];
                 }
                 plan.partitions[partition_index].push_back(data_file_ptr);
                 plan.snapshot_id_to_data_files[snapshot.snapshot_id].push_back(plan.partitions[partition_index].back());

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h
@@ -5,6 +5,7 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
+#include <Storages/ObjectStorage/Utils.h>
 
 
 namespace DB::Iceberg
@@ -15,7 +16,7 @@ void compactIcebergTable(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     DB::ObjectStoragePtr object_storage_,
-    std::map<String, DB::ObjectStoragePtr> & secondary_storages_,
+    SecondaryStorages & secondary_storages_,
     DB::StorageObjectStorageConfigurationPtr configuration_,
     const std::optional<DB::FormatSettings> & format_settings_,
     DB::SharedHeader sample_block_,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h
@@ -15,7 +15,7 @@ void compactIcebergTable(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     DB::ObjectStoragePtr object_storage_,
-    std::map<String, DB::ObjectStoragePtr> secondary_storages_,
+    std::map<String, DB::ObjectStoragePtr> & secondary_storages_,
     DB::StorageObjectStorageConfigurationPtr configuration_,
     const std::optional<DB::FormatSettings> & format_settings_,
     DB::SharedHeader sample_block_,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.h
@@ -15,6 +15,7 @@ void compactIcebergTable(
     IcebergHistory snapshots_info,
     const PersistentTableComponents & persistent_table_components,
     DB::ObjectStoragePtr object_storage_,
+    std::map<String, DB::ObjectStoragePtr> secondary_storages_,
     DB::StorageObjectStorageConfigurationPtr configuration_,
     const std::optional<DB::FormatSettings> & format_settings_,
     DB::SharedHeader sample_block_,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
@@ -37,22 +37,15 @@ namespace Setting
 extern const SettingsBool use_roaring_bitmap_iceberg_positional_deletes;
 };
 
-namespace
-{
-String toupper(String & str)
-{
-    std::transform(str.begin(), str.end(), str.begin(), ::toupper);
-    return str;
-}
-}
 
 IcebergDataObjectInfo::IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_manifest_file_entry_)
-    : PathWithMetadata(data_manifest_file_entry_.file_path, std::nullopt, data_manifest_file_entry_.file_path_key)
+    : PathWithMetadata(data_manifest_file_entry_.file_path, std::nullopt,
+                       data_manifest_file_entry_.file_path_key.empty() ? std::nullopt : std::make_optional(data_manifest_file_entry_.file_path_key))
     , data_object_file_path_key(data_manifest_file_entry_.file_path_key)
     , underlying_format_read_schema_id(data_manifest_file_entry_.schema_id)
     , sequence_number(data_manifest_file_entry_.added_sequence_number)
 {
-    if (!position_deletes_objects.empty() && toupper(data_manifest_file_entry_.file_format) != "PARQUET")
+    if (!position_deletes_objects.empty() && Poco::toUpperInPlace(data_manifest_file_entry_.file_format) != "PARQUET")
     {
         throw Exception(
             ErrorCodes::NOT_IMPLEMENTED,
@@ -65,17 +58,14 @@ IcebergDataObjectInfo::IcebergDataObjectInfo(
     Iceberg::ManifestFileEntry data_manifest_file_entry_,
     ObjectStoragePtr resolved_storage,
     const String & resolved_key)
-    : PathWithMetadata(resolved_key, std::nullopt, data_manifest_file_entry_.file_path, resolved_storage)
+    : PathWithMetadata(resolved_key, std::nullopt,
+                       data_manifest_file_entry_.file_path.empty() ? std::nullopt : std::make_optional(data_manifest_file_entry_.file_path), 
+                       resolved_storage)
     , data_object_file_path_key(data_manifest_file_entry_.file_path_key)
     , underlying_format_read_schema_id(data_manifest_file_entry_.schema_id)
     , sequence_number(data_manifest_file_entry_.added_sequence_number)
 {
-    auto toupper = [](String & str)
-    {
-        std::transform(str.begin(), str.end(), str.begin(), ::toupper);
-        return str;
-    };
-    if (!position_deletes_objects.empty() && toupper(data_manifest_file_entry_.file_format) != "PARQUET")
+    if (!position_deletes_objects.empty() && Poco::toUpperInPlace(data_manifest_file_entry_.file_format) != "PARQUET")
     {
         throw Exception(
             ErrorCodes::NOT_IMPLEMENTED,
@@ -90,7 +80,7 @@ std::shared_ptr<ISimpleTransform> IcebergDataObjectInfo::getPositionDeleteTransf
     const std::optional<FormatSettings> & format_settings,
     ContextPtr context_,
     const String & table_location,
-    std::map<String, ObjectStoragePtr> & secondary_storages)
+    SecondaryStorages & secondary_storages)
 {
     IcebergDataObjectInfoPtr self = shared_from_this();
     if (!context_->getSettingsRef()[Setting::use_roaring_bitmap_iceberg_positional_deletes].value)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
@@ -1,3 +1,4 @@
+#include <Poco/String.h>
 #include "config.h"
 
 #if USE_AVRO
@@ -42,12 +43,7 @@ IcebergDataObjectInfo::IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_man
     , underlying_format_read_schema_id(data_manifest_file_entry_.schema_id)
     , sequence_number(data_manifest_file_entry_.added_sequence_number)
 {
-    auto toupper = [](String & str)
-    {
-        std::transform(str.begin(), str.end(), str.begin(), ::toupper);
-        return str;
-    };
-    if (!position_deletes_objects.empty() && toupper(data_manifest_file_entry_.file_format) != "PARQUET")
+    if (!position_deletes_objects.empty() && Poco::toUpper(data_manifest_file_entry_.file_format) != "PARQUET")
     {
         throw Exception(
             ErrorCodes::NOT_IMPLEMENTED,
@@ -83,13 +79,15 @@ std::shared_ptr<ISimpleTransform> IcebergDataObjectInfo::getPositionDeleteTransf
     ObjectStoragePtr object_storage,
     const SharedHeader & header,
     const std::optional<FormatSettings> & format_settings,
-    ContextPtr context_)
+    ContextPtr context_,
+    const String & table_location,
+    std::map<String, ObjectStoragePtr> & secondary_storages)
 {
     IcebergDataObjectInfoPtr self = shared_from_this();
     if (!context_->getSettingsRef()[Setting::use_roaring_bitmap_iceberg_positional_deletes].value)
-        return std::make_shared<IcebergStreamingPositionDeleteTransform>(header, self, object_storage, format_settings, context_);
+        return std::make_shared<IcebergStreamingPositionDeleteTransform>(header, self, object_storage, format_settings, context_, table_location, secondary_storages);
     else
-        return std::make_shared<IcebergBitmapPositionDeleteTransform>(header, self, object_storage, format_settings, context_);
+        return std::make_shared<IcebergBitmapPositionDeleteTransform>(header, self, object_storage, format_settings, context_, table_location, secondary_storages);
 }
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
@@ -37,7 +37,30 @@ extern const SettingsBool use_roaring_bitmap_iceberg_positional_deletes;
 };
 
 IcebergDataObjectInfo::IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_manifest_file_entry_)
-    : RelativePathWithMetadata(data_manifest_file_entry_.file_path)
+    : PathWithMetadata(data_manifest_file_entry_.file_path, std::nullopt, data_manifest_file_entry_.file_path_key)
+    , data_object_file_path_key(data_manifest_file_entry_.file_path_key)
+    , underlying_format_read_schema_id(data_manifest_file_entry_.schema_id)
+    , sequence_number(data_manifest_file_entry_.added_sequence_number)
+{
+    auto toupper = [](String & str)
+    {
+        std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+        return str;
+    };
+    if (!position_deletes_objects.empty() && toupper(data_manifest_file_entry_.file_format) != "PARQUET")
+    {
+        throw Exception(
+            ErrorCodes::NOT_IMPLEMENTED,
+            "Position deletes are only supported for data files of Parquet format in Iceberg, but got {}",
+            data_manifest_file_entry_.file_format);
+    }
+}
+
+IcebergDataObjectInfo::IcebergDataObjectInfo(
+    Iceberg::ManifestFileEntry data_manifest_file_entry_,
+    ObjectStoragePtr resolved_storage,
+    const String & resolved_key)
+    : PathWithMetadata(resolved_key, std::nullopt, data_manifest_file_entry_.file_path, resolved_storage)
     , data_object_file_path_key(data_manifest_file_entry_.file_path_key)
     , underlying_format_read_schema_id(data_manifest_file_entry_.schema_id)
     , sequence_number(data_manifest_file_entry_.added_sequence_number)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.cpp
@@ -37,13 +37,22 @@ namespace Setting
 extern const SettingsBool use_roaring_bitmap_iceberg_positional_deletes;
 };
 
+namespace
+{
+String toupper(String & str)
+{
+    std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+    return str;
+}
+}
+
 IcebergDataObjectInfo::IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_manifest_file_entry_)
     : PathWithMetadata(data_manifest_file_entry_.file_path, std::nullopt, data_manifest_file_entry_.file_path_key)
     , data_object_file_path_key(data_manifest_file_entry_.file_path_key)
     , underlying_format_read_schema_id(data_manifest_file_entry_.schema_id)
     , sequence_number(data_manifest_file_entry_.added_sequence_number)
 {
-    if (!position_deletes_objects.empty() && Poco::toUpper(data_manifest_file_entry_.file_format) != "PARQUET")
+    if (!position_deletes_objects.empty() && toupper(data_manifest_file_entry_.file_format) != "PARQUET")
     {
         throw Exception(
             ErrorCodes::NOT_IMPLEMENTED,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
@@ -13,7 +13,7 @@
 
 namespace DB
 {
-struct IcebergDataObjectInfo : public RelativePathWithMetadata, std::enable_shared_from_this<IcebergDataObjectInfo>
+struct IcebergDataObjectInfo : public PathWithMetadata, std::enable_shared_from_this<IcebergDataObjectInfo>
 {
     using IcebergDataObjectInfoPtr = std::shared_ptr<IcebergDataObjectInfo>;
 
@@ -21,6 +21,12 @@ struct IcebergDataObjectInfo : public RelativePathWithMetadata, std::enable_shar
     /// It is used to filter position deletes objects by data file path.
     /// It is also used to create a filter for the data object in the position delete transform.
     explicit IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_manifest_file_entry_);
+    
+    /// Constructor with resolved storage and key for files that may be outside table location
+    explicit IcebergDataObjectInfo(
+        Iceberg::ManifestFileEntry data_manifest_file_entry_,
+        ObjectStoragePtr resolved_storage,
+        const String & resolved_key);
 
     std::shared_ptr<ISimpleTransform> getPositionDeleteTransformer(
         ObjectStoragePtr object_storage,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
@@ -22,7 +22,7 @@ struct IcebergDataObjectInfo : public PathWithMetadata, std::enable_shared_from_
     /// It is also used to create a filter for the data object in the position delete transform.
     explicit IcebergDataObjectInfo(Iceberg::ManifestFileEntry data_manifest_file_entry_);
     
-    /// Constructor with resolved storage and key for files that may be outside table location
+    /// Sometimes data files are located outside the table location and even in a different storage.
     explicit IcebergDataObjectInfo(
         Iceberg::ManifestFileEntry data_manifest_file_entry_,
         ObjectStoragePtr resolved_storage,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
@@ -32,7 +32,9 @@ struct IcebergDataObjectInfo : public PathWithMetadata, std::enable_shared_from_
         ObjectStoragePtr object_storage,
         const SharedHeader & header,
         const std::optional<FormatSettings> & format_settings,
-        ContextPtr context_);
+        ContextPtr context_,
+        const String & table_location,
+        std::map<String, ObjectStoragePtr> & secondary_storages);
 
     void addPositionDeleteObject(Iceberg::ManifestFileEntry position_delete_object)
     {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h
@@ -8,6 +8,7 @@
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h>
+#include <Storages/ObjectStorage/Utils.h>
 #include <base/defines.h>
 
 
@@ -34,7 +35,7 @@ struct IcebergDataObjectInfo : public PathWithMetadata, std::enable_shared_from_
         const std::optional<FormatSettings> & format_settings,
         ContextPtr context_,
         const String & table_location,
-        std::map<String, ObjectStoragePtr> & secondary_storages);
+        SecondaryStorages & secondary_storages);
 
     void addPositionDeleteObject(Iceberg::ManifestFileEntry position_delete_object)
     {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -24,6 +24,7 @@
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <Interpreters/Context.h>
+#include <Disks/DiskType.h>
 
 #include <IO/CompressedReadBufferWrapper.h>
 #include <Interpreters/ExpressionActions.h>
@@ -134,7 +135,7 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
                 data_snapshot->manifest_list_entries[manifest_file_index].manifest_file_absolute_path,
                 data_snapshot->manifest_list_entries[manifest_file_index].added_sequence_number,
                 data_snapshot->manifest_list_entries[manifest_file_index].added_snapshot_id,
-                secondary_storages);
+                *secondary_storages);
             internal_data_index = 0;
         }
         auto files = files_generator(current_manifest_file_content);
@@ -202,7 +203,7 @@ SingleThreadIcebergKeysIterator::SingleThreadIcebergKeysIterator(
     Iceberg::IcebergTableStateSnapshotPtr table_snapshot_,
     Iceberg::IcebergDataSnapshotPtr data_snapshot_,
     PersistentTableComponents persistent_components_,
-    std::map<String, ObjectStoragePtr> & secondary_storages_)
+    std::shared_ptr<SecondaryStorages> secondary_storages_)
     : object_storage(object_storage_)
     , filter_dag(filter_dag_ ? std::make_shared<ActionsDAG>(filter_dag_->clone()) : nullptr)
     , local_context(local_context_)
@@ -238,7 +239,7 @@ IcebergIterator::IcebergIterator(
     Iceberg::IcebergTableStateSnapshotPtr table_snapshot_,
     Iceberg::IcebergDataSnapshotPtr data_snapshot_,
     PersistentTableComponents persistent_components_,
-    std::map<String, ObjectStoragePtr> & secondary_storages_)
+    std::shared_ptr<SecondaryStorages> secondary_storages_)
     : filter_dag(filter_dag_ ? std::make_unique<ActionsDAG>(filter_dag_->clone()) : nullptr)
     , object_storage(std::move(object_storage_))
     , local_context(local_context_)
@@ -337,7 +338,7 @@ ObjectInfoPtr IcebergIterator::next(size_t)
     {
         // Resolve the data file path to get the correct storage and key
         auto [storage_to_use, resolved_key] = resolveObjectStorageForPath(
-            persistent_components.table_location, manifest_file_entry.file_path, object_storage, secondary_storages, local_context);
+            persistent_components.table_location, manifest_file_entry.file_path, object_storage, *secondary_storages, local_context);
         
         IcebergDataObjectInfoPtr object_info = std::make_shared<IcebergDataObjectInfo>(manifest_file_entry, storage_to_use, resolved_key);
         

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -125,7 +125,6 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
                 ++manifest_file_index;
                 continue;
             }
-            std::map<String, ObjectStoragePtr> empty_secondary_storages;
             current_manifest_file_content = Iceberg::getManifestFile(
                 object_storage,
                 configuration.lock(),
@@ -135,7 +134,7 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
                 data_snapshot->manifest_list_entries[manifest_file_index].manifest_file_absolute_path,
                 data_snapshot->manifest_list_entries[manifest_file_index].added_sequence_number,
                 data_snapshot->manifest_list_entries[manifest_file_index].added_snapshot_id,
-                empty_secondary_storages);
+                secondary_storages);
             internal_data_index = 0;
         }
         auto files = files_generator(current_manifest_file_content);
@@ -202,7 +201,8 @@ SingleThreadIcebergKeysIterator::SingleThreadIcebergKeysIterator(
     const ActionsDAG * filter_dag_,
     Iceberg::IcebergTableStateSnapshotPtr table_snapshot_,
     Iceberg::IcebergDataSnapshotPtr data_snapshot_,
-    PersistentTableComponents persistent_components_)
+    PersistentTableComponents persistent_components_,
+    std::map<String, ObjectStoragePtr> & secondary_storages_)
     : object_storage(object_storage_)
     , filter_dag(filter_dag_ ? std::make_shared<ActionsDAG>(filter_dag_->clone()) : nullptr)
     , local_context(local_context_)
@@ -224,6 +224,7 @@ SingleThreadIcebergKeysIterator::SingleThreadIcebergKeysIterator(
     , persistent_components(persistent_components_)
     , files_generator(files_generator_)
     , log(getLogger("IcebergIterator"))
+    , secondary_storages(secondary_storages_)
     , manifest_file_content_type(manifest_file_content_type_)
 {
 }
@@ -236,7 +237,8 @@ IcebergIterator::IcebergIterator(
     IDataLakeMetadata::FileProgressCallback callback_,
     Iceberg::IcebergTableStateSnapshotPtr table_snapshot_,
     Iceberg::IcebergDataSnapshotPtr data_snapshot_,
-    PersistentTableComponents persistent_components_)
+    PersistentTableComponents persistent_components_,
+    std::map<String, ObjectStoragePtr> & secondary_storages_)
     : filter_dag(filter_dag_ ? std::make_unique<ActionsDAG>(filter_dag_->clone()) : nullptr)
     , object_storage(std::move(object_storage_))
     , local_context(local_context_)
@@ -249,7 +251,8 @@ IcebergIterator::IcebergIterator(
           filter_dag.get(),
           table_snapshot_,
           data_snapshot_,
-          persistent_components_)
+          persistent_components_,
+          secondary_storages_)
     , deletes_iterator(
           object_storage,
           local_context_,
@@ -265,7 +268,8 @@ IcebergIterator::IcebergIterator(
           filter_dag.get(),
           table_snapshot_,
           data_snapshot_,
-          persistent_components_)
+          persistent_components_,
+          secondary_storages_)
     , blocking_queue(100)
     , producer_task(local_context_->getSchedulePool().createTask(
           "IcebergMetaReaderThread",
@@ -305,6 +309,7 @@ IcebergIterator::IcebergIterator(
     , compression_method(configuration_.lock()->getCompressionMethod())
     , persistent_components(persistent_components_)
     , table_schema_id(table_snapshot_->schema_id)
+    , secondary_storages(secondary_storages_)
 {
     auto delete_file = deletes_iterator.next();
     while (delete_file.has_value())
@@ -331,9 +336,8 @@ ObjectInfoPtr IcebergIterator::next(size_t)
     if (blocking_queue.pop(manifest_file_entry))
     {
         // Resolve the data file path to get the correct storage and key
-        std::map<String, ObjectStoragePtr> empty_secondary_storages;
         auto [storage_to_use, resolved_key] = resolveObjectStorageForPath(
-            persistent_components.table_location, manifest_file_entry.file_path, object_storage, empty_secondary_storages, local_context);
+            persistent_components.table_location, manifest_file_entry.file_path, object_storage, secondary_storages, local_context);
         
         // Create IcebergDataObjectInfo with resolved storage
         IcebergDataObjectInfoPtr object_info = std::make_shared<IcebergDataObjectInfo>(manifest_file_entry, storage_to_use, resolved_key);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -42,6 +42,7 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
+#include <Storages/ObjectStorage/Utils.h>
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.h>
 
@@ -124,15 +125,17 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
                 ++manifest_file_index;
                 continue;
             }
+            std::map<String, ObjectStoragePtr> empty_secondary_storages;
             current_manifest_file_content = Iceberg::getManifestFile(
                 object_storage,
                 configuration.lock(),
                 persistent_components,
                 local_context,
                 log,
-                data_snapshot->manifest_list_entries[manifest_file_index].manifest_file_path,
+                data_snapshot->manifest_list_entries[manifest_file_index].manifest_file_absolute_path,
                 data_snapshot->manifest_list_entries[manifest_file_index].added_sequence_number,
-                data_snapshot->manifest_list_entries[manifest_file_index].added_snapshot_id);
+                data_snapshot->manifest_list_entries[manifest_file_index].added_snapshot_id,
+                empty_secondary_storages);
             internal_data_index = 0;
         }
         auto files = files_generator(current_manifest_file_content);
@@ -236,6 +239,7 @@ IcebergIterator::IcebergIterator(
     PersistentTableComponents persistent_components_)
     : filter_dag(filter_dag_ ? std::make_unique<ActionsDAG>(filter_dag_->clone()) : nullptr)
     , object_storage(std::move(object_storage_))
+    , local_context(local_context_)
     , data_files_iterator(
           object_storage,
           local_context_,
@@ -326,7 +330,13 @@ ObjectInfoPtr IcebergIterator::next(size_t)
     Iceberg::ManifestFileEntry manifest_file_entry;
     if (blocking_queue.pop(manifest_file_entry))
     {
-        IcebergDataObjectInfoPtr object_info = std::make_shared<IcebergDataObjectInfo>(manifest_file_entry);
+        // Resolve the data file path to get the correct storage and key
+        std::map<String, ObjectStoragePtr> empty_secondary_storages;
+        auto [storage_to_use, resolved_key] = resolveObjectStorageForPath(
+            persistent_components.table_location, manifest_file_entry.file_path, object_storage, empty_secondary_storages, local_context);
+        
+        // Create IcebergDataObjectInfo with resolved storage
+        IcebergDataObjectInfoPtr object_info = std::make_shared<IcebergDataObjectInfo>(manifest_file_entry, storage_to_use, resolved_key);
         for (const auto & position_delete : defineDeletesSpan(manifest_file_entry, position_deletes_files, false))
         {
             object_info->addPositionDeleteObject(position_delete);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -137,7 +137,7 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
                 secondary_storages);
             internal_data_index = 0;
         }
-        auto files = files_generator(current_manifest_file_content);
+        const auto & files = files_generator(current_manifest_file_content);
         while (internal_data_index < files.size())
         {
             const auto & manifest_file_entry = files[internal_data_index++];

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -135,12 +135,12 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
                 data_snapshot->manifest_list_entries[manifest_file_index].added_sequence_number,
                 data_snapshot->manifest_list_entries[manifest_file_index].added_snapshot_id,
                 secondary_storages);
-            current_files = files_generator(current_manifest_file_content);
             internal_data_index = 0;
         }
-        while (internal_data_index < current_files.size())
+        auto files = files_generator(current_manifest_file_content);
+        while (internal_data_index < files.size())
         {
-            const auto & manifest_file_entry = current_files[internal_data_index++];
+            const auto & manifest_file_entry = files[internal_data_index++];
             if ((manifest_file_entry.schema_id != previous_entry_schema) && (use_partition_pruning))
             {
                 previous_entry_schema = manifest_file_entry.schema_id;
@@ -175,7 +175,6 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
             }
         }
         current_manifest_file_content = nullptr;
-        current_files.clear();
         current_pruner = std::nullopt;
         ++manifest_file_index;
         internal_data_index = 0;
@@ -340,16 +339,14 @@ ObjectInfoPtr IcebergIterator::next(size_t)
         auto [storage_to_use, resolved_key] = resolveObjectStorageForPath(
             persistent_components.table_location, manifest_file_entry.file_path, object_storage, secondary_storages, local_context);
         
-        // Create IcebergDataObjectInfo with resolved storage
         IcebergDataObjectInfoPtr object_info = std::make_shared<IcebergDataObjectInfo>(manifest_file_entry, storage_to_use, resolved_key);
+        
         for (const auto & position_delete : defineDeletesSpan(manifest_file_entry, position_deletes_files, false))
-        {
             object_info->addPositionDeleteObject(position_delete);
-        }
+
         for (const auto & equality_delete : defineDeletesSpan(manifest_file_entry, equality_deletes_files, true))
-        {
             object_info->addEqualityDeleteObject(equality_delete);
-        }
+        
         object_info->setFileMetaInfo(std::make_shared<DataFileMetaInfo>(
                                     *persistent_components.schema_processor,
                                     table_schema_id, /// current schema id to use current column names

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.cpp
@@ -135,12 +135,12 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
                 data_snapshot->manifest_list_entries[manifest_file_index].added_sequence_number,
                 data_snapshot->manifest_list_entries[manifest_file_index].added_snapshot_id,
                 secondary_storages);
+            current_files = files_generator(current_manifest_file_content);
             internal_data_index = 0;
         }
-        const auto & files = files_generator(current_manifest_file_content);
-        while (internal_data_index < files.size())
+        while (internal_data_index < current_files.size())
         {
-            const auto & manifest_file_entry = files[internal_data_index++];
+            const auto & manifest_file_entry = current_files[internal_data_index++];
             if ((manifest_file_entry.schema_id != previous_entry_schema) && (use_partition_pruning))
             {
                 previous_entry_schema = manifest_file_entry.schema_id;
@@ -175,6 +175,7 @@ std::optional<ManifestFileEntry> SingleThreadIcebergKeysIterator::next()
             }
         }
         current_manifest_file_content = nullptr;
+        current_files.clear();
         current_pruner = std::nullopt;
         ++manifest_file_index;
         internal_data_index = 0;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
@@ -100,6 +100,7 @@ public:
 private:
     std::unique_ptr<ActionsDAG> filter_dag;
     ObjectStoragePtr object_storage;
+    ContextPtr local_context;
     Iceberg::SingleThreadIcebergKeysIterator data_files_iterator;
     Iceberg::SingleThreadIcebergKeysIterator deletes_iterator;
     ConcurrentBoundedQueue<Iceberg::ManifestFileEntry> blocking_queue;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
@@ -69,6 +69,7 @@ private:
     size_t manifest_file_index = 0;
     size_t internal_data_index = 0;
     Iceberg::ManifestFilePtr current_manifest_file_content;
+    std::vector<ManifestFileEntry> current_files;
     Int32 previous_entry_schema = -1;
     std::optional<Iceberg::ManifestFilesPruner> current_pruner;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
@@ -25,6 +25,7 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h>
+#include <Storages/ObjectStorage/Utils.h>
 
 namespace DB
 {
@@ -46,7 +47,7 @@ public:
         IcebergTableStateSnapshotPtr table_snapshot_,
         IcebergDataSnapshotPtr data_snapshot_,
         PersistentTableComponents persistent_components,
-        std::map<String, ObjectStoragePtr> & secondary_storages_);
+        std::shared_ptr<SecondaryStorages> secondary_storages_);
 
     std::optional<DB::Iceberg::ManifestFileEntry> next();
 
@@ -63,7 +64,7 @@ private:
     PersistentTableComponents persistent_components;
     FilesGenerator files_generator;
     LoggerPtr log;
-    std::map<String, ObjectStoragePtr> & secondary_storages;
+    std::shared_ptr<SecondaryStorages> secondary_storages;
 
     // By Iceberg design it is difficult to avoid storing position deletes in memory.
     size_t manifest_file_index = 0;
@@ -92,7 +93,7 @@ public:
         Iceberg::IcebergTableStateSnapshotPtr table_snapshot_,
         Iceberg::IcebergDataSnapshotPtr data_snapshot_,
         Iceberg::PersistentTableComponents persistent_components_,
-        std::map<String, ObjectStoragePtr> & secondary_storages_);
+        std::shared_ptr<SecondaryStorages> secondary_storages_);
 
     ObjectInfoPtr next(size_t) override;
 
@@ -116,7 +117,7 @@ private:
     std::mutex exception_mutex;
     Iceberg::PersistentTableComponents persistent_components;
     Int32 table_schema_id;
-    std::map<String, ObjectStoragePtr> & secondary_storages;
+    std::shared_ptr<SecondaryStorages> secondary_storages;  // Sometimes data or manifests can be located on another storage
 };
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
@@ -69,7 +69,6 @@ private:
     size_t manifest_file_index = 0;
     size_t internal_data_index = 0;
     Iceberg::ManifestFilePtr current_manifest_file_content;
-    std::vector<ManifestFileEntry> current_files;
     Int32 previous_entry_schema = -1;
     std::optional<Iceberg::ManifestFilesPruner> current_pruner;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h
@@ -45,7 +45,8 @@ public:
         const ActionsDAG * filter_dag_,
         IcebergTableStateSnapshotPtr table_snapshot_,
         IcebergDataSnapshotPtr data_snapshot_,
-        PersistentTableComponents persistent_components);
+        PersistentTableComponents persistent_components,
+        std::map<String, ObjectStoragePtr> & secondary_storages_);
 
     std::optional<DB::Iceberg::ManifestFileEntry> next();
 
@@ -62,7 +63,7 @@ private:
     PersistentTableComponents persistent_components;
     FilesGenerator files_generator;
     LoggerPtr log;
-
+    std::map<String, ObjectStoragePtr> & secondary_storages;
 
     // By Iceberg design it is difficult to avoid storing position deletes in memory.
     size_t manifest_file_index = 0;
@@ -90,7 +91,8 @@ public:
         IDataLakeMetadata::FileProgressCallback callback_,
         Iceberg::IcebergTableStateSnapshotPtr table_snapshot_,
         Iceberg::IcebergDataSnapshotPtr data_snapshot_,
-        Iceberg::PersistentTableComponents persistent_components_);
+        Iceberg::PersistentTableComponents persistent_components_,
+        std::map<String, ObjectStoragePtr> & secondary_storages_);
 
     ObjectInfoPtr next(size_t) override;
 
@@ -114,6 +116,7 @@ private:
     std::mutex exception_mutex;
     Iceberg::PersistentTableComponents persistent_components;
     Int32 table_schema_id;
+    std::map<String, ObjectStoragePtr> & secondary_storages;
 };
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -501,7 +501,8 @@ void IcebergMetadata::updateSnapshot(ContextPtr local_context, Poco::JSON::Objec
 
             auto [partition_key, sorting_key] = extractIcebergKeys(metadata_object);
 
-            auto [storage_to_use, key_in_storage] = resolveObjectStorageForPath(persistent_components.table_location, snapshot->getValue<String>(f_manifest_list), object_storage, secondary_storages, local_context);
+            String manifest_list_path = snapshot->getValue<String>(f_manifest_list);
+            auto [storage_to_use, key_in_storage] = resolveObjectStorageForPath(persistent_components.table_location, manifest_list_path, object_storage, secondary_storages, local_context);
 
             relevant_snapshot = std::make_shared<IcebergDataSnapshot>(
                 getManifestList(
@@ -510,7 +511,7 @@ void IcebergMetadata::updateSnapshot(ContextPtr local_context, Poco::JSON::Objec
                 persistent_components,
                     local_context,
                     key_in_storage,
-                    makeAbsolutePath(persistent_components.table_location, snapshot->getValue<String>(f_manifest_list)),
+                    makeAbsolutePath(persistent_components.table_location, manifest_list_path),
                 log),
                 relevant_snapshot_id,
                 total_rows,
@@ -635,7 +636,7 @@ std::shared_ptr<NamesAndTypesList> IcebergMetadata::getInitialSchemaByPath(Conte
         : nullptr;
 }
 
-std::shared_ptr<const ActionsDAG> IcebergMetadata::getSchemaTransformer(ContextPtr context_, ObjectInfoPtr object_info) const
+std::shared_ptr<const ActionsDAG> IcebergMetadata::getSchemaTransformer(ContextPtr local_context, ObjectInfoPtr object_info) const
 {
     IcebergDataObjectInfo * iceberg_object_info = dynamic_cast<IcebergDataObjectInfo *>(object_info.get());
     SharedLockGuard lock(mutex);
@@ -643,7 +644,7 @@ std::shared_ptr<const ActionsDAG> IcebergMetadata::getSchemaTransformer(ContextP
         return nullptr;
     return (iceberg_object_info->underlying_format_read_schema_id != relevant_snapshot_schema_id)
         ? persistent_components.schema_processor->getSchemaTransformationDagByIds(
-            context_,
+            local_context,
             iceberg_object_info->underlying_format_read_schema_id,
             relevant_snapshot_schema_id)
         : nullptr;
@@ -1012,7 +1013,8 @@ ObjectIterator IcebergMetadata::iterate(
         callback,
         table_snapshot,
         relevant_snapshot,
-        persistent_components);
+        persistent_components,
+        secondary_storages);
 }
 
 NamesAndTypesList IcebergMetadata::getTableSchema() const
@@ -1050,7 +1052,7 @@ void IcebergMetadata::addDeleteTransformers(
         LOG_DEBUG(log, "Constructing filter transform for position delete, there are {} delete objects", iceberg_object_info->position_deletes_objects.size());
         builder.addSimpleTransform(
             [&](const SharedHeader & header)
-            { return iceberg_object_info->getPositionDeleteTransformer(object_storage, header, format_settings, local_context); });
+            { return iceberg_object_info->getPositionDeleteTransformer(object_storage, header, format_settings, local_context, persistent_components.table_location, secondary_storages); });
     }
     const auto & delete_files = iceberg_object_info->equality_deletes_objects;
     if (!delete_files.empty())
@@ -1061,9 +1063,14 @@ void IcebergMetadata::addDeleteTransformers(
         {
             /// get header of delete file
             Block delete_file_header;
-            ObjectInfo delete_file_object(delete_file.file_path);
+            // Resolve the delete file path to get the correct storage and key
+            // This handles cases where delete files are outside the table location
+            auto [delete_storage_to_use, resolved_delete_key] = resolveObjectStorageForPath(
+                persistent_components.table_location, delete_file.file_path, object_storage, secondary_storages, local_context);
+            
+            PathWithMetadata delete_file_object(resolved_delete_key, std::nullopt, delete_file.file_path, delete_storage_to_use);
             {
-                auto schema_read_buffer = createReadBuffer(delete_file_object, object_storage, local_context, log);
+                auto schema_read_buffer = createReadBuffer(delete_file_object, delete_storage_to_use, local_context, log);
                 auto schema_reader = FormatFactory::instance().getSchemaReader(delete_file.file_format, *schema_read_buffer, local_context);
                 auto columns_with_names = schema_reader->readSchema();
                 ColumnsWithTypeAndName initial_header_data;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -1093,7 +1093,7 @@ void IcebergMetadata::addDeleteTransformers(
             }
             /// Then we read the content of the delete file.
             auto mutable_columns_for_set = block_for_set.cloneEmptyColumns();
-            std::unique_ptr<ReadBuffer> data_read_buffer = createReadBuffer(delete_file_object, object_storage, local_context, log);
+            std::unique_ptr<ReadBuffer> data_read_buffer = createReadBuffer(delete_file_object, delete_storage_to_use, local_context, log);
             CompressionMethod compression_method = chooseCompressionMethod(delete_file.file_path, "auto");
             auto delete_format = FormatFactory::instance().getInput(
                 delete_file.file_format,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -500,17 +500,17 @@ void IcebergMetadata::updateSnapshot(ContextPtr local_context, Poco::JSON::Objec
             }
 
             auto [partition_key, sorting_key] = extractIcebergKeys(metadata_object);
+
+            auto [storage_to_use, key_in_storage] = resolveObjectStorageForPath(persistent_components.table_location, snapshot->getValue<String>(f_manifest_list), object_storage, secondary_storages, local_context);
+
             relevant_snapshot = std::make_shared<IcebergDataSnapshot>(
                 getManifestList(
-                object_storage,
+                    storage_to_use,
                 configuration_ptr,
                 persistent_components,
-                local_context,
-                getProperFilePathFromMetadataInfo(
-                    snapshot->getValue<String>(f_manifest_list),
-                    configuration_ptr->getPathForRead().path,
-                    persistent_components.table_location,
-                    configuration_ptr->getNamespace()),
+                    local_context,
+                    key_in_storage,
+                    makeAbsolutePath(persistent_components.table_location, snapshot->getValue<String>(f_manifest_list)),
                 log),
                 relevant_snapshot_id,
                 total_rows,
@@ -548,6 +548,7 @@ bool IcebergMetadata::optimize(const StorageMetadataPtr & metadata_snapshot, Con
             snapshots_info,
             persistent_components,
             object_storage,
+            secondary_storages,
             configuration_ptr,
             format_settings,
             sample_block,
@@ -925,9 +926,10 @@ std::optional<size_t> IcebergMetadata::totalRows(ContextPtr local_context) const
             persistent_components,
             local_context,
             log,
-            manifest_list_entry.manifest_file_path,
+            manifest_list_entry.manifest_file_absolute_path,
             manifest_list_entry.added_sequence_number,
-            manifest_list_entry.added_snapshot_id);
+            manifest_list_entry.added_snapshot_id,
+            secondary_storages);
         auto data_count = manifest_file_ptr->getRowsCountInAllFilesExcludingDeleted(FileContentType::DATA);
         auto position_deletes_count = manifest_file_ptr->getRowsCountInAllFilesExcludingDeleted(FileContentType::POSITION_DELETE);
         if (!data_count.has_value() || !position_deletes_count.has_value())
@@ -965,9 +967,10 @@ std::optional<size_t> IcebergMetadata::totalBytes(ContextPtr local_context) cons
             persistent_components,
             local_context,
             log,
-            manifest_list_entry.manifest_file_path,
+            manifest_list_entry.manifest_file_absolute_path,
             manifest_list_entry.added_sequence_number,
-            manifest_list_entry.added_snapshot_id);
+            manifest_list_entry.added_snapshot_id,
+            secondary_storages);
         auto count = manifest_file_ptr->getBytesCountInAllDataFilesExcludingDeleted();
         if (!count.has_value())
             return {};

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -133,6 +133,7 @@ IcebergMetadata::IcebergMetadata(
     IcebergMetadataFilesCachePtr cache_ptr,
     CompressionMethod metadata_compression_method_)
     : object_storage(std::move(object_storage_))
+    , secondary_storages(std::make_shared<SecondaryStorages>())
     , configuration(std::move(configuration_))
     , persistent_components(PersistentTableComponents{
           .schema_processor = std::make_shared<IcebergSchemaProcessor>(context_),
@@ -502,7 +503,7 @@ void IcebergMetadata::updateSnapshot(ContextPtr local_context, Poco::JSON::Objec
             auto [partition_key, sorting_key] = extractIcebergKeys(metadata_object);
 
             String manifest_list_path = snapshot->getValue<String>(f_manifest_list);
-            auto [storage_to_use, key_in_storage] = resolveObjectStorageForPath(persistent_components.table_location, manifest_list_path, object_storage, secondary_storages, local_context);
+            auto [storage_to_use, key_in_storage] = resolveObjectStorageForPath(persistent_components.table_location, manifest_list_path, object_storage, *secondary_storages, local_context);
 
             relevant_snapshot = std::make_shared<IcebergDataSnapshot>(
                 getManifestList(
@@ -549,7 +550,7 @@ bool IcebergMetadata::optimize(const StorageMetadataPtr & metadata_snapshot, Con
             snapshots_info,
             persistent_components,
             object_storage,
-            secondary_storages,
+            *secondary_storages,
             configuration_ptr,
             format_settings,
             sample_block,
@@ -930,7 +931,7 @@ std::optional<size_t> IcebergMetadata::totalRows(ContextPtr local_context) const
             manifest_list_entry.manifest_file_absolute_path,
             manifest_list_entry.added_sequence_number,
             manifest_list_entry.added_snapshot_id,
-            secondary_storages);
+            *secondary_storages);
         auto data_count = manifest_file_ptr->getRowsCountInAllFilesExcludingDeleted(FileContentType::DATA);
         auto position_deletes_count = manifest_file_ptr->getRowsCountInAllFilesExcludingDeleted(FileContentType::POSITION_DELETE);
         if (!data_count.has_value() || !position_deletes_count.has_value())
@@ -971,7 +972,7 @@ std::optional<size_t> IcebergMetadata::totalBytes(ContextPtr local_context) cons
             manifest_list_entry.manifest_file_absolute_path,
             manifest_list_entry.added_sequence_number,
             manifest_list_entry.added_snapshot_id,
-            secondary_storages);
+            *secondary_storages);
         auto count = manifest_file_ptr->getBytesCountInAllDataFilesExcludingDeleted();
         if (!count.has_value())
             return {};
@@ -1052,7 +1053,7 @@ void IcebergMetadata::addDeleteTransformers(
         LOG_DEBUG(log, "Constructing filter transform for position delete, there are {} delete objects", iceberg_object_info->position_deletes_objects.size());
         builder.addSimpleTransform(
             [&](const SharedHeader & header)
-            { return iceberg_object_info->getPositionDeleteTransformer(object_storage, header, format_settings, local_context, persistent_components.table_location, secondary_storages); });
+            { return iceberg_object_info->getPositionDeleteTransformer(object_storage, header, format_settings, local_context, persistent_components.table_location, *secondary_storages); });
     }
     const auto & delete_files = iceberg_object_info->equality_deletes_objects;
     if (!delete_files.empty())
@@ -1065,7 +1066,7 @@ void IcebergMetadata::addDeleteTransformers(
             Block delete_file_header;
 
             auto [delete_storage_to_use, resolved_delete_key] = resolveObjectStorageForPath(
-                persistent_components.table_location, delete_file.file_path, object_storage, secondary_storages, local_context);
+                persistent_components.table_location, delete_file.file_path, object_storage, *secondary_storages, local_context);
             
             PathWithMetadata delete_file_object(resolved_delete_key, std::nullopt, delete_file.file_path, delete_storage_to_use);
             {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -1063,8 +1063,7 @@ void IcebergMetadata::addDeleteTransformers(
         {
             /// get header of delete file
             Block delete_file_header;
-            // Resolve the delete file path to get the correct storage and key
-            // This handles cases where delete files are outside the table location
+
             auto [delete_storage_to_use, resolved_delete_key] = resolveObjectStorageForPath(
                 persistent_components.table_location, delete_file.file_path, object_storage, secondary_storages, local_context);
             

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -129,11 +129,19 @@ public:
     std::optional<String> sortingKey(ContextPtr) const override;
 
 protected:
+    ObjectIterator createIcebergKeysIterator(
+        Strings && data_files_,
+        ObjectStoragePtr,
+        IDataLakeMetadata::FileProgressCallback callback_,
+        ContextPtr local_context);
+
     ObjectIterator
     iterate(const ActionsDAG * filter_dag, FileProgressCallback callback, size_t list_batch_size, ContextPtr local_context) const override;
 
 private:
     const ObjectStoragePtr object_storage;
+    mutable std::map<String, ObjectStoragePtr> secondary_storages; // Sometimes data or manifests can be located on another storage
+
     const StorageObjectStorageConfigurationWeakPtr configuration;
 
     DB::Iceberg::PersistentTableComponents persistent_components;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -28,6 +28,7 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergIterator.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.h>
+#include <Storages/ObjectStorage/Utils.h>
 
 namespace DB
 {
@@ -140,7 +141,7 @@ protected:
 
 private:
     const ObjectStoragePtr object_storage;
-    mutable std::map<String, ObjectStoragePtr> secondary_storages; // Sometimes data or manifests can be located on another storage
+    mutable std::shared_ptr<SecondaryStorages> secondary_storages; // Sometimes data or manifests can be located on another storage
 
     const StorageObjectStorageConfigurationWeakPtr configuration;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -32,6 +32,7 @@ namespace DB
 struct ManifestFileCacheKey
 {
     String manifest_file_path;
+    String manifest_file_absolute_path;
     Int64 added_sequence_number;
     Int64 added_snapshot_id;
     Iceberg::ManifestFileContentType content_type;
@@ -73,7 +74,7 @@ private:
          size_t total_size = 0;
          for (const auto & entry: manifest_file_cache_keys)
          {
-             total_size += sizeof(ManifestFileCacheKey) + entry.manifest_file_path.capacity();
+             total_size += sizeof(ManifestFileCacheKey) + entry.manifest_file_absolute_path.capacity();
          }
          return total_size;
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -74,7 +74,7 @@ private:
          size_t total_size = 0;
          for (const auto & entry: manifest_file_cache_keys)
          {
-             total_size += sizeof(ManifestFileCacheKey) + entry.manifest_file_absolute_path.capacity();
+             total_size += sizeof(ManifestFileCacheKey) + entry.manifest_file_path.capacity() + entry.manifest_file_absolute_path.capacity();
          }
          return total_size;
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadataFilesCache.h
@@ -31,7 +31,6 @@ namespace DB
 /// And we can get `ManifestFileContent` from cache by ManifestFileEntry.
 struct ManifestFileCacheKey
 {
-    String manifest_file_path;
     String manifest_file_absolute_path;
     Int64 added_sequence_number;
     Int64 added_snapshot_id;
@@ -74,7 +73,7 @@ private:
          size_t total_size = 0;
          for (const auto & entry: manifest_file_cache_keys)
          {
-             total_size += sizeof(ManifestFileCacheKey) + entry.manifest_file_path.capacity() + entry.manifest_file_absolute_path.capacity();
+             total_size += sizeof(ManifestFileCacheKey) + entry.manifest_file_absolute_path.capacity();
          }
          return total_size;
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -8,9 +8,9 @@
 #include <Interpreters/IcebergMetadataLog.h>
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
-#include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.h>
+#include <Storages/ObjectStorage/Utils.h>
 
 #include <Core/TypeId.h>
 #include <DataTypes/DataTypesDecimal.h>
@@ -150,7 +150,6 @@ ManifestFileContent::ManifestFileContent(
     Int64 inherited_sequence_number,
     Int64 inherited_snapshot_id,
     const String & table_location,
-    const String & common_namespace,
     DB::ContextPtr context,
     const String & path_to_manifest_file_)
     : path_to_manifest_file(path_to_manifest_file_)
@@ -244,7 +243,6 @@ ManifestFileContent::ManifestFileContent(
             content_type = FileContentType(manifest_file_deserializer.getValueFromRowByName(i, c_data_file_content, TypeIndex::Int32).safeGet<UInt64>());
         const auto status = ManifestEntryStatus(manifest_file_deserializer.getValueFromRowByName(i, f_status, TypeIndex::Int32).safeGet<UInt64>());
 
-
         if (status == ManifestEntryStatus::DELETED)
             continue;
 
@@ -289,11 +287,9 @@ ManifestFileContent::ManifestFileContent(
 
         const auto file_path_key
             = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_file_path, TypeIndex::String).safeGet<String>();
-        const auto file_path = getProperFilePathFromMetadataInfo(
-            manifest_file_deserializer.getValueFromRowByName(i, c_data_file_file_path, TypeIndex::String).safeGet<String>(),
-            common_path,
+        const auto file_path = makeAbsolutePath(
             table_location,
-            common_namespace);
+            manifest_file_deserializer.getValueFromRowByName(i, c_data_file_file_path, TypeIndex::String).safeGet<String>());
 
         /// NOTE: This is weird, because in manifest file partition looks like this:
         /// {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -285,11 +285,9 @@ ManifestFileContent::ManifestFileContent(
         }
         const auto schema_id = schema_id_opt.has_value() ? schema_id_opt.value() : manifest_schema_id;
 
-        const auto file_path_key
-            = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_file_path, TypeIndex::String).safeGet<String>();
-        const auto file_path = makeAbsolutePath(
-            table_location,
-            manifest_file_deserializer.getValueFromRowByName(i, c_data_file_file_path, TypeIndex::String).safeGet<String>());
+        const auto file_path_key_field = manifest_file_deserializer.getValueFromRowByName(i, c_data_file_file_path, TypeIndex::String);
+        const auto file_path_key = file_path_key_field.safeGet<String>();
+        const auto file_path = makeAbsolutePath(table_location, file_path_key);
 
         /// NOTE: This is weird, because in manifest file partition looks like this:
         /// {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h
@@ -124,7 +124,6 @@ public:
         Int64 inherited_sequence_number,
         Int64 inherited_snapshot_id,
         const std::string & table_location,
-        const std::string & common_namespace,
         DB::ContextPtr context,
         const String & path_to_manifest_file_);
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -168,15 +168,19 @@ std::optional<DeleteFileWriteResultWithStats> writeDataFiles(
                     Field cur_value;
                     col_data_filename.column->get(i, cur_value);
 
+                    String original_path = cur_value.safeGet<String>();
                     String path_without_namespace;
-                    if (cur_value.safeGet<String>().starts_with(configuration->getNamespace()))
-                        path_without_namespace = cur_value.safeGet<String>().substr(configuration->getNamespace().size());
 
-                    if (!path_without_namespace.starts_with(configuration->getPathForRead().path))
+                    if (original_path.starts_with(configuration->getNamespace()))
+                        path_without_namespace = original_path.substr(configuration->getNamespace().size());
+                    else
+                        path_without_namespace = original_path;
+
+                    if (!path_without_namespace.empty() && !path_without_namespace.starts_with(configuration->getPathForRead().path))
                     {
                         if (path_without_namespace.starts_with('/'))
                             path_without_namespace = path_without_namespace.substr(1);
-                        else
+                        else if (!path_without_namespace.empty())
                             path_without_namespace = "/" + path_without_namespace;
                     }
                     col_data_filename_without_namespaces->insert(path_without_namespace);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
@@ -67,7 +67,7 @@ void IcebergPositionDeleteTransform::initializeDeleteSources()
     {
         /// Skip position deletes that do not match the data file path.
         if (position_deletes_object.reference_data_file_path.has_value()
-            && position_deletes_object.reference_data_file_path != iceberg_data_path)
+            && position_deletes_object.reference_data_file_path.value() != iceberg_data_path)
             continue;
 
         /// Resolve the position delete file path to get the correct storage and key
@@ -192,10 +192,8 @@ void IcebergBitmapPositionDeleteTransform::initialize()
         while (auto delete_chunk = delete_source->read())
         {
             int position_index = getColumnIndex(delete_source, IcebergPositionDeleteTransform::positions_column_name);
-            int filename_index = getColumnIndex(delete_source, IcebergPositionDeleteTransform::data_file_path_column_name);
 
             auto position_column = delete_chunk.getColumns()[position_index];
-            auto filename_column = delete_chunk.getColumns()[filename_index];
 
             for (size_t i = 0; i < delete_chunk.getNumRows(); ++i)
             {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
@@ -70,15 +70,19 @@ void IcebergPositionDeleteTransform::initializeDeleteSources()
             && position_deletes_object.reference_data_file_path != iceberg_data_path)
             continue;
 
-        auto object_path = position_deletes_object.file_path;
-        auto object_metadata = object_storage->getObjectMetadata(object_path);
-        auto object_info = std::make_shared<ObjectInfo>(object_path, object_metadata);
+        /// Resolve the position delete file path to get the correct storage and key
+        /// This handles cases where delete files are outside the table location
+        auto [delete_storage_to_use, resolved_delete_key] = resolveObjectStorageForPath(
+            table_location, position_deletes_object.file_path, object_storage, secondary_storages, context);
+        
+        auto object_metadata = delete_storage_to_use->getObjectMetadata(resolved_delete_key);
+        PathWithMetadata delete_file_object(resolved_delete_key, object_metadata, position_deletes_object.file_path, delete_storage_to_use);
 
 
         String format = position_deletes_object.file_format;
         Block initial_header;
         {
-            std::unique_ptr<ReadBuffer> read_buf_schema = createReadBuffer(*object_info, object_storage, context, log);
+            std::unique_ptr<ReadBuffer> read_buf_schema = createReadBuffer(delete_file_object, delete_storage_to_use, context, log);
             auto schema_reader = FormatFactory::instance().getSchemaReader(format, *read_buf_schema, context);
             auto columns_with_names = schema_reader->readSchema();
             ColumnsWithTypeAndName initial_header_data;
@@ -89,9 +93,9 @@ void IcebergPositionDeleteTransform::initializeDeleteSources()
             initial_header = Block(initial_header_data);
         }
 
-        CompressionMethod compression_method = chooseCompressionMethod(object_path, "auto");
+        CompressionMethod compression_method = chooseCompressionMethod(resolved_delete_key, "auto");
 
-        delete_read_buffers.push_back(createReadBuffer(*object_info, object_storage, context, log));
+        delete_read_buffers.push_back(createReadBuffer(delete_file_object, delete_storage_to_use, context, log));
 
         auto syntax_result = TreeRewriter(context).analyze(where_ast, initial_header.getNamesAndTypesList());
         ExpressionAnalyzer analyzer(where_ast, syntax_result, context);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h
@@ -27,13 +27,17 @@ public:
         IcebergDataObjectInfoPtr iceberg_object_info_,
         ObjectStoragePtr object_storage_,
         const std::optional<FormatSettings> & format_settings_,
-        ContextPtr context_)
+        ContextPtr context_,
+        const String & table_location_,
+        std::map<String, ObjectStoragePtr> & secondary_storages_)
         : ISimpleTransform(header_, header_, false)
         , header(header_)
         , iceberg_object_info(iceberg_object_info_)
         , object_storage(object_storage_)
         , format_settings(format_settings_)
         , context(context_)
+        , table_location(table_location_)
+        , secondary_storages(secondary_storages_)
     {
         initializeDeleteSources();
     }
@@ -52,6 +56,8 @@ protected:
     const ObjectStoragePtr object_storage;
     const std::optional<FormatSettings> format_settings;
     ContextPtr context;
+    const String table_location;
+    std::map<String, ObjectStoragePtr> & secondary_storages;
 
     /// We need to keep the read buffers alive since the delete_sources depends on them.
     std::vector<std::unique_ptr<ReadBuffer>> delete_read_buffers;
@@ -66,8 +72,10 @@ public:
         IcebergDataObjectInfoPtr iceberg_object_info_,
         ObjectStoragePtr object_storage_,
         const std::optional<FormatSettings> & format_settings_,
-        ContextPtr context_)
-        : IcebergPositionDeleteTransform(header_, iceberg_object_info_, object_storage_, format_settings_, context_)
+        ContextPtr context_,
+        const String & table_location_,
+        std::map<String, ObjectStoragePtr> & secondary_storages_)
+        : IcebergPositionDeleteTransform(header_, iceberg_object_info_, object_storage_, format_settings_, context_, table_location_, secondary_storages_)
     {
         initialize();
     }
@@ -91,8 +99,10 @@ public:
         IcebergDataObjectInfoPtr iceberg_object_info_,
         ObjectStoragePtr object_storage_,
         const std::optional<FormatSettings> & format_settings_,
-        ContextPtr context_)
-        : IcebergPositionDeleteTransform(header_, iceberg_object_info_, object_storage_, format_settings_, context_)
+        ContextPtr context_,
+        const String & table_location_,
+        std::map<String, ObjectStoragePtr> & secondary_storages_)
+        : IcebergPositionDeleteTransform(header_, iceberg_object_info_, object_storage_, format_settings_, context_, table_location_, secondary_storages_)
     {
         initialize();
     }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h
@@ -29,7 +29,7 @@ public:
         const std::optional<FormatSettings> & format_settings_,
         ContextPtr context_,
         const String & table_location_,
-        std::map<String, ObjectStoragePtr> & secondary_storages_)
+        SecondaryStorages & secondary_storages_)
         : ISimpleTransform(header_, header_, false)
         , header(header_)
         , iceberg_object_info(iceberg_object_info_)
@@ -57,7 +57,7 @@ protected:
     const std::optional<FormatSettings> format_settings;
     ContextPtr context;
     const String table_location;
-    std::map<String, ObjectStoragePtr> & secondary_storages;
+    SecondaryStorages & secondary_storages;
 
     /// We need to keep the read buffers alive since the delete_sources depends on them.
     std::vector<std::unique_ptr<ReadBuffer>> delete_read_buffers;
@@ -74,7 +74,7 @@ public:
         const std::optional<FormatSettings> & format_settings_,
         ContextPtr context_,
         const String & table_location_,
-        std::map<String, ObjectStoragePtr> & secondary_storages_)
+        SecondaryStorages & secondary_storages_)
         : IcebergPositionDeleteTransform(header_, iceberg_object_info_, object_storage_, format_settings_, context_, table_location_, secondary_storages_)
     {
         initialize();
@@ -101,7 +101,7 @@ public:
         const std::optional<FormatSettings> & format_settings_,
         ContextPtr context_,
         const String & table_location_,
-        std::map<String, ObjectStoragePtr> & secondary_storages_)
+        SecondaryStorages & secondary_storages_)
         : IcebergPositionDeleteTransform(header_, iceberg_object_info_, object_storage_, format_settings_, context_, table_location_, secondary_storages_)
     {
         initialize();

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h
@@ -46,6 +46,7 @@ struct IcebergHistoryRecord
     Int64 parent_id;
     bool is_current_ancestor;
     String manifest_list_path;
+    String manifest_list_absolute_path;
 
     Int32 added_files = 0;
     Int32 added_records = 0;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
@@ -85,7 +85,6 @@ Iceberg::ManifestFilePtr getManifestFile(
 
     auto create_fn = [&, use_iceberg_metadata_cache]()
     {
-        // Resolve the absolute path to get the correct storage and key_in_storage
         auto [storage_to_use, resolved_key_in_storage] = resolveObjectStorageForPath(
             persistent_table_components.table_location, absolute_path, object_storage, secondary_storages, local_context);
         

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
@@ -76,7 +76,7 @@ Iceberg::ManifestFilePtr getManifestFile(
     const String & absolute_path,
     Int64 inherited_sequence_number,
     Int64 inherited_snapshot_id,
-    std::map<String, ObjectStoragePtr> & secondary_storages)
+    SecondaryStorages & secondary_storages)
 {
     auto log_level = local_context->getSettingsRef()[Setting::iceberg_metadata_log_level].value;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
@@ -165,7 +165,7 @@ ManifestFileCacheKeys getManifestList(
         {
             const std::string file_path
                 = manifest_list_deserializer.getValueFromRowByName(i, f_manifest_path, TypeIndex::String).safeGet<std::string>();
-            const auto manifest_file_name = makeAbsolutePath(persistent_table_components.table_location, file_path);
+            const auto manifest_absolute_path = makeAbsolutePath(persistent_table_components.table_location, file_path);
             Int64 added_sequence_number = 0;
             auto added_snapshot_id = manifest_list_deserializer.getValueFromRowByName(i, f_added_snapshot_id);
             if (added_snapshot_id.isNull())
@@ -184,7 +184,7 @@ ManifestFileCacheKeys getManifestList(
                     manifest_list_deserializer.getValueFromRowByName(i, f_content, TypeIndex::Int32).safeGet<Int32>());
             }
             manifest_file_cache_keys.emplace_back(
-                file_path, manifest_file_name, added_sequence_number, added_snapshot_id.safeGet<Int64>(), content_type);
+                manifest_absolute_path, added_sequence_number, added_snapshot_id.safeGet<Int64>(), content_type);
 
             auto dump_row_metadata = [&]()->String { return manifest_list_deserializer.getContent(i); };
             insertRowToLogTable(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
@@ -73,9 +73,10 @@ Iceberg::ManifestFilePtr getManifestFile(
     const PersistentTableComponents & persistent_table_components,
     ContextPtr local_context,
     LoggerPtr log,
-    const String & filename,
+    const String & absolute_path,
     Int64 inherited_sequence_number,
-    Int64 inherited_snapshot_id)
+    Int64 inherited_snapshot_id,
+    std::map<String, ObjectStoragePtr> & secondary_storages)
 {
     auto log_level = local_context->getSettingsRef()[Setting::iceberg_metadata_log_level].value;
 
@@ -84,34 +85,37 @@ Iceberg::ManifestFilePtr getManifestFile(
 
     auto create_fn = [&, use_iceberg_metadata_cache]()
     {
-        RelativePathWithMetadata manifest_object_info(filename);
+        // Resolve the absolute path to get the correct storage and key_in_storage
+        auto [storage_to_use, resolved_key_in_storage] = resolveObjectStorageForPath(
+            persistent_table_components.table_location, absolute_path, object_storage, secondary_storages, local_context);
+        
+        PathWithMetadata manifest_object_info(resolved_key_in_storage, std::nullopt, absolute_path, storage_to_use);
 
         auto read_settings = local_context->getReadSettings();
         /// Do not utilize filesystem cache if more precise cache enabled
         if (use_iceberg_metadata_cache)
             read_settings.enable_filesystem_cache = false;
 
-        auto buffer = createReadBuffer(manifest_object_info, object_storage, local_context, log, read_settings);
-        Iceberg::AvroForIcebergDeserializer manifest_file_deserializer(std::move(buffer), filename, getFormatSettings(local_context));
+        auto buffer = createReadBuffer(manifest_object_info, storage_to_use, local_context, log, read_settings);
+        Iceberg::AvroForIcebergDeserializer manifest_file_deserializer(std::move(buffer), resolved_key_in_storage, getFormatSettings(local_context));
 
         return std::make_shared<Iceberg::ManifestFileContent>(
             manifest_file_deserializer,
-            filename,
+            resolved_key_in_storage,
             persistent_table_components.format_version,
             configuration->getPathForRead().path,
             *persistent_table_components.schema_processor,
             inherited_sequence_number,
             inherited_snapshot_id,
             persistent_table_components.table_location,
-            configuration->getNamespace(),
             local_context,
-            filename);
+            absolute_path);
     };
 
     if (use_iceberg_metadata_cache)
     {
         auto manifest_file = persistent_table_components.metadata_cache->getOrSetManifestFile(
-            IcebergMetadataFilesCache::getKey(configuration, filename), create_fn);
+            IcebergMetadataFilesCache::getKey(configuration, absolute_path), create_fn);
         return manifest_file;
     }
     return create_fn();
@@ -122,7 +126,8 @@ ManifestFileCacheKeys getManifestList(
     StorageObjectStorageConfigurationWeakPtr configuration,
     const PersistentTableComponents & persistent_table_components,
     ContextPtr local_context,
-    const String & filename,
+    const String & key_in_storage,
+    const String & absolute_path,
     LoggerPtr log)
 {
     auto configuration_ptr = configuration.lock();
@@ -136,7 +141,7 @@ ManifestFileCacheKeys getManifestList(
 
     auto create_fn = [&, use_iceberg_metadata_cache]()
     {
-        StorageObjectStorage::ObjectInfo object_info(filename);
+        PathWithMetadata object_info(key_in_storage, std::nullopt, absolute_path, object_storage);
 
         auto read_settings = local_context->getReadSettings();
         /// Do not utilize filesystem cache if more precise cache enabled
@@ -144,7 +149,7 @@ ManifestFileCacheKeys getManifestList(
             read_settings.enable_filesystem_cache = false;
 
         auto manifest_list_buf = createReadBuffer(object_info, object_storage, local_context, log, read_settings);
-        AvroForIcebergDeserializer manifest_list_deserializer(std::move(manifest_list_buf), filename, getFormatSettings(local_context));
+        AvroForIcebergDeserializer manifest_list_deserializer(std::move(manifest_list_buf), key_in_storage, getFormatSettings(local_context));
 
         ManifestFileCacheKeys manifest_file_cache_keys;
 
@@ -154,18 +159,14 @@ ManifestFileCacheKeys getManifestList(
             dump_metadata,
             DB::IcebergMetadataLogLevel::ManifestListMetadata,
             configuration_ptr->getRawPath().path,
-            filename,
+            key_in_storage,
             std::nullopt);
 
         for (size_t i = 0; i < manifest_list_deserializer.rows(); ++i)
         {
             const std::string file_path
                 = manifest_list_deserializer.getValueFromRowByName(i, f_manifest_path, TypeIndex::String).safeGet<std::string>();
-            const auto manifest_file_name = getProperFilePathFromMetadataInfo(
-                file_path,
-                configuration_ptr->getPathForRead().path,
-                persistent_table_components.table_location,
-                configuration_ptr->getNamespace());
+            const auto manifest_file_name = makeAbsolutePath(persistent_table_components.table_location, file_path);
             Int64 added_sequence_number = 0;
             auto added_snapshot_id = manifest_list_deserializer.getValueFromRowByName(i, f_added_snapshot_id);
             if (added_snapshot_id.isNull())
@@ -184,7 +185,7 @@ ManifestFileCacheKeys getManifestList(
                     manifest_list_deserializer.getValueFromRowByName(i, f_content, TypeIndex::Int32).safeGet<Int32>());
             }
             manifest_file_cache_keys.emplace_back(
-                manifest_file_name, added_sequence_number, added_snapshot_id.safeGet<Int64>(), content_type);
+                file_path, manifest_file_name, added_sequence_number, added_snapshot_id.safeGet<Int64>(), content_type);
 
             auto dump_row_metadata = [&]()->String { return manifest_list_deserializer.getContent(i); };
             insertRowToLogTable(
@@ -192,7 +193,7 @@ ManifestFileCacheKeys getManifestList(
                 dump_row_metadata,
                 DB::IcebergMetadataLogLevel::ManifestListEntry,
                 configuration_ptr->getRawPath().path,
-                filename,
+                absolute_path,
                 i);
         }
         /// We only return the list of {file name, seq number} for cache.
@@ -204,7 +205,7 @@ ManifestFileCacheKeys getManifestList(
     ManifestFileCacheKeys manifest_file_cache_keys;
     if (use_iceberg_metadata_cache)
         manifest_file_cache_keys = persistent_table_components.metadata_cache->getOrSetManifestFileCacheKeys(
-            IcebergMetadataFilesCache::getKey(configuration_ptr, filename), create_fn);
+            IcebergMetadataFilesCache::getKey(configuration_ptr, absolute_path), create_fn);
     else
         manifest_file_cache_keys = create_fn();
     return manifest_file_cache_keys;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.h
@@ -19,6 +19,7 @@
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PersistentTableComponents.h>
+#include <Storages/ObjectStorage/Utils.h>
 
 namespace DB::Iceberg
 {
@@ -32,7 +33,7 @@ Iceberg::ManifestFilePtr getManifestFile(
     const String & absolute_path,
     Int64 inherited_sequence_number,
     Int64 inherited_snapshot_id,
-    std::map<String, ObjectStoragePtr> & secondary_storages);
+    SecondaryStorages & secondary_storages);
 
 
 ManifestFileCacheKeys getManifestList(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.h
@@ -29,9 +29,10 @@ Iceberg::ManifestFilePtr getManifestFile(
     const PersistentTableComponents & persistent_table_components,
     ContextPtr local_context,
     LoggerPtr log,
-    const String & filename,
+    const String & absolute_path,
     Int64 inherited_sequence_number,
-    Int64 inherited_snapshot_id);
+    Int64 inherited_snapshot_id,
+    std::map<String, ObjectStoragePtr> & secondary_storages);
 
 
 ManifestFileCacheKeys getManifestList(
@@ -39,7 +40,8 @@ ManifestFileCacheKeys getManifestList(
     StorageObjectStorageConfigurationWeakPtr configuration,
     const PersistentTableComponents & persistent_table_components,
     ContextPtr local_context,
-    const String & filename,
+    const String & key_in_storage,
+    const String & absolute_path,
     LoggerPtr log);
 
 std::pair<Poco::JSON::Object::Ptr, Int32> parseTableSchemaV1Method(const Poco::JSON::Object::Ptr & metadata_object);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -78,7 +78,6 @@ namespace DB::Setting
 
 namespace DB::Iceberg
 {
-
 using namespace DB;
 
 void writeMessageToFile(
@@ -165,95 +164,6 @@ std::optional<TransformAndArgument> parseTransformAndArgument(const String & tra
         }
     }
     return std::nullopt;
-}
-
-// This function is used to get the file path inside the directory which corresponds to iceberg table from the full blob path which is written in manifest and metadata files.
-// For example, if the full blob path is s3://bucket/table_name/data/00000-1-1234567890.avro, the function will return table_name/data/00000-1-1234567890.avro
-// Common path should end with "<table_name>" or "<table_name>/".
-std::string getProperFilePathFromMetadataInfo(
-    std::string_view data_path,
-    std::string_view common_path,
-    std::string_view table_location,
-    std::string_view common_namespace)
-{
-    auto trim_backward_slash = [](std::string_view str) -> std::string_view
-    {
-        if (str.ends_with('/'))
-        {
-            return str.substr(0, str.size() - 1);
-        }
-        return str;
-    };
-    auto trim_forward_slash = [](std::string_view str) -> std::string_view
-    {
-        if (str.starts_with('/'))
-        {
-            return str.substr(1);
-        }
-        return str;
-    };
-    common_path = trim_backward_slash(common_path);
-    table_location = trim_backward_slash(table_location);
-
-    if (data_path.starts_with(table_location) && table_location.ends_with(common_path))
-    {
-        return std::filesystem::path{common_path} / trim_forward_slash(data_path.substr(table_location.size()));
-    }
-
-
-    auto pos = data_path.find(common_path);
-    /// Valid situation when data and metadata files are stored in different directories.
-    if (pos == std::string::npos)
-    {
-        /// connection://bucket
-        auto prefix = table_location.substr(0, table_location.size() - common_path.size());
-        return std::string{data_path.substr(prefix.size())};
-    }
-
-    size_t good_pos = std::string::npos;
-    while (pos != std::string::npos)
-    {
-        auto potential_position = pos + common_path.size();
-        if ((std::string_view(data_path.data() + potential_position, 6) == "/data/")
-            || (std::string_view(data_path.data() + potential_position, 10) == "/metadata/"))
-        {
-            good_pos = pos;
-            break;
-        }
-        size_t new_pos = data_path.find(common_path, pos + 1);
-        if (new_pos == std::string::npos)
-        {
-            break;
-        }
-        pos = new_pos;
-    }
-
-
-    if (good_pos != std::string::npos)
-    {
-        return std::string{data_path.substr(good_pos)};
-    }
-    else if (pos != std::string::npos)
-    {
-        return std::string{data_path.substr(pos)};
-    }
-    else
-    {
-        /// Data files can have different path
-        pos = data_path.find("://");
-        if (pos == std::string::npos)
-            throw ::DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unexpected data path: '{}'", data_path);
-        pos = data_path.find('/', pos + 3);
-        if (pos == std::string::npos)
-            throw ::DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unexpected data path: '{}'", data_path);
-        if (data_path.substr(pos + 1).starts_with(common_namespace))
-        {
-            auto new_pos = data_path.find('/', pos + 1);
-            if (new_pos - pos == common_namespace.length() + 1) /// bucket in the path
-                pos = new_pos;
-        }
-        return std::string(data_path.substr(pos));
-    }
 }
 
 enum class MostRecentMetadataFileSelectionWay

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
@@ -1,7 +1,10 @@
 #pragma once
 
+
+#include <Interpreters/Context_fwd.h>
 #include "config.h"
 
+#include <map>
 #include <string>
 #include <string_view>
 
@@ -30,12 +33,6 @@ void writeMessageToFile(
     DB::ContextPtr context,
     std::function<void()> cleanup,
     DB::CompressionMethod compression_method = DB::CompressionMethod::None);
-
-std::string getProperFilePathFromMetadataInfo(
-    std::string_view data_path,
-    std::string_view common_path,
-    std::string_view table_location,
-    std::string_view common_namespace);
 
 struct TransformAndArgument
 {

--- a/src/Storages/ObjectStorage/IObjectIterator.h
+++ b/src/Storages/ObjectStorage/IObjectIterator.h
@@ -5,8 +5,8 @@
 namespace DB
 {
 
-using ObjectInfo = RelativePathWithMetadata;
-using ObjectInfoPtr = std::shared_ptr<RelativePathWithMetadata>;
+using ObjectInfo = PathWithMetadata;
+using ObjectInfoPtr = std::shared_ptr<PathWithMetadata>;
 class ExpressionActions;
 
 struct IObjectIterator

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -37,7 +37,10 @@ struct IPartitionStrategy;
 class StorageObjectStorage : public IStorage
 {
 public:
-    using ObjectInfo = RelativePathWithMetadata;
+    class Configuration;
+    using ConfigurationPtr = std::shared_ptr<Configuration>;
+    using ConfigurationObserverPtr = std::weak_ptr<Configuration>;
+    using ObjectInfo = PathWithMetadata;
     using ObjectInfoPtr = std::shared_ptr<ObjectInfo>;
     using ObjectInfos = std::vector<ObjectInfoPtr>;
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -500,7 +500,9 @@ public:
     {
         auto task = task_distributor.getNextTask(number_of_current_replica);
         if (task)
+        {
             return std::make_shared<ClusterFunctionReadTaskResponse>(std::move(task), context);
+        }
         return std::make_shared<ClusterFunctionReadTaskResponse>();
     }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -346,10 +346,14 @@ Chunk StorageObjectStorageSource::generate()
                     path);
             }
 
+            /// For _path column, use absolute_path if available (e.g., file:///home/...)
+            /// Otherwise, fall back to the storage path identifier
+            std::string path_for_virtual_column = object_info->getAbsolutePath().value_or(path);
+
             VirtualColumnUtils::addRequestedFileLikeStorageVirtualsToChunk(
                 chunk,
                 read_from_format_info.requested_virtual_columns,
-                {.path = path,
+                {.path = path_for_virtual_column,
                  .size = object_info->isArchive() ? object_info->fileSizeInArchive() : object_info->metadata->size_bytes,
                  .filename = &filename,
                  .last_modified = object_info->metadata->last_modified,
@@ -484,8 +488,6 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
     ObjectInfoPtr object_info;
     auto query_settings = configuration->getQuerySettings(context_);
 
-    ObjectStoragePtr storage_to_use = object_storage;
-
     bool not_a_path = false;
 
     do
@@ -516,6 +518,8 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
         object_info->loadMetadata(object_storage, query_settings.ignore_non_existent_file);
     }
     while (not_a_path || (query_settings.skip_empty_files && object_info->metadata->size_bytes == 0));
+    
+    ObjectStoragePtr storage_to_use = object_info->getObjectStorage().value_or(object_storage);
 
     QueryPipelineBuilder builder;
     std::shared_ptr<ISource> source;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -1291,6 +1291,10 @@ StorageObjectStorageSource::ReadTaskIterator::ReadTaskIterator(
                     object->relative_path = key;
                 }
             }
+            else
+            {
+                object->object_storage_to_use = object_storage;
+            }
             buffer.push_back(object);
         }
     }
@@ -1315,17 +1319,20 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::ReadTaskIterator
 
         object_info = raw->getObjectInfo();
 
-        if (object_info->getObjectStorage().has_value())
-        {
-
-        }
-        else if (raw->absolute_path.has_value())
+        if (raw->absolute_path.has_value())
         {
             auto [storage_to_use, key]
                 = resolveObjectStorageForPath("", raw->absolute_path.value(), object_storage, secondary_storages, getContext());
 
-            if (!key.empty()) /// Not a valid key/path, maybe it is "retry_after_us". Store as is.
+            if (!key.empty()) /// Otherwise not a valid key/path, maybe it is "retry_after_us". Store as is.
+            {
                 object_info->object_storage_to_use = storage_to_use;
+                object_info->relative_path = key;
+            }
+        }
+        else
+        {
+            object_info->object_storage_to_use = object_storage;
         }
     }
     else

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -39,7 +39,7 @@
 #endif
 
 #include <fmt/ranges.h>
-
+#include <Disks/DiskType.h>
 
 namespace fs = std::filesystem;
 namespace ProfileEvents
@@ -519,7 +519,9 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
     }
     while (not_a_path || (query_settings.skip_empty_files && object_info->metadata->size_bytes == 0));
     
-    ObjectStoragePtr storage_to_use = object_info->getObjectStorage().value_or(object_storage);
+    ObjectStoragePtr storage_to_use = object_info->getObjectStorage();
+    if (!storage_to_use)
+        storage_to_use = object_storage;
 
     QueryPipelineBuilder builder;
     std::shared_ptr<ISource> source;
@@ -830,7 +832,9 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     const auto & settings = context_->getSettingsRef();
     const auto & effective_read_settings = read_settings.has_value() ? read_settings.value() : context_->getReadSettings();
 
-    ObjectStoragePtr storage_to_use = object_info.getObjectStorage().value_or(object_storage);
+    ObjectStoragePtr storage_to_use = object_info.getObjectStorage();
+    if (!storage_to_use)
+        storage_to_use = object_storage;
 
     bool use_distributed_cache = false;
 #if ENABLE_DISTRIBUTED_CACHE
@@ -1319,20 +1323,22 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::ReadTaskIterator
 
         object_info = raw->getObjectInfo();
 
+        // The 'path' field from master is already the correctly resolved relative path.
+        // We should use it directly and NOT overwrite relative_path.
+        // Only resolve absolute_path if we need to determine which storage to use (for secondary storages).
+        object_info->object_storage_to_use = object_storage;
+        
         if (raw->absolute_path.has_value())
         {
             auto [storage_to_use, key]
                 = resolveObjectStorageForPath("", raw->absolute_path.value(), object_storage, secondary_storages, getContext());
 
-            if (!key.empty()) /// Otherwise not a valid key/path, maybe it is "retry_after_us". Store as is.
+            if (!key.empty() && storage_to_use != object_storage)
             {
+                // File is in a different storage (secondary storage), use that storage
+                // BUT preserve the original relative_path from master - don't overwrite it!
                 object_info->object_storage_to_use = storage_to_use;
-                object_info->relative_path = key;
             }
-        }
-        else
-        {
-            object_info->object_storage_to_use = object_storage;
         }
     }
     else
@@ -1430,7 +1436,10 @@ StorageObjectStorageSource::ArchiveIterator::createArchiveReader(ObjectInfoPtr o
     return DB::createArchiveReader(
         /* path_to_archive */
         object_info->getPath(),
-        /* archive_read_function */ [=, this]() { return createReadBuffer(*object_info, object_info->getObjectStorage().value_or(object_storage), getContext(), log); },
+        /* archive_read_function */ [=, this]() { 
+            ObjectStoragePtr storage = object_info->getObjectStorage() ? object_info->getObjectStorage() : object_storage;
+            return createReadBuffer(*object_info, storage, getContext(), log); 
+        },
         /* archive_size */ size);
 }
 
@@ -1453,7 +1462,9 @@ ObjectInfoPtr StorageObjectStorageSource::ArchiveIterator::next(size_t processor
 
                 if (!archive_object->metadata)
                 {
-                    ObjectStoragePtr storage_to_use = archive_object->getObjectStorage().value_or(object_storage);
+                    ObjectStoragePtr storage_to_use = archive_object->getObjectStorage();
+                    if (!storage_to_use)
+                        storage_to_use = object_storage;
                     archive_object->metadata = storage_to_use->getObjectMetadata(archive_object->getPath());
                 }
 
@@ -1482,7 +1493,9 @@ ObjectInfoPtr StorageObjectStorageSource::ArchiveIterator::next(size_t processor
 
             if (!archive_object->metadata)
             {
-                ObjectStoragePtr storage_to_use = archive_object->getObjectStorage().value_or(object_storage);
+                ObjectStoragePtr storage_to_use = archive_object->getObjectStorage();
+                if (!storage_to_use)
+                    storage_to_use = object_storage;
                 archive_object->metadata = storage_to_use->getObjectMetadata(archive_object->getPath());
             }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -484,6 +484,8 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
     ObjectInfoPtr object_info;
     auto query_settings = configuration->getQuerySettings(context_);
 
+    ObjectStoragePtr storage_to_use = object_storage;
+
     bool not_a_path = false;
 
     do
@@ -701,7 +703,7 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
         else
         {
             compression_method = chooseCompressionMethod(object_info->getFileName(), configuration->getCompressionMethod());
-            read_buf = createReadBuffer(*object_info, object_storage, context_, log);
+            read_buf = createReadBuffer(*object_info, storage_to_use, context_, log);
         }
 
         Block initial_header = read_from_format_info.format_header;
@@ -824,6 +826,8 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     const auto & settings = context_->getSettingsRef();
     const auto & effective_read_settings = read_settings.has_value() ? read_settings.value() : context_->getReadSettings();
 
+    ObjectStoragePtr storage_to_use = object_info.getObjectStorage().value_or(object_storage);
+
     bool use_distributed_cache = false;
 #if ENABLE_DISTRIBUTED_CACHE
     ObjectStorageConnectionInfoPtr connection_info;
@@ -831,7 +835,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
         && DistributedCache::Registry::instance().isReady(
             effective_read_settings.distributed_cache_settings.read_only_from_current_az))
     {
-        connection_info = object_storage->getConnectionInfo();
+        connection_info = storage_to_use->getConnectionInfo();
         if (connection_info)
             use_distributed_cache = true;
     }
@@ -844,15 +848,15 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
         filesystem_cache_name = settings[Setting::filesystem_cache_name].value;
         use_filesystem_cache = effective_read_settings.enable_filesystem_cache
             && !filesystem_cache_name.empty()
-            && (object_storage->getType() == ObjectStorageType::Azure
-                || object_storage->getType() == ObjectStorageType::S3);
+            && (storage_to_use->getType() == ObjectStorageType::Azure
+                || storage_to_use->getType() == ObjectStorageType::S3);
     }
 
     /// We need object metadata for two cases:
     /// 1. object size suggests whether we need to use prefetch
     /// 2. object etag suggests a cache key in case we use filesystem cache
     if (!object_info.metadata)
-        object_info.metadata = object_storage->getObjectMetadata(object_info.getPath());
+        object_info.metadata = storage_to_use->getObjectMetadata(object_info.getPath());
 
     const auto & object_size = object_info.metadata->size_bytes;
 
@@ -888,9 +892,9 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     {
         const std::string path = object_info.getPath();
         StoredObject object(path, "", object_size);
-        auto read_buffer_creator = [object, nested_buffer_read_settings, object_storage]()
+        auto read_buffer_creator = [object, nested_buffer_read_settings, storage_to_use]()
         {
-            return object_storage->readObject(object, nested_buffer_read_settings);
+            return storage_to_use->readObject(object, nested_buffer_read_settings);
         };
 
         impl = std::make_unique<ReadBufferFromDistributedCache>(
@@ -923,9 +927,9 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
             const auto cache_key = FileCacheKey::fromKey(hash.get128());
             auto cache = FileCacheFactory::instance().get(filesystem_cache_name);
 
-            auto read_buffer_creator = [path = object_info.getPath(), object_size, nested_buffer_read_settings, object_storage]()
+            auto read_buffer_creator = [path = object_info.getPath(), object_size, nested_buffer_read_settings, object_storage, storage_to_use]()
             {
-                return object_storage->readObject(StoredObject(path, "", object_size), nested_buffer_read_settings);
+                return storage_to_use->readObject(StoredObject(path, "", object_size), nested_buffer_read_settings);
             };
 
             impl = std::make_unique<CachedOnDiskReadBufferFromFile>(
@@ -953,7 +957,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     }
 
     if (!impl)
-        impl = object_storage->readObject(StoredObject(object_info.getPath(), "", object_size), nested_buffer_read_settings);
+        impl = storage_to_use->readObject(StoredObject(object_info.getPath(), "", object_size), nested_buffer_read_settings);
 
     if (!use_async_buffer)
         return impl;
@@ -1273,7 +1277,18 @@ StorageObjectStorageSource::ReadTaskIterator::ReadTaskIterator(
     {
         auto object = object_future.get();
         if (object)
+        {
+            if (object->getAbsolutePath().has_value())
+            {
+                auto [storage_to_use, key] = resolveObjectStorageForPath("", object->getAbsolutePath().value(), object_storage, secondary_storages, getContext());
+                if (!key.empty())
+                {
+                    object->object_storage_to_use = storage_to_use;
+                    object->relative_path = key;
+                }
+            }
             buffer.push_back(object);
+        }
     }
 }
 
@@ -1290,10 +1305,24 @@ StorageObjectStorage::ObjectInfoPtr StorageObjectStorageSource::ReadTaskIterator
             return nullptr;
         }
 
-        auto task = callback();
-        if (!task || task->isEmpty())
+        auto raw = callback();
+        if (!raw || raw->isEmpty())
             return nullptr;
-        object_info = task->getObjectInfo();
+
+        object_info = raw->getObjectInfo();
+
+        if (object_info->getObjectStorage().has_value())
+        {
+
+        }
+        else if (raw->absolute_path.has_value())
+        {
+            auto [storage_to_use, key]
+                = resolveObjectStorageForPath("", raw->absolute_path.value(), object_storage, secondary_storages, getContext());
+
+            if (!key.empty()) /// Not a valid key/path, maybe it is "retry_after_us". Store as is.
+                object_info->object_storage_to_use = storage_to_use;
+        }
     }
     else
     {
@@ -1390,7 +1419,7 @@ StorageObjectStorageSource::ArchiveIterator::createArchiveReader(ObjectInfoPtr o
     return DB::createArchiveReader(
         /* path_to_archive */
         object_info->getPath(),
-        /* archive_read_function */ [=, this]() { return createReadBuffer(*object_info, object_storage, getContext(), log); },
+        /* archive_read_function */ [=, this]() { return createReadBuffer(*object_info, object_info->getObjectStorage().value_or(object_storage), getContext(), log); },
         /* archive_size */ size);
 }
 
@@ -1412,7 +1441,10 @@ ObjectInfoPtr StorageObjectStorageSource::ArchiveIterator::next(size_t processor
                 }
 
                 if (!archive_object->metadata)
-                    archive_object->metadata = object_storage->getObjectMetadata(archive_object->getPath());
+                {
+                    ObjectStoragePtr storage_to_use = archive_object->getObjectStorage().value_or(object_storage);
+                    archive_object->metadata = storage_to_use->getObjectMetadata(archive_object->getPath());
+                }
 
                 archive_reader = createArchiveReader(archive_object);
                 file_enumerator = archive_reader->firstFile();
@@ -1438,7 +1470,10 @@ ObjectInfoPtr StorageObjectStorageSource::ArchiveIterator::next(size_t processor
                 return {};
 
             if (!archive_object->metadata)
-                archive_object->metadata = object_storage->getObjectMetadata(archive_object->getPath());
+            {
+                ObjectStoragePtr storage_to_use = archive_object->getObjectStorage().value_or(object_storage);
+                archive_object->metadata = storage_to_use->getObjectMetadata(archive_object->getPath());
+            }
 
             archive_reader = createArchiveReader(archive_object);
             if (!archive_reader->fileExists(path_in_archive))

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -179,6 +179,7 @@ private:
     std::atomic_size_t index = 0;
     bool is_archive;
     ObjectStoragePtr object_storage;
+    mutable std::map<String, ObjectStoragePtr> secondary_storages; // Sometimes data can be located on a different storage
     /// path_to_archive -> archive reader.
     std::unordered_map<std::string, std::shared_ptr<IArchiveReader>> archive_readers;
     std::mutex archive_readers_mutex;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -179,7 +179,7 @@ private:
     std::atomic_size_t index = 0;
     bool is_archive;
     ObjectStoragePtr object_storage;
-    mutable std::map<String, ObjectStoragePtr> secondary_storages; // Sometimes data can be located on a different storage
+    std::map<String, ObjectStoragePtr> secondary_storages; // Sometimes data can be located on a different storage
     /// path_to_archive -> archive reader.
     std::unordered_map<std::string, std::shared_ptr<IArchiveReader>> archive_readers;
     std::mutex archive_readers_mutex;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.h
@@ -8,6 +8,7 @@
 #include <Processors/Formats/IInputFormat.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/ObjectStorage/IObjectIterator.h>
+#include <Storages/ObjectStorage/Utils.h>
 #include <Formats/FormatParserSharedResources.h>
 #include <Formats/FormatFilterInfo.h>
 #include <Storages/Cache/ObjectStorageListObjectsCache.h>
@@ -179,7 +180,7 @@ private:
     std::atomic_size_t index = 0;
     bool is_archive;
     ObjectStoragePtr object_storage;
-    std::map<String, ObjectStoragePtr> secondary_storages; // Sometimes data can be located on a different storage
+    SecondaryStorages secondary_storages; // Sometimes data can be located on a different storage
     /// path_to_archive -> archive reader.
     std::unordered_map<std::string, std::shared_ptr<IArchiveReader>> archive_readers;
     std::mutex archive_readers_mutex;

--- a/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
@@ -165,7 +165,7 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getMatchingFileFromIter
         }
         else
         {
-            file_path = object_info->getPath();
+            file_path = object_info->getAbsolutePath().value_or(object_info->getPath());
         }
 
         size_t file_replica_idx = getReplicaForFile(file_path);
@@ -245,7 +245,7 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getAnyUnprocessedFile(s
 
         /// All unprocessed files owned by alive replicas with recenlty activity
         /// Need to retry after (oldest_activity - activity_limit) microseconds
-        RelativePathWithMetadata::CommandInTaskResponse response;
+        PathWithMetadata::CommandInTaskResponse response;
         response.set_retry_after_us(oldest_activity - activity_limit);
         return std::make_shared<ObjectInfo>(response.to_string());
     }

--- a/src/Storages/ObjectStorage/Utils.cpp
+++ b/src/Storages/ObjectStorage/Utils.cpp
@@ -13,6 +13,7 @@
 #include <Poco/Util/MapConfiguration.h>
 #include <IO/S3/URI.h>
 #include <filesystem>
+#include <functional>
 #if USE_AWS_S3
 #include <Disks/ObjectStorages/S3/S3ObjectStorage.h>
 #endif
@@ -33,7 +34,7 @@ namespace ErrorCodes
 namespace
 {
 
-inline std::string normalizeSchema(const std::string & schema)
+std::string normalizeSchema(const std::string & schema)
 {
     auto schema_lowercase = Poco::toLower(schema);
 
@@ -45,18 +46,109 @@ inline std::string normalizeSchema(const std::string & schema)
     return schema_lowercase;
 }
 
-inline std::string endpoint_cache_key(const std::string & normalized_scheme, const std::string & authority)
-{
-    return normalized_scheme + "://" + authority;
-}
-
-static std::string factoryTypeForScheme(const std::string & normalized_scheme)
+std::string factoryTypeForScheme(const std::string & normalized_scheme)
 {
     if (normalized_scheme == "s3") return "s3";
     if (normalized_scheme == "abfs") return "azure";
     if (normalized_scheme == "hdfs") return "hdfs";
     if (normalized_scheme == "file") return "local";
     return "";
+}
+
+bool isAbsolutePath(const std::string & path)
+{
+    if (!path.empty() && (path.front() == '/' || path.find("://") != std::string_view::npos))
+        return true;
+
+    return false;
+}
+
+std::string normalizePathString(const std::string & path)
+{
+    std::filesystem::path fs_path(path);
+    std::filesystem::path normalized = fs_path.lexically_normal();
+
+    std::string normalized_result = normalized.string();
+
+    while (!normalized_result.empty() && normalized_result.front() == '/')
+        normalized_result = normalized_result.substr(1);
+
+    return normalized_result;
+}
+
+#if USE_AWS_S3
+/// For s3:// URIs (generic), bucket needs to match.
+/// For explicit http(s):// URIs, both bucket and endpoint must match.
+bool s3URIMatches(const S3::URI & target_uri, const std::string & base_bucket, const std::string & base_endpoint, const std::string & target_schema_normalized)
+{
+    bool bucket_matches = (target_uri.bucket == base_bucket);
+    bool endpoint_matches = (target_uri.endpoint == base_endpoint);
+    bool is_generic_s3_uri = (target_schema_normalized == "s3");
+    return bucket_matches && (endpoint_matches || is_generic_s3_uri);
+}
+#endif
+
+std::pair<ObjectStoragePtr, std::string> getOrCreateStorageAndKey(
+    const std::string & cache_key,
+    const std::string & key_to_use,
+    const std::string & storage_type,
+    std::map<std::string, ObjectStoragePtr> & secondary_storages,
+    const ContextPtr & context,
+    std::function<void(Poco::Util::MapConfiguration &, const std::string &)> configure_fn)
+{
+    if (auto it = secondary_storages.find(cache_key); it != secondary_storages.end())
+        return {it->second, key_to_use};
+
+    Poco::AutoPtr<Poco::Util::MapConfiguration> cfg(new Poco::Util::MapConfiguration);
+    const std::string config_prefix = "object_storages." + cache_key;
+
+    cfg->setString(config_prefix + ".object_storage_type", storage_type);
+
+    configure_fn(*cfg, config_prefix);
+
+    auto & factory = ObjectStorageFactory::instance();
+    ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
+
+    secondary_storages.emplace(cache_key, storage);
+
+    return {storage, key_to_use};
+}
+
+std::string normalizePathToStorageRoot(const std::string & table_location, const std::string & path)
+{
+    if (table_location.empty())
+    {
+        if (!path.empty() && path.front() == '/')
+            return path.substr(1);
+        return path;
+    }
+
+    if (isAbsolutePath(path))
+        return SchemeAuthorityKey(path).key; // Absolute path, return the key part
+
+    SchemeAuthorityKey base{table_location};
+    if (base.key.empty())
+        return path; // Table location is empty, return the path as is
+
+    std::string base_key_trimmed = base.key;
+    while (!base_key_trimmed.empty() && base_key_trimmed.front() == '/')
+        base_key_trimmed = base_key_trimmed.substr(1);
+    while (!base_key_trimmed.empty() && base_key_trimmed.back() == '/')
+        base_key_trimmed.pop_back();
+
+    std::string rel_path = path;
+    while (!rel_path.empty() && rel_path.front() == '/')
+        rel_path = rel_path.substr(1);
+
+    if (!base_key_trimmed.empty() && (rel_path == base_key_trimmed || rel_path.starts_with(base_key_trimmed + "/")))
+        return normalizePathString(rel_path);  // Path already includes table location
+
+    std::string result = base.key;
+    if (!result.empty() && result.back() != '/')
+        result += '/';
+    result += rel_path;
+
+    return normalizePathString(result);
 }
 
 }
@@ -67,7 +159,6 @@ SchemeAuthorityKey::SchemeAuthorityKey(const std::string & uri)
     if (uri.empty())
         return;
 
-    // scheme://authority/path
     if (auto scheme_sep = uri.find("://"); scheme_sep != std::string_view::npos)
     {
         scheme = Poco::toLower(uri.substr(0, scheme_sep));
@@ -78,7 +169,7 @@ SchemeAuthorityKey::SchemeAuthorityKey(const std::string & uri)
         if (slash == std::string_view::npos)
         {
             authority = std::string(rest);
-            key = "/";   // Happy debugging. FIXME: throw exception, path obviously incorrect
+            key = "/";   // Path obviously incorrect, but it will be dealt with by caller
             return;
         }
         authority = std::string(rest.substr(0, slash));
@@ -94,7 +185,7 @@ SchemeAuthorityKey::SchemeAuthorityKey(const std::string & uri)
         return;
     }
 
-    // Relative path, return as is
+    // Relative path
     key = std::string(uri);
 }
 
@@ -196,147 +287,17 @@ void validateSupportedColumns(
     }
 }
 
-inline bool isSameStorageSchema(const std::string & schema1, const std::string & schema2)
-{
-    return normalizeSchema(schema1) == normalizeSchema(schema2);
-}
-
-std::string extractStorageType(const std::string & path)
-{
-    if (path.empty())
-        return "";
-
-    // Absolute POSIX path -> file
-    if (path.front() == '/')
-        return "file";
-
-    // Look for "scheme://..."
-    if (auto pos = path.find("://"); pos != std::string_view::npos && pos > 0)
-        return Poco::toLower(path.substr(0, pos));
-
-    // Tolerant: "scheme:..." with no slash before colon (avoid Windows drive letters like "C:\")
-    {
-        auto colon_pos = path.find(':');
-        auto slash_pos = path.find('/');
-        if (colon_pos != std::string_view::npos && (slash_pos == std::string_view::npos || colon_pos < slash_pos))
-        {
-            auto maybe_scheme = path.substr(0, colon_pos);
-            // Heuristic: treat single-letter prefix followed by ":\\" as Windows drive, not a scheme
-            if (!(maybe_scheme.size() == 1 && colon_pos + 1 < path.size() && (path[colon_pos + 1] == '\\' || path[colon_pos + 1] == '/')))
-                return Poco::toLower(maybe_scheme);
-        }
-    }
-
-    // Relative path or unknown
-    return "";
-}
-
-bool isRelativePath(const std::string & path)
-{
-    if (path.empty())
-        return true;
-
-    // Non-relative if it has a scheme (e.g., s3://, file://)
-    if (!extractStorageType(path).empty())
-        return false;
-
-    return true;
-}
-
-
-std::string normalizePathToStorageRoot(const std::string & table_location, const std::string & path)
-{
-    if (table_location.empty())
-    {
-        // Even when table_location is empty, normalize paths that start with '/'
-        std::string result = path;
-        if (!result.empty() && result.front() == '/')
-            result = result.substr(1);
-        return result;
-    }
-
-    if (!isRelativePath(path))
-    {
-        SchemeAuthorityKey target{path};
-        return target.key;
-    }
-
-    SchemeAuthorityKey base{table_location};
-    if (base.key.empty())
-        return path;
-
-    std::string rel_path = path;
-    if (!rel_path.empty() && rel_path.front() == '/')
-        rel_path = rel_path.substr(1);
-
-    std::string base_key_trimmed = base.key;
-    while (!base_key_trimmed.empty() && base_key_trimmed.front() == '/')
-        base_key_trimmed = base_key_trimmed.substr(1);
-    while (!base_key_trimmed.empty() && base_key_trimmed.back() == '/')
-        base_key_trimmed.pop_back();
-
-    // Check if the path already starts with the base.key (table location)
-    // This handles cases where paths in metadata are already absolute within the storage
-    if (!base_key_trimmed.empty() && (rel_path == base_key_trimmed || rel_path.starts_with(base_key_trimmed + "/")))
-    {
-        // Path already includes table location, return it as-is (normalized to remove any ".." or ".")
-        std::filesystem::path fs_path(rel_path);
-        std::filesystem::path normalized = fs_path.lexically_normal();
-        
-        std::string normalized_result = normalized.string();
-        std::replace(normalized_result.begin(), normalized_result.end(), '\\', '/');
-        
-        while (!normalized_result.empty() && normalized_result.front() == '/')
-            normalized_result = normalized_result.substr(1);
-        
-        return normalized_result;
-    }
-
-    // First, try combining and normalizing to see if the path resolves outside the table location
-    // This handles cases where paths use ".." to go up from table location to shared parent
-    std::string combined = base.key;
-    if (!combined.empty() && combined.back() != '/')
-        combined += '/';
-    combined += rel_path;
-
-    // Normalize the path to resolve "..", "."; remove duplicate slashes (just in case)
-    std::filesystem::path fs_path(combined);
-    std::filesystem::path normalized = fs_path.lexically_normal();
-    
-    std::string normalized_result = normalized.string();
-    std::replace(normalized_result.begin(), normalized_result.end(), '\\', '/');
-    
-    while (!normalized_result.empty() && normalized_result.front() == '/')
-        normalized_result = normalized_result.substr(1);
-
-    // Check if the normalized path still starts with base.key (meaning it's under table location)
-    // or if it doesn't (meaning it resolved outside, e.g., via "..")
-    if (!normalized_result.empty() && !base.key.empty())
-    {
-        // If normalized path doesn't start with base.key, it means the original path
-        // used ".." to go outside the table location - use the normalized path as-is
-        if (!normalized_result.starts_with(base.key + "/") && normalized_result != base.key)
-        {
-            return normalized_result;
-        }
-    }
-
-    return normalized_result;
-}
-
 std::string makeAbsolutePath(const std::string & table_location, const std::string & path)
 {
-    if (!isRelativePath(path))
+    if (isAbsolutePath(path))
         return path;
 
-    auto base = SchemeAuthorityKey(table_location);
+    auto table_location_decomposed = SchemeAuthorityKey(table_location);
 
     std::string normalized_key = normalizePathToStorageRoot(table_location, path);
-    
-    std::string abs_path = "/" + normalized_key;
 
-    if (!base.scheme.empty())
-        return base.scheme + "://" + base.authority + abs_path;
+    if (!table_location_decomposed.scheme.empty())
+        return table_location_decomposed.scheme + "://" + table_location_decomposed.authority + "/" + normalized_key;
 
     return normalized_key;
 }
@@ -348,154 +309,115 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     std::map<std::string, DB::ObjectStoragePtr> & secondary_storages,
     const DB::ContextPtr & context)
 {
-    if (isRelativePath(path))
+    if (!isAbsolutePath(path))
+        return {base_storage, normalizePathToStorageRoot(table_location, path)}; // Relative path definitely goes to base storage
+
+    SchemeAuthorityKey table_location_decomposed{table_location};
+    SchemeAuthorityKey target_decomposed{path};
+
+    if (target_decomposed.scheme.empty())
     {
-        // For relative paths, normalize to storage root
-        std::string normalized_key = normalizePathToStorageRoot(table_location, path);
-        return {base_storage, normalized_key}; // Relative path definitely goes to base storage
+        // Path has no scheme but wasn't caught by isRelativePath; treat it as relative and normalize to storage root
+        return {base_storage, normalizePathToStorageRoot(table_location, target_decomposed.key)};
     }
 
-    SchemeAuthorityKey base{table_location};
-    SchemeAuthorityKey target{path};
-
-    if (target.scheme.empty())
-    {
-        // Path has no scheme but wasn't caught by isRelativePath
-        // Treat it as relative and normalize to storage root
-        std::string normalized_key = normalizePathToStorageRoot(table_location, target.key);
-        return {base_storage, normalized_key};
-    }
-
-    const std::string base_norm = normalizeSchema(base.scheme);
-    const std::string target_norm = normalizeSchema(target.scheme);
+    const std::string base_schema_normalized = normalizeSchema(table_location_decomposed.scheme);
+    const std::string target_schema_normalized = normalizeSchema(target_decomposed.scheme);
 
     // For S3 URIs, use S3::URI to properly handle all kinds of URIs, e.g. https://s3.amazonaws.com/bucket/... == s3://bucket/...
     #if USE_AWS_S3
-    if (target_norm == "s3" || target_norm == "https" || target_norm == "http")
+    if (target_schema_normalized == "s3" || target_schema_normalized == "https" || target_schema_normalized == "http")
     {
-        try
+        std::string normalized_path = path;
+        if (target_decomposed.scheme == "s3a" || target_decomposed.scheme == "s3n")
         {
-            // Normalize s3a:// and s3n:// to s3:// for S3::URI parsing
-            std::string normalized_path = path;
-            if (target.scheme == "s3a" || target.scheme == "s3n")
-            {
-                normalized_path = "s3://" + target.authority + "/" + target.key;
-            }
-            S3::URI s3_uri(normalized_path);
+            normalized_path = "s3://" + target_decomposed.authority + "/" + target_decomposed.key;
+        }
+        S3::URI s3_uri(normalized_path);
 
-            std::string key_to_use = s3_uri.key;
+        std::string key_to_use = s3_uri.key;
 
-            bool use_base_storage = false;
-            if (base_storage->getType() == ObjectStorageType::S3)
+        bool use_base_storage = false;
+        if (base_storage->getType() == ObjectStorageType::S3)
+        {
+            if (auto s3_storage = std::dynamic_pointer_cast<S3ObjectStorage>(base_storage))
             {
-                if (auto s3_storage = std::dynamic_pointer_cast<S3ObjectStorage>(base_storage))
-                {
-                    const std::string base_bucket = s3_storage->getObjectsNamespace();
-                    const std::string base_endpoint = s3_storage->getDescription();
-                    
-                    // If bucket matches, use base storage. For s3:// URIs (which don't have explicit endpoint),
-                    // we should use base storage if bucket matches, regardless of endpoint.
-                    // For explicit http(s):// URIs, we require both bucket and endpoint to match.
-                    bool bucket_matches = (s3_uri.bucket == base_bucket);
-                    bool endpoint_matches = (s3_uri.endpoint == base_endpoint);
-                    bool is_generic_s3_uri = (target_norm == "s3");
-                    
-                    if (bucket_matches && (endpoint_matches || is_generic_s3_uri))
-                    {
-                        use_base_storage = true;
-                    }
-                }
-            }
-            
-            // Also check if table_location is provided and matches
-            if (!use_base_storage && (base_norm == "s3" || base_norm == "https" || base_norm == "http"))
-            {
-                // Normalize s3a:// and s3n:// in table_location to s3:// for S3::URI parsing
-                std::string normalized_table_location = table_location;
-                if (base.scheme == "s3a" || base.scheme == "s3n")
-                {
-                    normalized_table_location = "s3://" + base.authority + "/" + base.key;
-                }
-                S3::URI base_s3_uri(normalized_table_location);
+                const std::string base_bucket = s3_storage->getObjectsNamespace();
+                const std::string base_endpoint = s3_storage->getDescription();
 
-                // For s3:// URIs, match by bucket only. For explicit http(s):// URIs, require both bucket and endpoint.
-                bool bucket_matches = (s3_uri.bucket == base_s3_uri.bucket);
-                bool endpoint_matches = (s3_uri.endpoint == base_s3_uri.endpoint);
-                bool is_generic_s3_uri = (target_norm == "s3");
-                
-                if (bucket_matches && (endpoint_matches || is_generic_s3_uri))
-                {
+                if (s3URIMatches(s3_uri, base_bucket, base_endpoint, target_schema_normalized))
                     use_base_storage = true;
-                }
             }
-            
-            if (use_base_storage)
-                return {base_storage, key_to_use};
-
-            const std::string cache_key = "s3://" + s3_uri.bucket + "@" + (s3_uri.endpoint.empty() ? "amazonaws.com" : s3_uri.endpoint);
-
-            if (auto it = secondary_storages.find(cache_key); it != secondary_storages.end())
-                return {it->second, key_to_use};
-
-            /// TODO: maybe do not invent new configuration. Use old one and clean up later
-            Poco::AutoPtr<Poco::Util::MapConfiguration> cfg(new Poco::Util::MapConfiguration);
-            const std::string config_prefix = "object_storages." + cache_key;
-
-            cfg->setString(config_prefix + ".object_storage_type", "s3");
-
-            // Use the full endpoint or construct it from bucket
-            std::string endpoint = s3_uri.endpoint.empty()
-                ? ("https://" + s3_uri.bucket + ".s3.amazonaws.com")
-                : s3_uri.endpoint;
-            cfg->setString(config_prefix + ".endpoint", endpoint);
-
-            // Copy credentials from base storage if it's also S3
-            if (base_storage->getType() == ObjectStorageType::S3)
+        }
+        
+        if (!use_base_storage && (base_schema_normalized == "s3" || base_schema_normalized == "https" || base_schema_normalized == "http"))
+        {
+            std::string normalized_table_location = table_location;
+            if (table_location_decomposed.scheme == "s3a" || table_location_decomposed.scheme == "s3n")
             {
-                if (auto s3_storage = std::dynamic_pointer_cast<S3ObjectStorage>(base_storage))
-                {
-                    if (auto s3_client = s3_storage->tryGetS3StorageClient())
-                    {
-                        const auto credentials = s3_client->getCredentials();
-                        const String & access_key_id = credentials.GetAWSAccessKeyId();
-                        const String & secret_access_key = credentials.GetAWSSecretKey();
-                        const String & session_token = credentials.GetSessionToken();
-                        const String & region = s3_client->getRegion();
+                normalized_table_location = "s3://" + table_location_decomposed.authority + "/" + table_location_decomposed.key;
+            }
+            S3::URI base_s3_uri(normalized_table_location);
+            
+            if (s3URIMatches(s3_uri, base_s3_uri.bucket, base_s3_uri.endpoint, target_schema_normalized))
+                use_base_storage = true;
+        }
+        
+        if (use_base_storage)
+            return {base_storage, key_to_use};
 
-                        if (!access_key_id.empty())
-                            cfg->setString(config_prefix + ".access_key_id", access_key_id);
-                        if (!secret_access_key.empty())
-                            cfg->setString(config_prefix + ".secret_access_key", secret_access_key);
-                        if (!session_token.empty())
-                            cfg->setString(config_prefix + ".session_token", session_token);
-                        if (!region.empty())
-                            cfg->setString(config_prefix + ".region", region);
+        const std::string storage_cache_key = "s3://" + s3_uri.bucket + "@" + (s3_uri.endpoint.empty() ? "amazonaws.com" : s3_uri.endpoint);
+
+        return getOrCreateStorageAndKey(
+            storage_cache_key,
+            key_to_use,
+            "s3",
+            secondary_storages,
+            context,
+            [&](Poco::Util::MapConfiguration & cfg, const std::string & config_prefix)
+            {
+                // Use the full endpoint or construct it from bucket
+                std::string endpoint = s3_uri.endpoint.empty()
+                    ? ("https://" + s3_uri.bucket + ".s3.amazonaws.com")
+                    : s3_uri.endpoint;
+                cfg.setString(config_prefix + ".endpoint", endpoint);
+
+                // Copy credentials from base storage if it's also S3
+                if (base_storage->getType() == ObjectStorageType::S3)
+                {
+                    if (auto s3_storage = std::dynamic_pointer_cast<S3ObjectStorage>(base_storage))
+                    {
+                        if (auto s3_client = s3_storage->tryGetS3StorageClient())
+                        {
+                            const auto credentials = s3_client->getCredentials();
+                            const String & access_key_id = credentials.GetAWSAccessKeyId();
+                            const String & secret_access_key = credentials.GetAWSSecretKey();
+                            const String & session_token = credentials.GetSessionToken();
+                            const String & region = s3_client->getRegion();
+
+                            if (!access_key_id.empty())
+                                cfg.setString(config_prefix + ".access_key_id", access_key_id);
+                            if (!secret_access_key.empty())
+                                cfg.setString(config_prefix + ".secret_access_key", secret_access_key);
+                            if (!session_token.empty())
+                                cfg.setString(config_prefix + ".session_token", session_token);
+                            if (!region.empty())
+                                cfg.setString(config_prefix + ".region", region);
+                        }
                     }
                 }
-            }
-
-            auto & factory = DB::ObjectStorageFactory::instance();
-
-            DB::ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
-
-            secondary_storages.emplace(cache_key, storage);
-            return {storage, key_to_use};
-        }
-        catch (const Exception &) // NOLINT
-        {
-            // If S3::URI parsing fails, fall back to the old logic
-        }
+            });
     }
     #endif
 
-    // For HDFS URIs, check if we can reuse base storage
-    if (target_norm == "hdfs")
+    #if USE_HDFS
+    if (target_schema_normalized == "hdfs")
     {
-        // Check if base storage is HDFS and matches the path's endpoint
         bool use_base_storage = false;
+        
+        // Check if base_storage matches (only if it's HDFS)
         if (base_storage->getType() == ObjectStorageType::HDFS)
         {
-            #if USE_HDFS
             if (auto hdfs_storage = std::dynamic_pointer_cast<HDFSObjectStorage>(base_storage))
             {
                 const std::string base_url = hdfs_storage->getDescription();
@@ -507,109 +429,74 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
                     base_endpoint = base_url;
                 
                 // For HDFS, compare endpoints (namenode addresses)
-                std::string target_endpoint = target_norm + "://" + target.authority;
+                std::string target_endpoint = target_schema_normalized + "://" + target_decomposed.authority;
                 
                 if (base_endpoint == target_endpoint)
-                {
                     use_base_storage = true;
+                
+                // Also check if table_location matches
+                if (!use_base_storage && base_schema_normalized == "hdfs")
+                {
+                    if (table_location_decomposed.authority == target_decomposed.authority)
+                        use_base_storage = true;
                 }
-            }
-            #endif
-        }
-        
-        // Also check if table_location is provided and matches
-        if (!use_base_storage && base_norm == "hdfs")
-        {
-            std::string base_endpoint = base_norm + "://" + base.authority;
-            std::string target_endpoint = target_norm + "://" + target.authority;
-            
-            if (base_endpoint == target_endpoint)
-            {
-                use_base_storage = true;
             }
         }
         
         if (use_base_storage)
-            return {base_storage, target.key};
+            return {base_storage, target_decomposed.key};
     }
+    #endif
 
-    // Reuse base storage if scheme and authority (bucket) matches
-    if (base_norm == target_norm && base.authority == target.authority)
-    {
-        return {base_storage, target.key};
-    }
+    /// Fallback for schemes not handled above (e.g., abfs, file)
+    if (base_schema_normalized == target_schema_normalized && table_location_decomposed.authority == target_decomposed.authority)
+        return {base_storage, target_decomposed.key};
 
-    const std::string cache_key = endpoint_cache_key(target_norm, target.authority);
-    if (auto it = secondary_storages.find(cache_key); it != secondary_storages.end())
-    {
-        return {it->second, target.key};
-    }
+    const std::string cache_key = target_schema_normalized + "://" + target_decomposed.authority;
 
-    /// TODO: maybe do not invent new configuration. Use old one and clean up later
-    Poco::AutoPtr<Poco::Util::MapConfiguration> cfg(new Poco::Util::MapConfiguration);
-
-    const std::string type_for_factory = factoryTypeForScheme(target_norm);
+    const std::string type_for_factory = factoryTypeForScheme(target_schema_normalized);
     if (type_for_factory.empty())
-        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unsupported storage scheme '{}' in path '{}'", target_norm, path);
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unsupported storage scheme '{}' in path '{}'", target_schema_normalized, path);
 
-    const std::string config_prefix = "object_storages." + cache_key;
+    std::string key_to_use = target_decomposed.key;
+    if (target_schema_normalized == "file")
+        key_to_use = "/" + target_decomposed.key;  // file:///absolute/path/to/file -> key = /absolute/path/to/file (full POSIX path)
 
-    cfg->setString(config_prefix + ".object_storage_type", type_for_factory);
-
-    if (target_norm == "s3" || target_norm == "abfs")
-    {
-        cfg->setString(config_prefix + ".endpoint", target_norm + "://" + target.authority);
-    }
-    else if (target_norm == "hdfs")
-    {
-        // HDFS endpoint must end with '/'
-        auto endpoint = target_norm + "://" + target.authority;
-        if (!endpoint.empty() && endpoint.back() != '/')
-            endpoint.push_back('/');
-        cfg->setString(config_prefix + ".endpoint", endpoint);
-    }
-    else if (target_norm == "file")
-    {
-        // For file:// URIs, extract the directory path
-        // file:///absolute/path/to/file -> path = /absolute/path/to/, key = /absolute/path/to/file (full path)
-        std::string full_path = "/" + target.key;  // Reconstruct full path
-        std::filesystem::path fs_path(full_path);
-        std::filesystem::path parent = fs_path.parent_path();
-        std::string dir_path = parent.string();
-        
-        // Ensure directory path ends with /
-        if (dir_path.empty() || dir_path == "/")
+    /// Handle storage types that need new storage creation
+    return getOrCreateStorageAndKey(
+        cache_key,
+        key_to_use,
+        type_for_factory,
+        secondary_storages,
+        context,
+        [&](Poco::Util::MapConfiguration & cfg, const std::string & config_prefix)
         {
-            // Root directory
-            dir_path = "/";
-        }
-        else if (dir_path.back() != '/')
-        {
-            dir_path += '/';
-        }
-        
-        cfg->setString(config_prefix + ".path", dir_path);
-        
-        auto & factory = DB::ObjectStorageFactory::instance();
-
-        // Also use the cache key as a (unique) storage name
-        DB::ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
-
-        secondary_storages.emplace(cache_key, storage);
-
-        // For local storage, getObjectMetadata expects the full path, not just the filename
-        // Return the full absolute path as the key
-        return {storage, full_path};
-    }
-
-    auto & factory = DB::ObjectStorageFactory::instance();
-
-    // Also use the cache key as a (unique) storage name
-    DB::ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
-
-    secondary_storages.emplace(cache_key, storage);
-
-    return {storage, target.key};
+            if (target_schema_normalized == "file")
+            {
+                std::filesystem::path fs_path(key_to_use);
+                std::filesystem::path parent = fs_path.parent_path();
+                std::string dir_path = parent.string();
+                
+                if (dir_path.empty() || dir_path == "/")
+                    dir_path = "/";
+                else if (dir_path.back() != '/')
+                    dir_path += '/';
+                
+                cfg.setString(config_prefix + ".path", dir_path);
+            }
+            else if (target_schema_normalized == "abfs")
+            {
+                cfg.setString(config_prefix + ".endpoint", target_schema_normalized + "://" + target_decomposed.authority);
+            }
+            else if (target_schema_normalized == "hdfs")
+            {
+                // HDFS endpoint must end with '/'
+                auto endpoint = target_schema_normalized + "://" + target_decomposed.authority;
+                if (!endpoint.empty() && endpoint.back() != '/')
+                    endpoint.push_back('/');
+                cfg.setString(config_prefix + ".endpoint", endpoint);
+            }
+        });
 }
 
 }

--- a/src/Storages/ObjectStorage/Utils.cpp
+++ b/src/Storages/ObjectStorage/Utils.cpp
@@ -12,8 +12,12 @@
 #include <Disks/ObjectStorages/ObjectStorageFactory.h>
 #include <Poco/Util/MapConfiguration.h>
 #include <IO/S3/URI.h>
+#include <filesystem>
 #if USE_AWS_S3
 #include <Disks/ObjectStorages/S3/S3ObjectStorage.h>
+#endif
+#if USE_HDFS
+#include <Disks/ObjectStorages/HDFS/HDFSObjectStorage.h>
 #endif
 
 
@@ -239,6 +243,87 @@ bool isRelativePath(const std::string & path)
     return true;
 }
 
+
+std::string normalizePathToStorageRoot(const std::string & table_location, const std::string & path)
+{
+    if (table_location.empty())
+    {
+        // Even when table_location is empty, normalize paths that start with '/'
+        std::string result = path;
+        if (!result.empty() && result.front() == '/')
+            result = result.substr(1);
+        return result;
+    }
+
+    if (!isRelativePath(path))
+    {
+        SchemeAuthorityKey target{path};
+        return target.key;
+    }
+
+    SchemeAuthorityKey base{table_location};
+    if (base.key.empty())
+        return path;
+
+    std::string rel_path = path;
+    if (!rel_path.empty() && rel_path.front() == '/')
+        rel_path = rel_path.substr(1);
+
+    std::string base_key_trimmed = base.key;
+    while (!base_key_trimmed.empty() && base_key_trimmed.front() == '/')
+        base_key_trimmed = base_key_trimmed.substr(1);
+    while (!base_key_trimmed.empty() && base_key_trimmed.back() == '/')
+        base_key_trimmed.pop_back();
+
+    // Check if the path already starts with the base.key (table location)
+    // This handles cases where paths in metadata are already absolute within the storage
+    if (!base_key_trimmed.empty() && (rel_path == base_key_trimmed || rel_path.starts_with(base_key_trimmed + "/")))
+    {
+        // Path already includes table location, return it as-is (normalized to remove any ".." or ".")
+        std::filesystem::path fs_path(rel_path);
+        std::filesystem::path normalized = fs_path.lexically_normal();
+        
+        std::string normalized_result = normalized.string();
+        std::replace(normalized_result.begin(), normalized_result.end(), '\\', '/');
+        
+        while (!normalized_result.empty() && normalized_result.front() == '/')
+            normalized_result = normalized_result.substr(1);
+        
+        return normalized_result;
+    }
+
+    // First, try combining and normalizing to see if the path resolves outside the table location
+    // This handles cases where paths use ".." to go up from table location to shared parent
+    std::string combined = base.key;
+    if (!combined.empty() && combined.back() != '/')
+        combined += '/';
+    combined += rel_path;
+
+    // Normalize the path to resolve "..", "."; remove duplicate slashes (just in case)
+    std::filesystem::path fs_path(combined);
+    std::filesystem::path normalized = fs_path.lexically_normal();
+    
+    std::string normalized_result = normalized.string();
+    std::replace(normalized_result.begin(), normalized_result.end(), '\\', '/');
+    
+    while (!normalized_result.empty() && normalized_result.front() == '/')
+        normalized_result = normalized_result.substr(1);
+
+    // Check if the normalized path still starts with base.key (meaning it's under table location)
+    // or if it doesn't (meaning it resolved outside, e.g., via "..")
+    if (!normalized_result.empty() && !base.key.empty())
+    {
+        // If normalized path doesn't start with base.key, it means the original path
+        // used ".." to go outside the table location - use the normalized path as-is
+        if (!normalized_result.starts_with(base.key + "/") && normalized_result != base.key)
+        {
+            return normalized_result;
+        }
+    }
+
+    return normalized_result;
+}
+
 std::string makeAbsolutePath(const std::string & table_location, const std::string & path)
 {
     if (!isRelativePath(path))
@@ -246,22 +331,14 @@ std::string makeAbsolutePath(const std::string & table_location, const std::stri
 
     auto base = SchemeAuthorityKey(table_location);
 
-    std::string base_dir = base.key.empty() ? std::string("/") : base.key;
-    if (!base_dir.empty() && base_dir.back() != '/')
-        base_dir.push_back('/');
-
-    std::string rel = path;
-    if (!rel.empty() && rel.front() == '/')
-        rel.erase(0, 1);
-
-    std::string abs_path = base_dir + rel;
-    if (abs_path.empty() || abs_path.front() != '/')
-        abs_path.insert(abs_path.begin(), '/');
+    std::string normalized_key = normalizePathToStorageRoot(table_location, path);
+    
+    std::string abs_path = "/" + normalized_key;
 
     if (!base.scheme.empty())
         return base.scheme + "://" + base.authority + abs_path;
 
-    return std::string("file://") + abs_path;
+    return normalized_key;
 }
 
 std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
@@ -273,28 +350,9 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
 {
     if (isRelativePath(path))
     {
-        // For relative paths, we need to construct the "full" key: table location + relative path
-        std::string full_key = path;
-
-        if (!table_location.empty())
-        {
-            SchemeAuthorityKey base{table_location};
-            if (!base.key.empty())
-            {
-                // Combine base key with relative path
-                full_key = base.key;
-                if (!full_key.empty() && full_key.back() != '/')
-                    full_key += '/';
-
-                std::string rel_path = path;
-                if (!rel_path.empty() && rel_path.front() == '/')
-                    rel_path = rel_path.substr(1);
-
-                full_key += rel_path;
-            }
-        }
-
-        return {base_storage, full_key}; // Relative path definitely goes to base storage
+        // For relative paths, normalize to storage root
+        std::string normalized_key = normalizePathToStorageRoot(table_location, path);
+        return {base_storage, normalized_key}; // Relative path definitely goes to base storage
     }
 
     SchemeAuthorityKey base{table_location};
@@ -302,7 +360,10 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
 
     if (target.scheme.empty())
     {
-        return {base_storage, target.key};
+        // Path has no scheme but wasn't caught by isRelativePath
+        // Treat it as relative and normalize to storage root
+        std::string normalized_key = normalizePathToStorageRoot(table_location, target.key);
+        return {base_storage, normalized_key};
     }
 
     const std::string base_norm = normalizeSchema(base.scheme);
@@ -314,13 +375,19 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     {
         try
         {
-            S3::URI s3_uri(path);
+            // Normalize s3a:// and s3n:// to s3:// for S3::URI parsing
+            std::string normalized_path = path;
+            if (target.scheme == "s3a" || target.scheme == "s3n")
+            {
+                normalized_path = "s3://" + target.authority + "/" + target.key;
+            }
+            S3::URI s3_uri(normalized_path);
 
-            // Check if base storage is S3 and matches the path's bucket/endpoint
+            std::string key_to_use = s3_uri.key;
+
             bool use_base_storage = false;
             if (base_storage->getType() == ObjectStorageType::S3)
             {
-                #if USE_AWS_S3
                 if (auto s3_storage = std::dynamic_pointer_cast<S3ObjectStorage>(base_storage))
                 {
                     const std::string base_bucket = s3_storage->getObjectsNamespace();
@@ -338,13 +405,18 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
                         use_base_storage = true;
                     }
                 }
-                #endif
             }
             
             // Also check if table_location is provided and matches
             if (!use_base_storage && (base_norm == "s3" || base_norm == "https" || base_norm == "http"))
             {
-                S3::URI base_s3_uri(table_location);
+                // Normalize s3a:// and s3n:// in table_location to s3:// for S3::URI parsing
+                std::string normalized_table_location = table_location;
+                if (base.scheme == "s3a" || base.scheme == "s3n")
+                {
+                    normalized_table_location = "s3://" + base.authority + "/" + base.key;
+                }
+                S3::URI base_s3_uri(normalized_table_location);
 
                 // For s3:// URIs, match by bucket only. For explicit http(s):// URIs, require both bucket and endpoint.
                 bool bucket_matches = (s3_uri.bucket == base_s3_uri.bucket);
@@ -358,12 +430,12 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
             }
             
             if (use_base_storage)
-                return {base_storage, s3_uri.key};
+                return {base_storage, key_to_use};
 
             const std::string cache_key = "s3://" + s3_uri.bucket + "@" + (s3_uri.endpoint.empty() ? "amazonaws.com" : s3_uri.endpoint);
 
             if (auto it = secondary_storages.find(cache_key); it != secondary_storages.end())
-                return {it->second, s3_uri.key};
+                return {it->second, key_to_use};
 
             /// TODO: maybe do not invent new configuration. Use old one and clean up later
             Poco::AutoPtr<Poco::Util::MapConfiguration> cfg(new Poco::Util::MapConfiguration);
@@ -380,16 +452,15 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
             // Copy credentials from base storage if it's also S3
             if (base_storage->getType() == ObjectStorageType::S3)
             {
-                #if USE_AWS_S3
                 if (auto s3_storage = std::dynamic_pointer_cast<S3ObjectStorage>(base_storage))
                 {
                     if (auto s3_client = s3_storage->tryGetS3StorageClient())
                     {
                         const auto credentials = s3_client->getCredentials();
-                        const std::string access_key_id = credentials.GetAWSAccessKeyId();
-                        const std::string secret_access_key = credentials.GetAWSSecretKey();
-                        const std::string session_token = credentials.GetSessionToken();
-                        const std::string region = s3_client->getRegion();
+                        const String & access_key_id = credentials.GetAWSAccessKeyId();
+                        const String & secret_access_key = credentials.GetAWSSecretKey();
+                        const String & session_token = credentials.GetSessionToken();
+                        const String & region = s3_client->getRegion();
 
                         if (!access_key_id.empty())
                             cfg->setString(config_prefix + ".access_key_id", access_key_id);
@@ -401,7 +472,6 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
                             cfg->setString(config_prefix + ".region", region);
                     }
                 }
-                #endif
             }
 
             auto & factory = DB::ObjectStorageFactory::instance();
@@ -409,7 +479,7 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
             DB::ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
 
             secondary_storages.emplace(cache_key, storage);
-            return {storage, s3_uri.key};
+            return {storage, key_to_use};
         }
         catch (const Exception &) // NOLINT
         {
@@ -418,6 +488,50 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     }
     #endif
 
+    // For HDFS URIs, check if we can reuse base storage
+    if (target_norm == "hdfs")
+    {
+        // Check if base storage is HDFS and matches the path's endpoint
+        bool use_base_storage = false;
+        if (base_storage->getType() == ObjectStorageType::HDFS)
+        {
+            #if USE_HDFS
+            if (auto hdfs_storage = std::dynamic_pointer_cast<HDFSObjectStorage>(base_storage))
+            {
+                const std::string base_url = hdfs_storage->getDescription();
+                // Extract endpoint from base URL (hdfs://namenode:port/path -> hdfs://namenode:port)
+                std::string base_endpoint;
+                if (auto pos = base_url.find('/', base_url.find("//") + 2); pos != std::string::npos)
+                    base_endpoint = base_url.substr(0, pos);
+                else
+                    base_endpoint = base_url;
+                
+                // For HDFS, compare endpoints (namenode addresses)
+                std::string target_endpoint = target_norm + "://" + target.authority;
+                
+                if (base_endpoint == target_endpoint)
+                {
+                    use_base_storage = true;
+                }
+            }
+            #endif
+        }
+        
+        // Also check if table_location is provided and matches
+        if (!use_base_storage && base_norm == "hdfs")
+        {
+            std::string base_endpoint = base_norm + "://" + base.authority;
+            std::string target_endpoint = target_norm + "://" + target.authority;
+            
+            if (base_endpoint == target_endpoint)
+            {
+                use_base_storage = true;
+            }
+        }
+        
+        if (use_base_storage)
+            return {base_storage, target.key};
+    }
 
     // Reuse base storage if scheme and authority (bucket) matches
     if (base_norm == target_norm && base.authority == target.authority)
@@ -454,7 +568,39 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
             endpoint.push_back('/');
         cfg->setString(config_prefix + ".endpoint", endpoint);
     }
-    // No extra config needed for local storage (file://)
+    else if (target_norm == "file")
+    {
+        // For file:// URIs, extract the directory path
+        // file:///absolute/path/to/file -> path = /absolute/path/to/, key = /absolute/path/to/file (full path)
+        std::string full_path = "/" + target.key;  // Reconstruct full path
+        std::filesystem::path fs_path(full_path);
+        std::filesystem::path parent = fs_path.parent_path();
+        std::string dir_path = parent.string();
+        
+        // Ensure directory path ends with /
+        if (dir_path.empty() || dir_path == "/")
+        {
+            // Root directory
+            dir_path = "/";
+        }
+        else if (dir_path.back() != '/')
+        {
+            dir_path += '/';
+        }
+        
+        cfg->setString(config_prefix + ".path", dir_path);
+        
+        auto & factory = DB::ObjectStorageFactory::instance();
+
+        // Also use the cache key as a (unique) storage name
+        DB::ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
+
+        secondary_storages.emplace(cache_key, storage);
+
+        // For local storage, getObjectMetadata expects the full path, not just the filename
+        // Return the full absolute path as the key
+        return {storage, full_path};
+    }
 
     auto & factory = DB::ObjectStorageFactory::instance();
 

--- a/src/Storages/ObjectStorage/Utils.cpp
+++ b/src/Storages/ObjectStorage/Utils.cpp
@@ -9,6 +9,13 @@
 #include <Interpreters/Context.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/ObjectStorage/Utils.h>
+#include <Disks/ObjectStorages/ObjectStorageFactory.h>
+#include <Poco/Util/MapConfiguration.h>
+#include <IO/S3/URI.h>
+#if USE_AWS_S3
+#include <Disks/ObjectStorages/S3/S3ObjectStorage.h>
+#endif
+
 
 namespace DB
 {
@@ -17,6 +24,74 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+inline std::string normalizeSchema(const std::string & schema)
+{
+    auto schema_lowercase = Poco::toLower(schema);
+
+    if (schema_lowercase == "s3a" || schema_lowercase == "s3n")
+        schema_lowercase = "s3";
+    else if (schema_lowercase == "wasb" || schema_lowercase == "wasbs" || schema_lowercase == "abfss")
+        schema_lowercase = "abfs";
+
+    return schema_lowercase;
+}
+
+inline std::string endpoint_cache_key(const std::string & normalized_scheme, const std::string & authority)
+{
+    return normalized_scheme + "://" + authority;
+}
+
+static std::string factoryTypeForScheme(const std::string & normalized_scheme)
+{
+    if (normalized_scheme == "s3") return "s3";
+    if (normalized_scheme == "abfs") return "azure";
+    if (normalized_scheme == "hdfs") return "hdfs";
+    if (normalized_scheme == "file") return "local";
+    return "";
+}
+
+}
+
+// TODO: handle https://s3.amazonaws.com/bucketname/... properly
+SchemeAuthorityKey::SchemeAuthorityKey(const std::string & uri)
+{
+    if (uri.empty())
+        return;
+
+    // scheme://authority/path
+    if (auto scheme_sep = uri.find("://"); scheme_sep != std::string_view::npos)
+    {
+        scheme = Poco::toLower(uri.substr(0, scheme_sep));
+        auto rest = uri.substr(scheme_sep + 3); // skip ://
+
+        // authority is up to next '/'
+        auto slash = rest.find('/');
+        if (slash == std::string_view::npos)
+        {
+            authority = std::string(rest);
+            key = "/";   // Happy debugging. FIXME: throw exception, path obviously incorrect
+            return;
+        }
+        authority = std::string(rest.substr(0, slash));
+        key = std::string(rest.substr(++slash)); // do not keep leading '/'
+        return;
+    }
+
+    // if part has no scheme and starts with '/' -- it is an absolute uri for local file: file:///path
+    if (uri.front() == '/')
+    {
+        scheme = "file";
+        key = std::string(uri);
+        return;
+    }
+
+    // Relative path, return as is
+    key = std::string(uri);
 }
 
 std::optional<String> checkAndGetNewFileOnInsertIfNeeded(
@@ -117,11 +192,278 @@ void validateSupportedColumns(
     }
 }
 
-namespace Setting
+inline bool isSameStorageSchema(const std::string & schema1, const std::string & schema2)
 {
-extern const SettingsUInt64 max_download_buffer_size;
-extern const SettingsBool use_cache_for_count_from_files;
-extern const SettingsString filesystem_cache_name;
-extern const SettingsUInt64 filesystem_cache_boundary_alignment;
+    return normalizeSchema(schema1) == normalizeSchema(schema2);
 }
+
+std::string extractStorageType(const std::string & path)
+{
+    if (path.empty())
+        return "";
+
+    // Absolute POSIX path -> file
+    if (path.front() == '/')
+        return "file";
+
+    // Look for "scheme://..."
+    if (auto pos = path.find("://"); pos != std::string_view::npos && pos > 0)
+        return Poco::toLower(path.substr(0, pos));
+
+    // Tolerant: "scheme:..." with no slash before colon (avoid Windows drive letters like "C:\")
+    {
+        auto colon_pos = path.find(':');
+        auto slash_pos = path.find('/');
+        if (colon_pos != std::string_view::npos && (slash_pos == std::string_view::npos || colon_pos < slash_pos))
+        {
+            auto maybe_scheme = path.substr(0, colon_pos);
+            // Heuristic: treat single-letter prefix followed by ":\\" as Windows drive, not a scheme
+            if (!(maybe_scheme.size() == 1 && colon_pos + 1 < path.size() && (path[colon_pos + 1] == '\\' || path[colon_pos + 1] == '/')))
+                return Poco::toLower(maybe_scheme);
+        }
+    }
+
+    // Relative path or unknown
+    return "";
+}
+
+bool isRelativePath(const std::string & path)
+{
+    if (path.empty())
+        return true;
+
+    // Non-relative if it has a scheme (e.g., s3://, file://)
+    if (!extractStorageType(path).empty())
+        return false;
+
+    return true;
+}
+
+std::string makeAbsolutePath(const std::string & table_location, const std::string & path)
+{
+    if (!isRelativePath(path))
+        return path;
+
+    auto base = SchemeAuthorityKey(table_location);
+
+    std::string base_dir = base.key.empty() ? std::string("/") : base.key;
+    if (!base_dir.empty() && base_dir.back() != '/')
+        base_dir.push_back('/');
+
+    std::string rel = path;
+    if (!rel.empty() && rel.front() == '/')
+        rel.erase(0, 1);
+
+    std::string abs_path = base_dir + rel;
+    if (abs_path.empty() || abs_path.front() != '/')
+        abs_path.insert(abs_path.begin(), '/');
+
+    if (!base.scheme.empty())
+        return base.scheme + "://" + base.authority + abs_path;
+
+    return std::string("file://") + abs_path;
+}
+
+std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
+    const std::string & table_location,
+    const std::string & path,
+    const DB::ObjectStoragePtr & base_storage,
+    std::map<std::string, DB::ObjectStoragePtr> & secondary_storages,
+    const DB::ContextPtr & context)
+{
+    if (isRelativePath(path))
+    {
+        // For relative paths, we need to construct the "full" key: table location + relative path
+        std::string full_key = path;
+
+        if (!table_location.empty())
+        {
+            SchemeAuthorityKey base{table_location};
+            if (!base.key.empty())
+            {
+                // Combine base key with relative path
+                full_key = base.key;
+                if (!full_key.empty() && full_key.back() != '/')
+                    full_key += '/';
+
+                std::string rel_path = path;
+                if (!rel_path.empty() && rel_path.front() == '/')
+                    rel_path = rel_path.substr(1);
+
+                full_key += rel_path;
+            }
+        }
+
+        return {base_storage, full_key}; // Relative path definitely goes to base storage
+    }
+
+    SchemeAuthorityKey base{table_location};
+    SchemeAuthorityKey target{path};
+
+    if (target.scheme.empty())
+    {
+        return {base_storage, target.key};
+    }
+
+    const std::string base_norm = normalizeSchema(base.scheme);
+    const std::string target_norm = normalizeSchema(target.scheme);
+
+    // For S3 URIs, use S3::URI to properly handle all kinds of URIs, e.g. https://s3.amazonaws.com/bucket/... == s3://bucket/...
+    #if USE_AWS_S3
+    if (target_norm == "s3" || target_norm == "https" || target_norm == "http")
+    {
+        try
+        {
+            S3::URI s3_uri(path);
+
+            // Check if base storage is S3 and matches the path's bucket/endpoint
+            bool use_base_storage = false;
+            if (base_storage->getType() == ObjectStorageType::S3)
+            {
+                #if USE_AWS_S3
+                if (auto s3_storage = std::dynamic_pointer_cast<S3ObjectStorage>(base_storage))
+                {
+                    const std::string base_bucket = s3_storage->getObjectsNamespace();
+                    const std::string base_endpoint = s3_storage->getDescription();
+                    
+                    // If bucket matches, use base storage. For s3:// URIs (which don't have explicit endpoint),
+                    // we should use base storage if bucket matches, regardless of endpoint.
+                    // For explicit http(s):// URIs, we require both bucket and endpoint to match.
+                    bool bucket_matches = (s3_uri.bucket == base_bucket);
+                    bool endpoint_matches = (s3_uri.endpoint == base_endpoint);
+                    bool is_generic_s3_uri = (target_norm == "s3");
+                    
+                    if (bucket_matches && (endpoint_matches || is_generic_s3_uri))
+                    {
+                        use_base_storage = true;
+                    }
+                }
+                #endif
+            }
+            
+            // Also check if table_location is provided and matches
+            if (!use_base_storage && (base_norm == "s3" || base_norm == "https" || base_norm == "http"))
+            {
+                S3::URI base_s3_uri(table_location);
+
+                // For s3:// URIs, match by bucket only. For explicit http(s):// URIs, require both bucket and endpoint.
+                bool bucket_matches = (s3_uri.bucket == base_s3_uri.bucket);
+                bool endpoint_matches = (s3_uri.endpoint == base_s3_uri.endpoint);
+                bool is_generic_s3_uri = (target_norm == "s3");
+                
+                if (bucket_matches && (endpoint_matches || is_generic_s3_uri))
+                {
+                    use_base_storage = true;
+                }
+            }
+            
+            if (use_base_storage)
+                return {base_storage, s3_uri.key};
+
+            const std::string cache_key = "s3://" + s3_uri.bucket + "@" + (s3_uri.endpoint.empty() ? "amazonaws.com" : s3_uri.endpoint);
+
+            if (auto it = secondary_storages.find(cache_key); it != secondary_storages.end())
+                return {it->second, s3_uri.key};
+
+            /// TODO: maybe do not invent new configuration. Use old one and clean up later
+            Poco::AutoPtr<Poco::Util::MapConfiguration> cfg(new Poco::Util::MapConfiguration);
+            const std::string config_prefix = "object_storages." + cache_key;
+
+            cfg->setString(config_prefix + ".object_storage_type", "s3");
+
+            // Use the full endpoint or construct it from bucket
+            std::string endpoint = s3_uri.endpoint.empty()
+                ? ("https://" + s3_uri.bucket + ".s3.amazonaws.com")
+                : s3_uri.endpoint;
+            cfg->setString(config_prefix + ".endpoint", endpoint);
+
+            // Copy credentials from base storage if it's also S3
+            if (base_storage->getType() == ObjectStorageType::S3)
+            {
+                #if USE_AWS_S3
+                if (auto s3_storage = std::dynamic_pointer_cast<S3ObjectStorage>(base_storage))
+                {
+                    if (auto s3_client = s3_storage->tryGetS3StorageClient())
+                    {
+                        const auto credentials = s3_client->getCredentials();
+                        const std::string access_key_id = credentials.GetAWSAccessKeyId();
+                        const std::string secret_access_key = credentials.GetAWSSecretKey();
+                        const std::string session_token = credentials.GetSessionToken();
+                        const std::string region = s3_client->getRegion();
+
+                        if (!access_key_id.empty())
+                            cfg->setString(config_prefix + ".access_key_id", access_key_id);
+                        if (!secret_access_key.empty())
+                            cfg->setString(config_prefix + ".secret_access_key", secret_access_key);
+                        if (!session_token.empty())
+                            cfg->setString(config_prefix + ".session_token", session_token);
+                        if (!region.empty())
+                            cfg->setString(config_prefix + ".region", region);
+                    }
+                }
+                #endif
+            }
+
+            auto & factory = DB::ObjectStorageFactory::instance();
+
+            DB::ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
+
+            secondary_storages.emplace(cache_key, storage);
+            return {storage, s3_uri.key};
+        }
+        catch (const Exception &) // NOLINT
+        {
+            // If S3::URI parsing fails, fall back to the old logic
+        }
+    }
+    #endif
+
+
+    // Reuse base storage if scheme and authority (bucket) matches
+    if (base_norm == target_norm && base.authority == target.authority)
+    {
+        return {base_storage, target.key};
+    }
+
+    const std::string cache_key = endpoint_cache_key(target_norm, target.authority);
+    if (auto it = secondary_storages.find(cache_key); it != secondary_storages.end())
+    {
+        return {it->second, target.key};
+    }
+
+    /// TODO: maybe do not invent new configuration. Use old one and clean up later
+    Poco::AutoPtr<Poco::Util::MapConfiguration> cfg(new Poco::Util::MapConfiguration);
+
+    const std::string type_for_factory = factoryTypeForScheme(target_norm);
+    if (type_for_factory.empty())
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unsupported storage scheme '{}' in path '{}'", target_norm, path);
+
+    const std::string config_prefix = "object_storages." + cache_key;
+
+    cfg->setString(config_prefix + ".object_storage_type", type_for_factory);
+
+    if (target_norm == "s3" || target_norm == "abfs")
+    {
+        cfg->setString(config_prefix + ".endpoint", target_norm + "://" + target.authority);
+    }
+    else if (target_norm == "hdfs")
+    {
+        // HDFS endpoint must end with '/'
+        auto endpoint = target_norm + "://" + target.authority;
+        if (!endpoint.empty() && endpoint.back() != '/')
+            endpoint.push_back('/');
+        cfg->setString(config_prefix + ".endpoint", endpoint);
+    }
+    // No extra config needed for local storage (file://)
+
+    auto & factory = DB::ObjectStorageFactory::instance();
+
+    // Also use the cache key as a (unique) storage name
+    DB::ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
+
+    secondary_storages.emplace(cache_key, storage);
+
+    return {storage, target.key};
+}
+
 }

--- a/src/Storages/ObjectStorage/Utils.cpp
+++ b/src/Storages/ObjectStorage/Utils.cpp
@@ -34,16 +34,16 @@ namespace ErrorCodes
 namespace
 {
 
-std::string normalizeSchema(const std::string & schema)
+std::string normalizeScheme(const std::string & scheme)
 {
-    auto schema_lowercase = Poco::toLower(schema);
+    auto scheme_lowercase = Poco::toLower(scheme);
 
-    if (schema_lowercase == "s3a" || schema_lowercase == "s3n")
-        schema_lowercase = "s3";
-    else if (schema_lowercase == "wasb" || schema_lowercase == "wasbs" || schema_lowercase == "abfss")
-        schema_lowercase = "abfs";
+    if (scheme_lowercase == "s3a" || scheme_lowercase == "s3n")
+        scheme_lowercase = "s3";
+    else if (scheme_lowercase == "wasb" || scheme_lowercase == "wasbs" || scheme_lowercase == "abfss")
+        scheme_lowercase = "abfs";
 
-    return schema_lowercase;
+    return scheme_lowercase;
 }
 
 std::string factoryTypeForScheme(const std::string & normalized_scheme)
@@ -63,6 +63,7 @@ bool isAbsolutePath(const std::string & path)
     return false;
 }
 
+/// Normalize a path string by removing redundant components and leading slashes.
 std::string normalizePathString(const std::string & path)
 {
     std::filesystem::path fs_path(path);
@@ -79,11 +80,11 @@ std::string normalizePathString(const std::string & path)
 #if USE_AWS_S3
 /// For s3:// URIs (generic), bucket needs to match.
 /// For explicit http(s):// URIs, both bucket and endpoint must match.
-bool s3URIMatches(const S3::URI & target_uri, const std::string & base_bucket, const std::string & base_endpoint, const std::string & target_schema_normalized)
+bool s3URIMatches(const S3::URI & target_uri, const std::string & base_bucket, const std::string & base_endpoint, const std::string & target_scheme_normalized)
 {
     bool bucket_matches = (target_uri.bucket == base_bucket);
     bool endpoint_matches = (target_uri.endpoint == base_endpoint);
-    bool is_generic_s3_uri = (target_schema_normalized == "s3");
+    bool is_generic_s3_uri = (target_scheme_normalized == "s3");
     return bucket_matches && (endpoint_matches || is_generic_s3_uri);
 }
 #endif
@@ -92,12 +93,15 @@ std::pair<ObjectStoragePtr, std::string> getOrCreateStorageAndKey(
     const std::string & cache_key,
     const std::string & key_to_use,
     const std::string & storage_type,
-    std::map<std::string, ObjectStoragePtr> & secondary_storages,
+    SecondaryStorages & secondary_storages,
     const ContextPtr & context,
     std::function<void(Poco::Util::MapConfiguration &, const std::string &)> configure_fn)
 {
-    if (auto it = secondary_storages.find(cache_key); it != secondary_storages.end())
-        return {it->second, key_to_use};
+    {
+        std::lock_guard lock(secondary_storages.mutex);
+        if (auto it = secondary_storages.storages.find(cache_key); it != secondary_storages.storages.end())
+            return {it->second, key_to_use};
+    }
 
     Poco::AutoPtr<Poco::Util::MapConfiguration> cfg(new Poco::Util::MapConfiguration);
     const std::string config_prefix = "object_storages." + cache_key;
@@ -109,11 +113,17 @@ std::pair<ObjectStoragePtr, std::string> getOrCreateStorageAndKey(
     auto & factory = ObjectStorageFactory::instance();
     ObjectStoragePtr storage = factory.create(cache_key, *cfg, config_prefix, context, /*skip_access_check*/ true);
 
-    secondary_storages.emplace(cache_key, storage);
+    {
+        std::lock_guard lock(secondary_storages.mutex);
+        auto [it, inserted] = secondary_storages.storages.emplace(cache_key, storage);
+        if (!inserted)
+            return {it->second, key_to_use};
+    }
 
     return {storage, key_to_use};
 }
 
+/// Normalize a path (relative to table location ot absolute path) to a key that will be looked up in the object storage.
 std::string normalizePathToStorageRoot(const std::string & table_location, const std::string & path)
 {
     if (table_location.empty())
@@ -306,7 +316,7 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     const std::string & table_location,
     const std::string & path,
     const DB::ObjectStoragePtr & base_storage,
-    std::map<std::string, DB::ObjectStoragePtr> & secondary_storages,
+    SecondaryStorages & secondary_storages,
     const DB::ContextPtr & context)
 {
     if (!isAbsolutePath(path))
@@ -315,18 +325,12 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     SchemeAuthorityKey table_location_decomposed{table_location};
     SchemeAuthorityKey target_decomposed{path};
 
-    if (target_decomposed.scheme.empty())
-    {
-        // Path has no scheme but wasn't caught by isRelativePath; treat it as relative and normalize to storage root
-        return {base_storage, normalizePathToStorageRoot(table_location, target_decomposed.key)};
-    }
-
-    const std::string base_schema_normalized = normalizeSchema(table_location_decomposed.scheme);
-    const std::string target_schema_normalized = normalizeSchema(target_decomposed.scheme);
+    const std::string base_scheme_normalized = normalizeScheme(table_location_decomposed.scheme);
+    const std::string target_scheme_normalized = normalizeScheme(target_decomposed.scheme);
 
     // For S3 URIs, use S3::URI to properly handle all kinds of URIs, e.g. https://s3.amazonaws.com/bucket/... == s3://bucket/...
     #if USE_AWS_S3
-    if (target_schema_normalized == "s3" || target_schema_normalized == "https" || target_schema_normalized == "http")
+    if (target_scheme_normalized == "s3" || target_scheme_normalized == "https" || target_scheme_normalized == "http")
     {
         std::string normalized_path = path;
         if (target_decomposed.scheme == "s3a" || target_decomposed.scheme == "s3n")
@@ -345,12 +349,12 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
                 const std::string base_bucket = s3_storage->getObjectsNamespace();
                 const std::string base_endpoint = s3_storage->getDescription();
 
-                if (s3URIMatches(s3_uri, base_bucket, base_endpoint, target_schema_normalized))
+                if (s3URIMatches(s3_uri, base_bucket, base_endpoint, target_scheme_normalized))
                     use_base_storage = true;
             }
         }
         
-        if (!use_base_storage && (base_schema_normalized == "s3" || base_schema_normalized == "https" || base_schema_normalized == "http"))
+        if (!use_base_storage && (base_scheme_normalized == "s3" || base_scheme_normalized == "https" || base_scheme_normalized == "http"))
         {
             std::string normalized_table_location = table_location;
             if (table_location_decomposed.scheme == "s3a" || table_location_decomposed.scheme == "s3n")
@@ -359,7 +363,7 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
             }
             S3::URI base_s3_uri(normalized_table_location);
             
-            if (s3URIMatches(s3_uri, base_s3_uri.bucket, base_s3_uri.endpoint, target_schema_normalized))
+            if (s3URIMatches(s3_uri, base_s3_uri.bucket, base_s3_uri.endpoint, target_scheme_normalized))
                 use_base_storage = true;
         }
         
@@ -411,7 +415,7 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     #endif
 
     #if USE_HDFS
-    if (target_schema_normalized == "hdfs")
+    if (target_scheme_normalized == "hdfs")
     {
         bool use_base_storage = false;
         
@@ -429,13 +433,13 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
                     base_endpoint = base_url;
                 
                 // For HDFS, compare endpoints (namenode addresses)
-                std::string target_endpoint = target_schema_normalized + "://" + target_decomposed.authority;
+                std::string target_endpoint = target_scheme_normalized + "://" + target_decomposed.authority;
                 
                 if (base_endpoint == target_endpoint)
                     use_base_storage = true;
                 
                 // Also check if table_location matches
-                if (!use_base_storage && base_schema_normalized == "hdfs")
+                if (!use_base_storage && base_scheme_normalized == "hdfs")
                 {
                     if (table_location_decomposed.authority == target_decomposed.authority)
                         use_base_storage = true;
@@ -449,17 +453,17 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     #endif
 
     /// Fallback for schemes not handled above (e.g., abfs, file)
-    if (base_schema_normalized == target_schema_normalized && table_location_decomposed.authority == target_decomposed.authority)
+    if (base_scheme_normalized == target_scheme_normalized && table_location_decomposed.authority == target_decomposed.authority)
         return {base_storage, target_decomposed.key};
 
-    const std::string cache_key = target_schema_normalized + "://" + target_decomposed.authority;
+    const std::string cache_key = target_scheme_normalized + "://" + target_decomposed.authority;
 
-    const std::string type_for_factory = factoryTypeForScheme(target_schema_normalized);
+    const std::string type_for_factory = factoryTypeForScheme(target_scheme_normalized);
     if (type_for_factory.empty())
-        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unsupported storage scheme '{}' in path '{}'", target_schema_normalized, path);
+        throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS, "Unsupported storage scheme '{}' in path '{}'", target_scheme_normalized, path);
 
     std::string key_to_use = target_decomposed.key;
-    if (target_schema_normalized == "file")
+    if (target_scheme_normalized == "file")
         key_to_use = "/" + target_decomposed.key;  // file:///absolute/path/to/file -> key = /absolute/path/to/file (full POSIX path)
 
     /// Handle storage types that need new storage creation
@@ -471,7 +475,7 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
         context,
         [&](Poco::Util::MapConfiguration & cfg, const std::string & config_prefix)
         {
-            if (target_schema_normalized == "file")
+            if (target_scheme_normalized == "file")
             {
                 std::filesystem::path fs_path(key_to_use);
                 std::filesystem::path parent = fs_path.parent_path();
@@ -484,14 +488,14 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
                 
                 cfg.setString(config_prefix + ".path", dir_path);
             }
-            else if (target_schema_normalized == "abfs")
+            else if (target_scheme_normalized == "abfs")
             {
-                cfg.setString(config_prefix + ".endpoint", target_schema_normalized + "://" + target_decomposed.authority);
+                cfg.setString(config_prefix + ".endpoint", target_scheme_normalized + "://" + target_decomposed.authority);
             }
-            else if (target_schema_normalized == "hdfs")
+            else if (target_scheme_normalized == "hdfs")
             {
                 // HDFS endpoint must end with '/'
-                auto endpoint = target_schema_normalized + "://" + target_decomposed.authority;
+                auto endpoint = target_scheme_normalized + "://" + target_decomposed.authority;
                 if (!endpoint.empty() && endpoint.back() != '/')
                     endpoint.push_back('/');
                 cfg.setString(config_prefix + ".endpoint", endpoint);

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -56,6 +56,11 @@ std::string extractStorageType(const std::string & path);
 
 std::string makeAbsolutePath(const std::string & table_location, const std::string & path);
 
+// Normalize a path that may be relative to table location to be relative to storage root
+// Returns the normalized key (not a full URI)
+// Handles cases where the path already includes the table location prefix
+std::string normalizePathToStorageRoot(const std::string & table_location, const std::string & path);
+
 // Resolve object storage for reading a file from
 // * If path is relative -- it must be read from "base" storage
 // * Otherwise, lookup if suitable storage already exists in secondary_storages

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -1,10 +1,25 @@
 #pragma once
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 
+#include <Disks/ObjectStorages/IObjectStorage_fwd.h>
+
 namespace DB
 {
 
 class IObjectStorage;
+
+// A URI splitted into components
+//  s3://bucket/a/b -> scheme="s3", authority="bucket", path="/a/b"
+//  file:///var/x    -> scheme="file", authority="",     path="/var/x"
+//  /abs/p           -> scheme="",     authority="",     path="/abs/p"
+struct SchemeAuthorityKey
+{
+    explicit SchemeAuthorityKey(const std::string & uri);
+
+    std::string scheme;
+    std::string authority;
+    std::string key;
+};
 
 std::optional<std::string> checkAndGetNewFileOnInsertIfNeeded(
     const IObjectStorage & object_storage,
@@ -31,4 +46,25 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     const ContextPtr & context_,
     const LoggerPtr & log,
     const std::optional<ReadSettings> & read_settings = std::nullopt);
+
+bool isRelativePath(const std::string & path);
+
+bool isSameStorageSchema(const std::string & schema1, const std::string & schema2);
+
+// Returns lowercased and normalized schema / storage type (e.g. s3:// -> "s3")
+std::string extractStorageType(const std::string & path);
+
+std::string makeAbsolutePath(const std::string & table_location, const std::string & path);
+
+// Resolve object storage for reading a file from
+// * If path is relative -- it must be read from "base" storage
+// * Otherwise, lookup if suitable storage already exists in secondary_storages
+// * Also, TODO: come back here and make some comments
+std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
+    const std::string & table_location,
+    const std::string & path,
+    const DB::ObjectStoragePtr & base_storage,
+    std::map<std::string, DB::ObjectStoragePtr> & secondary_storages,
+    const DB::ContextPtr & context);
+
 }

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -2,11 +2,20 @@
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 
 #include <Disks/ObjectStorages/IObjectStorage_fwd.h>
+#include <mutex>
+#include <map>
 
 namespace DB
 {
 
 class IObjectStorage;
+
+/// Thread-safe wrapper for secondary object storages map
+struct SecondaryStorages
+{
+    mutable std::mutex mutex;
+    std::map<std::string, ObjectStoragePtr> storages;
+};
 
 // A URI splitted into components
 //  s3://bucket/a/b -> scheme="s3", authority="bucket", path="/a/b"
@@ -56,7 +65,7 @@ std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     const std::string & table_location,
     const std::string & path,
     const DB::ObjectStoragePtr & base_storage,
-    std::map<std::string, DB::ObjectStoragePtr> & secondary_storages,
+    SecondaryStorages & secondary_storages,
     const DB::ContextPtr & context);
 
 }

--- a/src/Storages/ObjectStorage/Utils.h
+++ b/src/Storages/ObjectStorage/Utils.h
@@ -47,24 +47,11 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     const LoggerPtr & log,
     const std::optional<ReadSettings> & read_settings = std::nullopt);
 
-bool isRelativePath(const std::string & path);
-
-bool isSameStorageSchema(const std::string & schema1, const std::string & schema2);
-
-// Returns lowercased and normalized schema / storage type (e.g. s3:// -> "s3")
-std::string extractStorageType(const std::string & path);
-
 std::string makeAbsolutePath(const std::string & table_location, const std::string & path);
 
-// Normalize a path that may be relative to table location to be relative to storage root
-// Returns the normalized key (not a full URI)
-// Handles cases where the path already includes the table location prefix
-std::string normalizePathToStorageRoot(const std::string & table_location, const std::string & path);
-
-// Resolve object storage for reading a file from
-// * If path is relative -- it must be read from "base" storage
-// * Otherwise, lookup if suitable storage already exists in secondary_storages
-// * Also, TODO: come back here and make some comments
+/// Resolve object storage and key for reading from that storage
+/// If path is relative -- it must be read from base_storage
+/// Otherwise, look for a suitable storage in secondary_storages
 std::pair<DB::ObjectStoragePtr, std::string> resolveObjectStorageForPath(
     const std::string & table_location,
     const std::string & path,

--- a/tests/queries/0_stateless/data_minio/field_ids_complex_test/metadata/v1.metadata.json
+++ b/tests/queries/0_stateless/data_minio/field_ids_complex_test/metadata/v1.metadata.json
@@ -1,7 +1,7 @@
 {
   "format-version" : 2,
   "table-uuid" : "d4b695ca-ceeb-4537-8a2a-eee90dc6e313",
-  "location" : "s3a://test/field_ids_struct_test/metadata/field_ids_complex_test",
+  "location" : "s3a://test/field_ids_complex_test",
   "last-sequence-number" : 1,
   "last-updated-ms" : 1757661733693,
   "last-column-id" : 9,
@@ -96,7 +96,7 @@
       "total-position-deletes" : "0",
       "total-equality-deletes" : "0"
     },
-    "manifest-list" : "s3a://test/field_ids_struct_test/metadata/field_ids_complex_test/metadata/snap-607752583403487091-1-140c8dff-1d83-4841-bc40-9aa85205b555.avro",
+    "manifest-list" : "s3a://test/field_ids_complex_test/metadata/snap-607752583403487091-1-140c8dff-1d83-4841-bc40-9aa85205b555.avro",
     "schema-id" : 0
   } ],
   "statistics" : [ ],

--- a/tests/queries/0_stateless/data_minio/field_ids_struct_test/metadata/v1.metadata.json
+++ b/tests/queries/0_stateless/data_minio/field_ids_struct_test/metadata/v1.metadata.json
@@ -1,7 +1,7 @@
 {
   "format-version" : 2,
   "table-uuid" : "149ecc15-7afc-4311-86b3-3a4c8d4ec08e",
-  "location" : "s3a://test/field_ids_struct_test/metadata/field_ids_struct_test",
+  "location" : "s3a://test/field_ids_struct_test",
   "last-sequence-number" : 1,
   "last-updated-ms" : 1753959190403,
   "last-column-id" : 6,
@@ -84,7 +84,7 @@
       "total-position-deletes" : "0",
       "total-equality-deletes" : "0"
     },
-    "manifest-list" : "s3a://test/field_ids_struct_test/metadata/field_ids_struct_test/metadata/snap-2512638186869817292-1-ec467367-15a4-4610-8ea8-cf76797afb03.avro",
+    "manifest-list" : "s3a://test/field_ids_struct_test/metadata/snap-2512638186869817292-1-ec467367-15a4-4610-8ea8-cf76797afb03.avro",
     "schema-id" : 0
   } ],
   "statistics" : [ ],

--- a/tests/queries/0_stateless/data_minio/field_ids_table_test/metadata/v1.metadata.json
+++ b/tests/queries/0_stateless/data_minio/field_ids_table_test/metadata/v1.metadata.json
@@ -1,7 +1,7 @@
 {
   "format-version" : 2,
   "table-uuid" : "8f1f9ae2-18bb-421e-b640-ec2f85e67bce",
-  "location" : "s3a://test/field_ids_table_test/metadata/field_ids_table_test",
+  "location" : "s3a://test/field_ids_table_test",
   "last-sequence-number" : 1,
   "last-updated-ms" : 1752481476160,
   "last-column-id" : 1,
@@ -56,7 +56,7 @@
       "total-position-deletes" : "0",
       "total-equality-deletes" : "0"
     },
-    "manifest-list" : "s3a://test/field_ids_table_test/metadata/field_ids_table_test/metadata/snap-2811410366534688344-1-3b002f99-b012-4041-9a97-db477fcc7115.avro",
+    "manifest-list" : "s3a://test/field_ids_table_test/metadata/snap-2811410366534688344-1-3b002f99-b012-4041-9a97-db477fcc7115.avro",
     "schema-id" : 0
   } ],
   "statistics" : [ ],


### PR DESCRIPTION
Successor of https://github.com/Altinity/ClickHouse/pull/1008.

Closes https://github.com/Altinity/ClickHouse/issues/963, https://github.com/ClickHouse/ClickHouse/issues/84609. PR to upstream is upcoming


### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Allow to read Iceberg data from any location


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)