### PR TITLE
Small iceberg read optimization

### DIFF
--- a/src/Interpreters/ClusterFunctionReadTask.cpp
+++ b/src/Interpreters/ClusterFunctionReadTask.cpp
@@ -19,6 +19,7 @@ namespace ErrorCodes
 namespace Setting
 {
     extern const SettingsBool cluster_function_process_archive_on_multiple_nodes;
+    extern const SettingsBool allow_experimental_iceberg_read_optimization;
 }
 
 ClusterFunctionReadTaskResponse::ClusterFunctionReadTaskResponse(ObjectInfoPtr object, const ContextPtr & context)
@@ -29,7 +30,8 @@ ClusterFunctionReadTaskResponse::ClusterFunctionReadTaskResponse(ObjectInfoPtr o
     if (object->data_lake_metadata.has_value())
         data_lake_metadata = object->data_lake_metadata.value();
 
-    file_meta_info = object->file_meta_info;
+    if (context->getSettingsRef()[Setting::allow_experimental_iceberg_read_optimization])
+        file_meta_info = object->file_meta_info;
 
     const bool send_over_whole_archive = !context->getSettingsRef()[Setting::cluster_function_process_archive_on_multiple_nodes];
     path = send_over_whole_archive ? object->getPathOrPathToArchiveIfArchive() : object->getPath();

--- a/src/Interpreters/ClusterFunctionReadTask.cpp
+++ b/src/Interpreters/ClusterFunctionReadTask.cpp
@@ -30,8 +30,9 @@ ClusterFunctionReadTaskResponse::ClusterFunctionReadTaskResponse(ObjectInfoPtr o
     if (object->data_lake_metadata.has_value())
         data_lake_metadata = object->data_lake_metadata.value();
 
-    if (context->getSettingsRef()[Setting::allow_experimental_iceberg_read_optimization])
-        file_meta_info = object->file_meta_info;
+    file_meta_info = object->file_meta_info;
+
+    iceberg_read_optimization_enabled = context->getSettingsRef()[Setting::allow_experimental_iceberg_read_optimization];
 
     const bool send_over_whole_archive = !context->getSettingsRef()[Setting::cluster_function_process_archive_on_multiple_nodes];
     path = send_over_whole_archive ? object->getPathOrPathToArchiveIfArchive() : object->getPath();
@@ -69,7 +70,8 @@ void ClusterFunctionReadTaskResponse::serialize(WriteBuffer & out, size_t protoc
 
     if (protocol_version >= DBMS_CLUSTER_PROCESSING_PROTOCOL_VERSION_WITH_DATA_LAKE_COLUMNS_METADATA)
     {
-        if (file_meta_info.has_value())
+        /// This info is not used when optimization is disabled, so there is no need to send it.
+        if (iceberg_read_optimization_enabled && file_meta_info.has_value())
             file_meta_info.value()->serialize(out);
         else
             DataFileMetaInfo().serialize(out);

--- a/src/Interpreters/ClusterFunctionReadTask.cpp
+++ b/src/Interpreters/ClusterFunctionReadTask.cpp
@@ -23,6 +23,7 @@ namespace Setting
 }
 
 ClusterFunctionReadTaskResponse::ClusterFunctionReadTaskResponse(ObjectInfoPtr object, const ContextPtr & context)
+    : iceberg_read_optimization_enabled(context->getSettingsRef()[Setting::allow_experimental_iceberg_read_optimization])
 {
     if (!object)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "`object` cannot be null");
@@ -31,8 +32,6 @@ ClusterFunctionReadTaskResponse::ClusterFunctionReadTaskResponse(ObjectInfoPtr o
         data_lake_metadata = object->data_lake_metadata.value();
 
     file_meta_info = object->file_meta_info;
-
-    iceberg_read_optimization_enabled = context->getSettingsRef()[Setting::allow_experimental_iceberg_read_optimization];
 
     const bool send_over_whole_archive = !context->getSettingsRef()[Setting::cluster_function_process_archive_on_multiple_nodes];
     path = send_over_whole_archive ? object->getPathOrPathToArchiveIfArchive() : object->getPath();

--- a/src/Interpreters/ClusterFunctionReadTask.h
+++ b/src/Interpreters/ClusterFunctionReadTask.h
@@ -23,6 +23,8 @@ struct ClusterFunctionReadTaskResponse
     /// File's columns info
     std::optional<DataFileMetaInfoPtr> file_meta_info;
 
+    bool iceberg_read_optimization_enabled;
+
     /// Convert received response into ObjectInfo.
     ObjectInfoPtr getObjectInfo() const;
 

--- a/src/Interpreters/ClusterFunctionReadTask.h
+++ b/src/Interpreters/ClusterFunctionReadTask.h
@@ -23,7 +23,7 @@ struct ClusterFunctionReadTaskResponse
     /// File's columns info
     std::optional<DataFileMetaInfoPtr> file_meta_info;
 
-    bool iceberg_read_optimization_enabled;
+    const bool iceberg_read_optimization_enabled = false;
 
     /// Convert received response into ObjectInfo.
     ObjectInfoPtr getObjectInfo() const;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not send min/max info on swarm nodes when setting `allow_experimental_iceberg_read_optimization` is turned off.

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)