### PR TITLE
Antalya 25.8: Fix for opt-in AWS S3 regions when no explicit region is specified

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -705,12 +705,13 @@ Client::doRequest(RequestType & request, RequestFn request_fn) const
 
         /// IllegalLocationConstraintException may indicate that we are working with an opt-in region (e.g. me-south-1)
         /// In that case, we need to update the region and try again
-        if (error.GetResponseCode() != Aws::Http::HttpResponseCode::MOVED_PERMANENTLY && error.GetExceptionName() != "IllegalLocationConstraintException")
+        bool is_illegal_constraint_exception = error.GetExceptionName() == "IllegalLocationConstraintException";
+        if (error.GetResponseCode() != Aws::Http::HttpResponseCode::MOVED_PERMANENTLY && !is_illegal_constraint_exception)
             return result;
 
         // maybe we detect a correct region
         bool new_region_detected = false;
-        if (!detect_region || error.GetExceptionName() == "IllegalLocationConstraintException")
+        if (!detect_region || is_illegal_constraint_exception)
         {
             if (auto region = GetErrorMarshaller()->ExtractRegion(error); !region.empty() && region != explicit_region)
             {
@@ -722,7 +723,7 @@ Client::doRequest(RequestType & request, RequestFn request_fn) const
         }
 
         /// special handling for opt-in regions
-        if (new_region_detected && error.GetExceptionName() == "IllegalLocationConstraintException" && initial_endpoint.substr(11) == "amazonaws.com")
+        if (new_region_detected && is_illegal_constraint_exception && initial_endpoint.substr(11) == "amazonaws.com")
         {
             S3::URI new_uri(initial_endpoint);
             new_uri.addRegionToURI(request.getRegionOverride());

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -733,7 +733,7 @@ Client::doRequest(RequestType & request, RequestFn request_fn) const
 
         // we possibly got new location, need to try with that one
         auto new_uri = getURIFromError(error);
-        if (!new_uri && !new_region_detected)
+        if (!new_uri)
             return result;
 
         if (initial_endpoint.substr(11) == "amazonaws.com") // Check if user didn't mention any region

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -703,22 +703,37 @@ Client::doRequest(RequestType & request, RequestFn request_fn) const
             continue;
         }
 
-        if (error.GetResponseCode() != Aws::Http::HttpResponseCode::MOVED_PERMANENTLY)
+        /// IllegalLocationConstraintException may indicate that we are working with an opt-in region (e.g. me-south-1)
+        /// In that case, we need to update the region and try again
+        if (error.GetResponseCode() != Aws::Http::HttpResponseCode::MOVED_PERMANENTLY && error.GetExceptionName() != "IllegalLocationConstraintException")
             return result;
 
         // maybe we detect a correct region
-        if (!detect_region)
+        bool new_region_detected = false;
+        if (!detect_region || error.GetExceptionName() == "IllegalLocationConstraintException")
         {
             if (auto region = GetErrorMarshaller()->ExtractRegion(error); !region.empty() && region != explicit_region)
             {
+                LOG_INFO(log, "Detected new region: {}", region);
                 request.overrideRegion(region);
                 insertRegionOverride(bucket, region);
+                new_region_detected = true;
             }
+        }
+
+        /// special handling for opt-in regions
+        if (new_region_detected && error.GetExceptionName() == "IllegalLocationConstraintException" && initial_endpoint.substr(11) == "amazonaws.com")
+        {
+            S3::URI new_uri(initial_endpoint);
+            new_uri.addRegionToURI(request.getRegionOverride());
+            found_new_endpoint = true;
+            request.overrideURI(new_uri);
+            continue;
         }
 
         // we possibly got new location, need to try with that one
         auto new_uri = getURIFromError(error);
-        if (!new_uri)
+        if (!new_uri && !new_region_detected)
             return result;
 
         if (initial_endpoint.substr(11) == "amazonaws.com") // Check if user didn't mention any region


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Proper handling of opt-in AWS regions for S3


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)