### PR TITLE
25.3.8 Backport of #86633 - Add support for user names in config containing a dot

### DIFF
--- a/src/Access/UsersConfigAccessStorage.cpp
+++ b/src/Access/UsersConfigAccessStorage.cpp
@@ -115,7 +115,7 @@ namespace
 
     UserPtr parseUser(
         const Poco::Util::AbstractConfiguration & config,
-        const String & user_name,
+        String user_name,
         const std::unordered_set<UUID> & allowed_profile_ids,
         const std::unordered_set<UUID> & allowed_role_ids,
         bool allow_no_password,
@@ -123,8 +123,12 @@ namespace
     {
         const bool validate = true;
         auto user = std::make_shared<User>();
-        user->setName(user_name);
         String user_config = "users." + user_name;
+
+        /// If the user name contains a dot, it is escaped with a backslash when parsed from the config file.
+        /// We need to remove the backslash to get the correct user name.
+        Poco::replaceInPlace(user_name, "\\.", ".");
+        user->setName(user_name);
         bool has_no_password = config.has(user_config + ".no_password");
         bool has_password_plaintext = config.has(user_config + ".password");
         bool has_password_sha256_hex = config.has(user_config + ".password_sha256_hex");

--- a/tests/integration/test_dot_in_user_name/configs/users.xml
+++ b/tests/integration/test_dot_in_user_name/configs/users.xml
@@ -1,0 +1,23 @@
+<clickhouse>
+    <users>
+        <default>
+            <password/>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </default>
+        <user.name>
+            <password/>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+        </user.name>
+    </users>
+    <quotas>
+        <default/>
+    </quotas>
+</clickhouse>

--- a/tests/integration/test_dot_in_user_name/test.py
+++ b/tests/integration/test_dot_in_user_name/test.py
@@ -1,0 +1,35 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    user_configs=[
+        "configs/users.xml",
+    ],
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_user_with_dot_in_name():
+    assert node.query("SELECT count()>0 FROM system.users where name = 'user.name'") == "1\n"
+    assert node.query("SELECT count()>0 FROM system.users where name = 'user\\.name'") == "0\n"
+
+    node.query("DROP USER IF EXISTS 'foo.bar'")
+    node.query("CREATE USER 'foo.bar'")
+    assert node.query("SELECT count()>0 FROM system.users where name = 'foo.bar'") == "1\n"
+    assert node.query("SELECT count()>0 FROM system.users where name = 'foo\\.bar'") == "0\n"
+
+    node.query("ALTER USER 'foo.bar' RENAME TO 'foo\\.bar'")
+    assert node.query("SELECT count()>0 FROM system.users where name = 'foo.bar'") == "0\n"
+    assert node.query("SELECT count()>0 FROM system.users where name = 'foo\\.bar'") == "1\n"
+    node.query("DROP USER 'foo\\.bar'")


### PR DESCRIPTION
Add support for user names in config containing a dot


### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes handling of users with a dot in the name when added via config file (https://github.com/ClickHouse/ClickHouse/pull/86633 by @mkmkme)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)