### PR TITLE
25.3.8 Backport of #79969 - Fix match(col, '^…') index analysis with escaped metacharacters to avoid wrong results and crashes 

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -126,7 +126,7 @@ static String extractFixedPrefixFromRegularExpression(const String & regexp)
     const char * pos = begin;
     const char * end = regexp.data() + regexp.size();
 
-    while (pos != end)
+    while (pos < end)
     {
         switch (*pos)
         {
@@ -149,19 +149,22 @@ static String extractFixedPrefixFromRegularExpression(const String & regexp)
                     case '$':
                     case '.':
                     case '[':
+                    case ']':
                     case '?':
                     case '*':
                     case '+':
+                    case '\\':
                     case '{':
+                    case '}':
+                    case '-':
                         fixed_prefix += *pos;
+                        ++pos;
                     break;
                     default:
                         /// all other escape sequences are not supported
                             pos = end;
-                    break;
                 }
 
-                ++pos;
                 break;
             }
 

--- a/tests/queries/0_stateless/03456_match_index_prefix_extraction.reference
+++ b/tests/queries/0_stateless/03456_match_index_prefix_extraction.reference
@@ -1,0 +1,52 @@
+Condition: (path in [\'xxx(zzz\', \'xxx(zz{\'))
+1
+Condition: (path in [\'xxx)zzz\', \'xxx)zz{\'))
+1
+Condition: (path in [\'xxx^zzz\', \'xxx^zz{\'))
+1
+Condition: (path in [\'xxx$zzz\', \'xxx$zz{\'))
+1
+Condition: (path in [\'xxx.zzz\', \'xxx.zz{\'))
+1
+Condition: (path in [\'xxx[zzz\', \'xxx[zz{\'))
+1
+Condition: (path in [\'xxx]zzz\', \'xxx]zz{\'))
+1
+Condition: (path in [\'xxx?zzz\', \'xxx?zz{\'))
+1
+Condition: (path in [\'xxx*zzz\', \'xxx*zz{\'))
+1
+Condition: (path in [\'xxx+zzz\', \'xxx+zz{\'))
+1
+Condition: (path in [\'xxx\\\\zzz\', \'xxx\\\\zz{\'))
+1
+Condition: (path in [\'xxx{zzz\', \'xxx{zz{\'))
+1
+Condition: (path in [\'xxx}zzz\', \'xxx}zz{\'))
+1
+Condition: (path in [\'xxx-zzz\', \'xxx-zz{\'))
+1
+Condition: (path in [\'xxx\', \'xxy\'))
+0
+Condition: (path in [\'xxx\', \'xxy\'))
+0
+Condition: (path in [\'xxx\', \'xxy\'))
+0
+Condition: (path in [\'xxx\', \'xxy\'))
+0
+Condition: (path in [\'xxx\', \'xxy\'))
+0
+Condition: (path in [\'xxx\', \'xxy\'))
+0
+Condition: (path in [\'xxx\', \'xxy\'))
+15
+Condition: (path in [\'xxx\', \'xxy\'))
+15
+Condition: (path in [\'xxx\', \'xxy\'))
+15
+Condition: (path in [\'xxx\', \'xxy\'))
+0
+Condition: (path in [\'xxx\', \'xxy\'))
+0
+Condition: true
+Condition: true

--- a/tests/queries/0_stateless/03456_match_index_prefix_extraction.sql
+++ b/tests/queries/0_stateless/03456_match_index_prefix_extraction.sql
@@ -1,0 +1,111 @@
+SET parallel_replicas_local_plan=1;
+
+drop table if exists foo;
+
+CREATE TABLE foo (id UInt8, path String) engine = MergeTree ORDER BY (path) SETTINGS index_granularity=1;
+
+INSERT INTO foo VALUES (1, 'xxx|yyy'),
+(2, 'xxx(zzz'),
+(3, 'xxx)zzz'),
+(4, 'xxx^zzz'),
+(5, 'xxx$zzz'),
+(6, 'xxx.zzz'),
+(7, 'xxx[zzz'),
+(8, 'xxx]zzz'),
+(9, 'xxx?zzz'),
+(10, 'xxx*zzz'),
+(11, 'xxx+zzz'),
+(12, 'xxx\\zzz'),
+(13, 'xxx{zzz'),
+(14, 'xxx}zzz'),
+(15, 'xxx-zzz');
+
+
+-- check if also escaped sequence are properly extracted
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\(zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\(zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\)zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\)zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\^zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\^zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\$zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\$zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\.zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\.zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\[zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\[zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\]zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\]zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\?zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\?zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\*zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\*zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\+zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\+zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\\\zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\\\zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\{zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\{zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\}zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\}zzz') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\-zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\-zzz') SETTINGS force_primary_key = 1;
+
+
+-- those regex chars prevent the index use (only 3 first chars used during index scan)
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\0bla')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\0bla') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx(bla)')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx(bla)') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx[bla]')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx[bla]') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx^bla')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx^bla') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx.bla')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx.bla') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx+bla')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx+bla') SETTINGS force_primary_key = 1;
+
+
+-- here the forth char is not used during index, because it has 0+ quantifier
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxxx{0,1}')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxxx{0,1}') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxxx?')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxxx?') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxxx*')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxxx*') SETTINGS force_primary_key = 1;
+
+-- some unsupported regex chars - only 3 first chars used during index scan
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\d+')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\d+') SETTINGS force_primary_key = 1;
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\w+')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\w+') SETTINGS force_primary_key = 1;
+
+
+-- fully disabled for pipes - see https://github.com/ClickHouse/ClickHouse/pull/54696
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxx\\|zzz')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxx\\|zzz') SETTINGS force_primary_key = 1; -- { serverError INDEX_NOT_USED }
+
+SELECT trimLeft(explain) FROM (EXPLAIN PLAN indexes=1 SELECT id FROM foo WHERE match(path, '^xxxx|foo')) WHERE explain like '%Condition%';
+SELECT count() FROM foo WHERE match(path, '^xxxx|foo') SETTINGS force_primary_key = 1; -- { serverError INDEX_NOT_USED }


### PR DESCRIPTION
Fix match(col, '^…') index analysis with escaped metacharacters to avoid wrong results and crashes


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed incorrect query results and out-of-memory crashes when using `match(column, '^…')` with backslash-escaped characters (https://github.com/ClickHouse/ClickHouse/pull/79969 by @filimonov).


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)