### PR TITLE
Preserve parquet specific parallel formatting for export part

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -212,8 +212,6 @@ namespace Setting
     extern const SettingsBool allow_experimental_export_merge_tree_part;
     extern const SettingsUInt64 min_bytes_to_use_direct_io;
     extern const SettingsBool export_merge_tree_part_overwrite_file_if_exists;
-    extern const SettingsBool output_format_parallel_formatting;
-    extern const SettingsBool output_format_parallel_formatting_parquet;
 }
 
 namespace MergeTreeSetting
@@ -6295,7 +6293,7 @@ void MergeTreeData::exportPartToTableImpl(
             manifest.data_part->name + "_" + manifest.data_part->checksums.getTotalChecksumHex(),
             block_with_partition_values,
             destination_file_path,
-            manifest.overwrite_file_if_exists,
+            local_context->getSettingsRef()[Setting::export_merge_tree_part_overwrite_file_if_exists],
             local_context);
     }
     catch (const Exception & e)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6295,7 +6295,7 @@ void MergeTreeData::exportPartToTableImpl(
     {
         auto context_copy = Context::createCopy(local_context);
         context_copy->setSetting("output_format_parallel_formatting", manifest.parallel_formatting);
-        context_copy->setSetting("output_format_parquet_parallel_encoding", manifest.parallel_formatting_parquet);
+        context_copy->setSetting("output_format_parquet_parallel_encoding", manifest.parquet_parallel_encoding);
         context_copy->setSetting("max_threads", manifest.max_threads);
 
         sink = destination_storage->import(

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -213,7 +213,7 @@ namespace Setting
     extern const SettingsUInt64 min_bytes_to_use_direct_io;
     extern const SettingsBool export_merge_tree_part_overwrite_file_if_exists;
     extern const SettingsBool output_format_parallel_formatting;
-    extern const SettingsBool output_format_parallel_formatting_parquet;
+    extern const SettingsBool output_format_parquet_parallel_encoding;
 }
 
 namespace MergeTreeSetting
@@ -6246,7 +6246,7 @@ void MergeTreeData::exportPartToTable(const PartitionCommand & command, ContextP
             part,
             query_context->getSettingsRef()[Setting::export_merge_tree_part_overwrite_file_if_exists],
             query_context->getSettingsRef()[Setting::output_format_parallel_formatting],
-            query_context->getSettingsRef()[Setting::output_format_parallel_formatting_parquet]);
+            query_context->getSettingsRef()[Setting::output_format_parquet_parallel_encoding]);
 
         std::lock_guard lock(export_manifests_mutex);
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6244,9 +6244,7 @@ void MergeTreeData::exportPartToTable(const PartitionCommand & command, ContextP
         MergeTreeExportManifest manifest(
             dest_storage->getStorageID(),
             part,
-            query_context->getSettingsRef()[Setting::export_merge_tree_part_overwrite_file_if_exists],
-            query_context->getSettingsRef()[Setting::output_format_parallel_formatting],
-            query_context->getSettingsRef()[Setting::output_format_parallel_formatting_parquet]);
+            query_context);
 
         std::lock_guard lock(export_manifests_mutex);
 
@@ -6291,17 +6289,14 @@ void MergeTreeData::exportPartToTableImpl(
     std::string destination_file_path;
 
     try
-    {
-        auto context_copy = Context::createCopy(local_context);
-        context_copy->setSetting("output_format_parallel_formatting", manifest.parallel_formatting);
-        context_copy->setSetting("output_format_parquet_parallel_encoding", manifest.parallel_formatting_parquet);
+        {
 
         sink = destination_storage->import(
             manifest.data_part->name + "_" + manifest.data_part->checksums.getTotalChecksumHex(),
             block_with_partition_values,
             destination_file_path,
             manifest.overwrite_file_if_exists,
-            context_copy);
+            local_context);
     }
     catch (const Exception & e)
     {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -212,6 +212,8 @@ namespace Setting
     extern const SettingsBool allow_experimental_export_merge_tree_part;
     extern const SettingsUInt64 min_bytes_to_use_direct_io;
     extern const SettingsBool export_merge_tree_part_overwrite_file_if_exists;
+    extern const SettingsBool output_format_parallel_formatting;
+    extern const SettingsBool output_format_parallel_formatting_parquet;
 }
 
 namespace MergeTreeSetting
@@ -6293,7 +6295,7 @@ void MergeTreeData::exportPartToTableImpl(
             manifest.data_part->name + "_" + manifest.data_part->checksums.getTotalChecksumHex(),
             block_with_partition_values,
             destination_file_path,
-            local_context->getSettingsRef()[Setting::export_merge_tree_part_overwrite_file_if_exists],
+            manifest.overwrite_file_if_exists,
             local_context);
     }
     catch (const Exception & e)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6244,7 +6244,9 @@ void MergeTreeData::exportPartToTable(const PartitionCommand & command, ContextP
         MergeTreeExportManifest manifest(
             dest_storage->getStorageID(),
             part,
-            query_context);
+            query_context->getSettingsRef()[Setting::export_merge_tree_part_overwrite_file_if_exists],
+            query_context->getSettingsRef()[Setting::output_format_parallel_formatting],
+            query_context->getSettingsRef()[Setting::output_format_parallel_formatting_parquet]);
 
         std::lock_guard lock(export_manifests_mutex);
 
@@ -6289,14 +6291,17 @@ void MergeTreeData::exportPartToTableImpl(
     std::string destination_file_path;
 
     try
-        {
+    {
+        auto context_copy = Context::createCopy(local_context);
+        context_copy->setSetting("output_format_parallel_formatting", manifest.parallel_formatting);
+        context_copy->setSetting("output_format_parquet_parallel_encoding", manifest.parallel_formatting_parquet);
 
         sink = destination_storage->import(
             manifest.data_part->name + "_" + manifest.data_part->checksums.getTotalChecksumHex(),
             block_with_partition_values,
             destination_file_path,
             manifest.overwrite_file_if_exists,
-            local_context);
+            context_copy);
     }
     catch (const Exception & e)
     {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -213,6 +213,7 @@ namespace Setting
     extern const SettingsUInt64 min_bytes_to_use_direct_io;
     extern const SettingsBool export_merge_tree_part_overwrite_file_if_exists;
     extern const SettingsBool output_format_parallel_formatting;
+    extern const SettingsBool output_format_parallel_formatting_parquet;
 }
 
 namespace MergeTreeSetting
@@ -6244,7 +6245,8 @@ void MergeTreeData::exportPartToTable(const PartitionCommand & command, ContextP
             dest_storage->getStorageID(),
             part,
             query_context->getSettingsRef()[Setting::export_merge_tree_part_overwrite_file_if_exists],
-            query_context->getSettingsRef()[Setting::output_format_parallel_formatting]);
+            query_context->getSettingsRef()[Setting::output_format_parallel_formatting],
+            query_context->getSettingsRef()[Setting::output_format_parallel_formatting_parquet]);
 
         std::lock_guard lock(export_manifests_mutex);
 
@@ -6292,6 +6294,7 @@ void MergeTreeData::exportPartToTableImpl(
     {
         auto context_copy = Context::createCopy(local_context);
         context_copy->setSetting("output_format_parallel_formatting", manifest.parallel_formatting);
+        context_copy->setSetting("output_format_parquet_parallel_encoding", manifest.parallel_formatting_parquet);
 
         sink = destination_storage->import(
             manifest.data_part->name + "_" + manifest.data_part->checksums.getTotalChecksumHex(),

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6246,7 +6246,8 @@ void MergeTreeData::exportPartToTable(const PartitionCommand & command, ContextP
             part,
             query_context->getSettingsRef()[Setting::export_merge_tree_part_overwrite_file_if_exists],
             query_context->getSettingsRef()[Setting::output_format_parallel_formatting],
-            query_context->getSettingsRef()[Setting::output_format_parquet_parallel_encoding]);
+            query_context->getSettingsRef()[Setting::output_format_parquet_parallel_encoding],
+            query_context->getSettingsRef()[Setting::max_threads]);
 
         std::lock_guard lock(export_manifests_mutex);
 
@@ -6295,6 +6296,7 @@ void MergeTreeData::exportPartToTableImpl(
         auto context_copy = Context::createCopy(local_context);
         context_copy->setSetting("output_format_parallel_formatting", manifest.parallel_formatting);
         context_copy->setSetting("output_format_parquet_parallel_encoding", manifest.parallel_formatting_parquet);
+        context_copy->setSetting("max_threads", manifest.max_threads);
 
         sink = destination_storage->import(
             manifest.data_part->name + "_" + manifest.data_part->checksums.getTotalChecksumHex(),

--- a/src/Storages/MergeTree/MergeTreeExportManifest.h
+++ b/src/Storages/MergeTree/MergeTreeExportManifest.h
@@ -14,12 +14,14 @@ struct MergeTreeExportManifest
         const DataPartPtr & data_part_,
         bool overwrite_file_if_exists_,
         bool parallel_formatting_,
-        bool parallel_formatting_parquet_)
+        bool parallel_formatting_parquet_,
+        std::size_t max_threads_)
         : destination_storage_id(destination_storage_id_),
           data_part(data_part_),
           overwrite_file_if_exists(overwrite_file_if_exists_),
           parallel_formatting(parallel_formatting_),
           parallel_formatting_parquet(parallel_formatting_parquet_),
+          max_threads(max_threads_),
           create_time(time(nullptr)) {}
 
     StorageID destination_storage_id;
@@ -28,6 +30,7 @@ struct MergeTreeExportManifest
     bool parallel_formatting;
     /// parquet has a different setting for parallel formatting
     bool parallel_formatting_parquet;
+    std::size_t max_threads;
 
     time_t create_time;
     mutable bool in_progress = false;

--- a/src/Storages/MergeTree/MergeTreeExportManifest.h
+++ b/src/Storages/MergeTree/MergeTreeExportManifest.h
@@ -12,15 +12,23 @@ struct MergeTreeExportManifest
     MergeTreeExportManifest(
         const StorageID & destination_storage_id_,
         const DataPartPtr & data_part_,
-        ContextPtr context_)
+        bool overwrite_file_if_exists_,
+        bool parallel_formatting_,
+        bool parallel_formatting_parquet_)
         : destination_storage_id(destination_storage_id_),
           data_part(data_part_),
-          context(context_),
+          overwrite_file_if_exists(overwrite_file_if_exists_),
+          parallel_formatting(parallel_formatting_),
+          parallel_formatting_parquet(parallel_formatting_parquet_),
           create_time(time(nullptr)) {}
 
     StorageID destination_storage_id;
     DataPartPtr data_part;
-    ContextPtr context;
+    bool overwrite_file_if_exists;
+    bool parallel_formatting;
+    /// parquet has a different setting for parallel formatting
+    bool parallel_formatting_parquet;
+
     time_t create_time;
     mutable bool in_progress = false;
 

--- a/src/Storages/MergeTree/MergeTreeExportManifest.h
+++ b/src/Storages/MergeTree/MergeTreeExportManifest.h
@@ -12,23 +12,15 @@ struct MergeTreeExportManifest
     MergeTreeExportManifest(
         const StorageID & destination_storage_id_,
         const DataPartPtr & data_part_,
-        bool overwrite_file_if_exists_,
-        bool parallel_formatting_,
-        bool parallel_formatting_parquet_)
+        ContextPtr context_)
         : destination_storage_id(destination_storage_id_),
           data_part(data_part_),
-          overwrite_file_if_exists(overwrite_file_if_exists_),
-          parallel_formatting(parallel_formatting_),
-          parallel_formatting_parquet(parallel_formatting_parquet_),
+          context(context_),
           create_time(time(nullptr)) {}
 
     StorageID destination_storage_id;
     DataPartPtr data_part;
-    bool overwrite_file_if_exists;
-    bool parallel_formatting;
-    /// parquet has a different setting for parallel formatting
-    bool parallel_formatting_parquet;
-
+    ContextPtr context;
     time_t create_time;
     mutable bool in_progress = false;
 

--- a/src/Storages/MergeTree/MergeTreeExportManifest.h
+++ b/src/Storages/MergeTree/MergeTreeExportManifest.h
@@ -20,7 +20,7 @@ struct MergeTreeExportManifest
           data_part(data_part_),
           overwrite_file_if_exists(overwrite_file_if_exists_),
           parallel_formatting(parallel_formatting_),
-          parallel_formatting_parquet(parallel_formatting_parquet_),
+          parquet_parallel_encoding(parallel_formatting_parquet_),
           max_threads(max_threads_),
           create_time(time(nullptr)) {}
 
@@ -29,7 +29,7 @@ struct MergeTreeExportManifest
     bool overwrite_file_if_exists;
     bool parallel_formatting;
     /// parquet has a different setting for parallel formatting
-    bool parallel_formatting_parquet;
+    bool parquet_parallel_encoding;
     std::size_t max_threads;
 
     time_t create_time;

--- a/src/Storages/MergeTree/MergeTreeExportManifest.h
+++ b/src/Storages/MergeTree/MergeTreeExportManifest.h
@@ -13,17 +13,21 @@ struct MergeTreeExportManifest
         const StorageID & destination_storage_id_,
         const DataPartPtr & data_part_,
         bool overwrite_file_if_exists_,
-        bool parallel_formatting_)
+        bool parallel_formatting_,
+        bool parallel_formatting_parquet_)
         : destination_storage_id(destination_storage_id_),
           data_part(data_part_),
           overwrite_file_if_exists(overwrite_file_if_exists_),
           parallel_formatting(parallel_formatting_),
