### PR TITLE
Do not throw exception when reading Iceberg metadata failed in call to system.tables 

### DIFF
--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -607,18 +607,25 @@ protected:
                 if (columns_mask[src_index++])
                 {
                     bool inserted = false;
-                    // Extract from specific DataLake metadata if suitable
-                    if (auto * obj = dynamic_cast<StorageObjectStorageCluster *>(table.get()))
+                    try
                     {
-                        if (auto * dl_meta = obj->getExternalMetadata(context))
+                        // Extract from specific DataLake metadata if suitable
+                        if (auto * obj = dynamic_cast<StorageObjectStorageCluster *>(table.get()))
                         {
-                            if (auto p = dl_meta->partitionKey(context); p.has_value())
+                            if (auto * dl_meta = obj->getExternalMetadata(context))
                             {
-                                res_columns[res_index++]->insert(*p);
-                                inserted = true;
+                                if (auto p = dl_meta->partitionKey(context); p.has_value())
+                                {
+                                    res_columns[res_index++]->insert(*p);
+                                    inserted = true;
+                                }
                             }
                         }
-
+                    }
+                    catch (const Exception &)
+                    {
+                        /// Failed to get info from Iceberg. It's not critical, just log it.
+                        tryLogCurrentException("StorageSystemTables");
                     }
 
                     if (!inserted)
@@ -634,17 +641,25 @@ protected:
                 {
                     bool inserted = false;
 
-                    // Extract from specific DataLake metadata if suitable
-                    if (auto * obj = dynamic_cast<StorageObjectStorageCluster *>(table.get()))
+                    try
                     {
-                        if (auto * dl_meta = obj->getExternalMetadata(context))
+                        // Extract from specific DataLake metadata if suitable
+                        if (auto * obj = dynamic_cast<StorageObjectStorageCluster *>(table.get()))
                         {
-                            if (auto p = dl_meta->sortingKey(context); p.has_value())
+                            if (auto * dl_meta = obj->getExternalMetadata(context))
                             {
-                                res_columns[res_index++]->insert(*p);
-                                inserted = true;
+                                if (auto p = dl_meta->sortingKey(context); p.has_value())
+                                {
+                                    res_columns[res_index++]->insert(*p);
+                                    inserted = true;
+                                }
                             }
                         }
+                    }
+                    catch (const Exception &)
+                    {
+                        /// Failed to get info from Iceberg. It's not critical, just log it.
+                        tryLogCurrentException("StorageSystemTables");
                     }
 
                     if (!inserted)


### PR DESCRIPTION
Follow-up for https://github.com/Altinity/ClickHouse/pull/1095

cc @filimonov 

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not throw exception when reading Iceberg metadata failed in call to system.tables 


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)