+          parallel_formatting_parquet(parallel_formatting_parquet_),
           create_time(time(nullptr)) {}
 
     StorageID destination_storage_id;
     DataPartPtr data_part;
     bool overwrite_file_if_exists;
     bool parallel_formatting;
+    /// parquet has a different setting for parallel formatting
+    bool parallel_formatting_parquet;
 
     time_t create_time;
     mutable bool in_progress = false;

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -169,7 +169,8 @@ MergeTreeSequentialSource::MergeTreeSequentialSource(
             addThrottler(read_settings.local_throttler, context->getMergesThrottler());
             break;
         case Export:
-            read_settings.local_throttler = context->getExportsThrottler();
+            addThrottler(read_settings.local_throttler, context->getExportsThrottler());
+            addThrottler(read_settings.remote_throttler, context->getExportsThrottler());
             break;
     }
 

--- a/src/Storages/ObjectStorage/ObjectStorageFilePathGenerator.h
+++ b/src/Storages/ObjectStorage/ObjectStorageFilePathGenerator.h
@@ -55,7 +55,7 @@ namespace DB
 
             result += raw_path;
 
-            if (raw_path.back() != '/')
+            if (!raw_path.empty() && raw_path.back() != '/')
             {
                 result += "/";
             }

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -1,3 +1,4 @@
+#include <optional>
 #include <thread>
 #include <Core/ColumnWithTypeAndName.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
@@ -507,7 +508,7 @@ SinkToStoragePtr StorageObjectStorage::import(
         destination_file_path,
         object_storage,
         configuration,
-        format_settings,
+        std::nullopt, /// passing nullopt to force rebuild for format_settings based on query context
         std::make_shared<const Block>(getInMemoryMetadataPtr()->getSampleBlock()),
         local_context);
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Preserve a few file format settings in the export part manifest to be able to better control parallelism 

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)