### PR TITLE
More profile metrics for Iceberg, S3 and Azure

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -299,6 +299,11 @@
     M(IcebergTrivialCountOptimizationApplied, "Trivial count optimization applied while reading from Iceberg", ValueType::Number) \
     M(IcebergVersionHintUsed, "Number of times version-hint.text has been used.", ValueType::Number) \
     M(IcebergMinMaxIndexPrunedFiles, "Number of skipped files by using MinMax index in Iceberg", ValueType::Number) \
+    M(IcebergAvroFileParsing, "Number of times avro metadata files have been parsed.", ValueType::Number) \
+    M(IcebergAvroFileParsingMicroseconds, "Time spent for parsing avro metadata files for Iceberg tables.", ValueType::Microseconds) \
+    M(IcebergJsonFileParsing, "Number of times json metadata files have been parsed.", ValueType::Number) \
+    M(IcebergJsonFileParsingMicroseconds, "Time spent for parsing json metadata files for Iceberg tables.", ValueType::Microseconds) \
+    \
     M(JoinBuildTableRowCount, "Total number of rows in the build table for a JOIN operation.", ValueType::Number) \
     M(JoinProbeTableRowCount, "Total number of rows in the probe table for a JOIN operation.", ValueType::Number) \
     M(JoinResultRowCount, "Total number of rows in the result of a JOIN operation.", ValueType::Number) \
@@ -580,7 +585,9 @@ The server successfully detected this situation and will download merged part fr
     M(S3DeleteObjects, "Number of S3 API DeleteObject(s) calls.", ValueType::Number) \
     M(S3CopyObject, "Number of S3 API CopyObject calls.", ValueType::Number) \
     M(S3ListObjects, "Number of S3 API ListObjects calls.", ValueType::Number) \
+    M(S3ListObjectsMicroseconds, "Time of S3 API ListObjects execution.", ValueType::Microseconds) \
     M(S3HeadObject,  "Number of S3 API HeadObject calls.", ValueType::Number) \
+    M(S3HeadObjectMicroseconds,  "Time of S3 API HeadObject execution.", ValueType::Microseconds) \
     M(S3GetObjectAttributes, "Number of S3 API GetObjectAttributes calls.", ValueType::Number) \
     M(S3CreateMultipartUpload, "Number of S3 API CreateMultipartUpload calls.", ValueType::Number) \
     M(S3UploadPartCopy, "Number of S3 API UploadPartCopy calls.", ValueType::Number) \
@@ -634,6 +641,7 @@ The server successfully detected this situation and will download merged part fr
     M(AzureCopyObject, "Number of Azure blob storage API CopyObject calls", ValueType::Number) \
     M(AzureDeleteObjects, "Number of Azure blob storage API DeleteObject(s) calls.", ValueType::Number) \
     M(AzureListObjects, "Number of Azure blob storage API ListObjects calls.", ValueType::Number) \
+    M(AzureListObjectsMicroseconds, "Time of Azure blob storage API ListObjects execution.", ValueType::Microseconds) \
     M(AzureGetProperties, "Number of Azure blob storage API GetProperties calls.", ValueType::Number) \
     M(AzureCreateContainer, "Number of Azure blob storage API CreateContainer calls.", ValueType::Number) \
     \

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -185,9 +185,12 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
         ProfileEvents::increment(ProfileEvents::AzureListObjects);
         if (client_ptr->IsClientForDisk())
             ProfileEvents::increment(ProfileEvents::DiskAzureListObjects);
-        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::AzureListObjectsMicroseconds);
 
-        blob_list_response = client_ptr->ListBlobs(options);
+        {
+            ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::AzureListObjectsMicroseconds);
+            blob_list_response = client_ptr->ListBlobs(options);
+        }
+
         const auto & blobs_list = blob_list_response.Blobs;
 
         for (const auto & blob : blobs_list)

--- a/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/AzureBlobStorage/AzureObjectStorage.cpp
@@ -13,6 +13,7 @@
 #include <Disks/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h>
 #include <Disks/ObjectStorages/ObjectStorageIteratorAsync.h>
 #include <Interpreters/Context.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
 
 
 namespace CurrentMetrics
@@ -25,6 +26,7 @@ namespace CurrentMetrics
 namespace ProfileEvents
 {
     extern const Event AzureListObjects;
+    extern const Event AzureListObjectsMicroseconds;
     extern const Event DiskAzureListObjects;
     extern const Event AzureDeleteObjects;
     extern const Event DiskAzureDeleteObjects;
@@ -76,6 +78,7 @@ private:
         ProfileEvents::increment(ProfileEvents::AzureListObjects);
         if (client->IsClientForDisk())
             ProfileEvents::increment(ProfileEvents::DiskAzureListObjects);
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::AzureListObjectsMicroseconds);
 
         chassert(batch.empty());
         auto blob_list_response = client->ListBlobs(options);
@@ -182,6 +185,7 @@ void AzureObjectStorage::listObjects(const std::string & path, RelativePathsWith
         ProfileEvents::increment(ProfileEvents::AzureListObjects);
         if (client_ptr->IsClientForDisk())
             ProfileEvents::increment(ProfileEvents::DiskAzureListObjects);
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::AzureListObjectsMicroseconds);
 
         blob_list_response = client_ptr->ListBlobs(options);
         const auto & blobs_list = blob_list_response.Blobs;

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -30,11 +30,13 @@
 #include <Common/logger_useful.h>
 #include <Common/MultiVersion.h>
 #include <Common/Macros.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
 
 
 namespace ProfileEvents
 {
     extern const Event S3ListObjects;
+    extern const Event S3ListObjectsMicroseconds;
     extern const Event DiskS3DeleteObjects;
     extern const Event DiskS3ListObjects;
 }
@@ -136,6 +138,7 @@ private:
     {
         ProfileEvents::increment(ProfileEvents::S3ListObjects);
         ProfileEvents::increment(ProfileEvents::DiskS3ListObjects);
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::S3ListObjectsMicroseconds);
 
         auto outcome = client->ListObjectsV2(*request);
 
@@ -263,6 +266,7 @@ void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMet
     {
         ProfileEvents::increment(ProfileEvents::S3ListObjects);
         ProfileEvents::increment(ProfileEvents::DiskS3ListObjects);
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::S3ListObjectsMicroseconds);
 
         outcome = client.get()->ListObjectsV2(request);
         throwIfError(outcome);

--- a/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
+++ b/src/Disks/ObjectStorages/S3/S3ObjectStorage.cpp
@@ -138,9 +138,13 @@ private:
     {
         ProfileEvents::increment(ProfileEvents::S3ListObjects);
         ProfileEvents::increment(ProfileEvents::DiskS3ListObjects);
-        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::S3ListObjectsMicroseconds);
 
-        auto outcome = client->ListObjectsV2(*request);
+        Aws::S3::Model::ListObjectsV2Outcome outcome;
+
+        {
+            ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::S3ListObjectsMicroseconds);
+            outcome = client->ListObjectsV2(*request);
+        }
 
         /// Outcome failure will be handled on the caller side.
         if (outcome.IsSuccess())
@@ -266,9 +270,12 @@ void S3ObjectStorage::listObjects(const std::string & path, RelativePathsWithMet
     {
         ProfileEvents::increment(ProfileEvents::S3ListObjects);
         ProfileEvents::increment(ProfileEvents::DiskS3ListObjects);
-        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::S3ListObjectsMicroseconds);
 
-        outcome = client.get()->ListObjectsV2(request);
+        {
+            ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::S3ListObjectsMicroseconds);
+            outcome = client.get()->ListObjectsV2(request);
+        }
+
         throwIfError(outcome);
 
         auto result = outcome.GetResult();

--- a/src/IO/S3/getObjectInfo.cpp
+++ b/src/IO/S3/getObjectInfo.cpp
@@ -1,6 +1,7 @@
 #include <optional>
 #include <IO/S3/getObjectInfo.h>
 #include <IO/Expect404ResponseScope.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
 
 #if USE_AWS_S3
 
@@ -15,6 +16,7 @@ namespace ProfileEvents
     extern const Event S3GetObject;
     extern const Event S3GetObjectAttributes;
     extern const Event S3HeadObject;
+    extern const Event S3HeadObjectMicroseconds;
     extern const Event DiskS3GetObject;
     extern const Event DiskS3GetObjectAttributes;
     extern const Event DiskS3HeadObject;
@@ -32,6 +34,7 @@ namespace
         ProfileEvents::increment(ProfileEvents::S3HeadObject);
         if (client.isClientForDisk())
             ProfileEvents::increment(ProfileEvents::DiskS3HeadObject);
+        ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::S3HeadObjectMicroseconds);
 
         S3::HeadObjectRequest req;
         req.SetBucket(bucket);

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -19,16 +19,6 @@
 #include <IO/S3/Requests.h>
 
 
-namespace ProfileEvents
-{
-    extern const Event S3GetObjectAttributes;
-    extern const Event S3GetObjectMetadata;
-    extern const Event S3HeadObject;
-    extern const Event DiskS3GetObjectAttributes;
-    extern const Event DiskS3GetObjectMetadata;
-    extern const Event DiskS3HeadObject;
-}
-
 namespace DB
 {
 

--- a/src/Interpreters/IcebergMetadataLog.cpp
+++ b/src/Interpreters/IcebergMetadataLog.cpp
@@ -84,7 +84,7 @@ void IcebergMetadataLogElement::appendToBlock(MutableColumns & columns) const
 
 void insertRowToLogTable(
     const ContextPtr & local_context,
-    String row,
+    std::function<String()> get_row,
     IcebergMetadataLogLevel row_log_level,
     const String & table_path,
     const String & file_path,
@@ -104,40 +104,7 @@ void insertRowToLogTable(
             .content_type = row_log_level,
             .table_path = table_path,
             .file_path = file_path,
-            .metadata_content = row,
-            .row_in_file = row_in_file});
-}
-
-String dumpMetadataObjectToString(const Poco::JSON::Object::Ptr & metadata_object)
-{
-    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    Poco::JSON::Stringifier::stringify(metadata_object, oss);
-    return removeEscapedSlashes(oss.str());
-}
-
-void insertRowToLogTable(
-    const ContextPtr & local_context,
-    const Poco::JSON::Object::Ptr metadata_object,
-    IcebergMetadataLogLevel row_log_level,
-    const String & table_path,
-    const String & file_path,
-    std::optional<UInt64> row_in_file)
-{
-    IcebergMetadataLogLevel set_log_level = local_context->getSettingsRef()[Setting::iceberg_metadata_log_level].value;
-    if (set_log_level < row_log_level)
-        return;
-    timespec spec{};
-    if (clock_gettime(CLOCK_REALTIME, &spec))
-        throw ErrnoException(ErrorCodes::CANNOT_CLOCK_GETTIME, "Cannot clock_gettime");
-
-    Context::getGlobalContextInstance()->getIcebergMetadataLog()->add(
-        DB::IcebergMetadataLogElement{
-            .current_time = spec.tv_sec,
-            .query_id = local_context->getCurrentQueryId(),
-            .content_type = row_log_level,
-            .table_path = table_path,
-            .file_path = file_path,
-            .metadata_content = dumpMetadataObjectToString(metadata_object),
+            .metadata_content = get_row(),
             .row_in_file = row_in_file});
 }
 }

--- a/src/Interpreters/IcebergMetadataLog.cpp
+++ b/src/Interpreters/IcebergMetadataLog.cpp
@@ -20,6 +20,7 @@
 #include <Processors/QueryPlan/ReadFromSystemNumbersStep.h>
 #include <Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h>
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 #include <Storages/SelectQueryInfo.h>
 #include <base/Decimal.h>
@@ -104,6 +105,39 @@ void insertRowToLogTable(
             .table_path = table_path,
             .file_path = file_path,
             .metadata_content = row,
+            .row_in_file = row_in_file});
+}
+
+String dumpMetadataObjectToString(const Poco::JSON::Object::Ptr & metadata_object)
+{
+    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    Poco::JSON::Stringifier::stringify(metadata_object, oss);
+    return removeEscapedSlashes(oss.str());
+}
+
+void insertRowToLogTable(
+    const ContextPtr & local_context,
+    const Poco::JSON::Object::Ptr metadata_object,
+    IcebergMetadataLogLevel row_log_level,
+    const String & table_path,
+    const String & file_path,
+    std::optional<UInt64> row_in_file)
+{
+    IcebergMetadataLogLevel set_log_level = local_context->getSettingsRef()[Setting::iceberg_metadata_log_level].value;
+    if (set_log_level < row_log_level)
+        return;
+    timespec spec{};
+    if (clock_gettime(CLOCK_REALTIME, &spec))
+        throw ErrnoException(ErrorCodes::CANNOT_CLOCK_GETTIME, "Cannot clock_gettime");
+
+    Context::getGlobalContextInstance()->getIcebergMetadataLog()->add(
+        DB::IcebergMetadataLogElement{
+            .current_time = spec.tv_sec,
+            .query_id = local_context->getCurrentQueryId(),
+            .content_type = row_log_level,
+            .table_path = table_path,
+            .file_path = file_path,
+            .metadata_content = dumpMetadataObjectToString(metadata_object),
             .row_in_file = row_in_file});
 }
 }

--- a/src/Interpreters/IcebergMetadataLog.h
+++ b/src/Interpreters/IcebergMetadataLog.h
@@ -24,6 +24,8 @@ struct IcebergMetadataLogElement
     void appendToBlock(MutableColumns & columns) const;
 };
 
+/// Here `get_row` function is used instead `row` string to calculate string only when required.
+/// Inside `insertRowToLogTable` code can exit immediately after `iceberg_metadata_log_level` setting check.
 void insertRowToLogTable(
     const ContextPtr & local_context,
     std::function<String()> get_row,

--- a/src/Interpreters/IcebergMetadataLog.h
+++ b/src/Interpreters/IcebergMetadataLog.h
@@ -26,15 +26,7 @@ struct IcebergMetadataLogElement
 
 void insertRowToLogTable(
     const ContextPtr & local_context,
-    String row,
-    IcebergMetadataLogLevel row_log_level,
-    const String & table_path,
-    const String & file_path,
-    std::optional<UInt64> row_in_file);
-
-void insertRowToLogTable(
-    const ContextPtr & local_context,
-    const Poco::JSON::Object::Ptr metadata_object,
+    std::function<String()> get_row,
     IcebergMetadataLogLevel row_log_level,
     const String & table_path,
     const String & file_path,

--- a/src/Interpreters/IcebergMetadataLog.h
+++ b/src/Interpreters/IcebergMetadataLog.h
@@ -2,6 +2,7 @@
 
 #include <Interpreters/SystemLog.h>
 #include <Storages/ColumnsDescription.h>
+#include <Poco/JSON/Object.h>
 
 namespace DB
 {
@@ -26,6 +27,14 @@ struct IcebergMetadataLogElement
 void insertRowToLogTable(
     const ContextPtr & local_context,
     String row,
+    IcebergMetadataLogLevel row_log_level,
+    const String & table_path,
+    const String & file_path,
+    std::optional<UInt64> row_in_file);
+
+void insertRowToLogTable(
+    const ContextPtr & local_context,
+    const Poco::JSON::Object::Ptr metadata_object,
     IcebergMetadataLogLevel row_log_level,
     const String & table_path,
     const String & file_path,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/AvroForIcebergDeserializer.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/AvroForIcebergDeserializer.cpp
@@ -12,11 +12,18 @@
 #include <Common/assert_cast.h>
 #include <base/find_symbols.h>
 #include <Processors/Formats/Impl/JSONObjectEachRowRowOutputFormat.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
 
 namespace DB::ErrorCodes
 {
     extern const int ICEBERG_SPECIFICATION_VIOLATION;
     extern const int INCORRECT_DATA;
+}
+
+namespace ProfileEvents
+{
+    extern const Event IcebergAvroFileParsing;
+    extern const Event IcebergAvroFileParsingMicroseconds;
 }
 
 namespace DB::Iceberg
@@ -30,6 +37,9 @@ try
     : buffer(std::move(buffer_))
     , manifest_file_path(manifest_file_path_)
 {
+    ProfileEvents::increment(ProfileEvents::IcebergAvroFileParsing);
+    ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::IcebergAvroFileParsingMicroseconds);
+
     auto manifest_file_reader
         = std::make_unique<avro::DataFileReaderBase>(std::make_unique<AvroInputStreamReadBufferAdapter>(*buffer));
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -110,6 +110,16 @@ extern const SettingsBool allow_experimental_insert_into_iceberg;
 extern const SettingsBool allow_experimental_iceberg_compaction;
 }
 
+namespace
+{
+String dumpMetadataObjectToString(const Poco::JSON::Object::Ptr & metadata_object)
+{
+    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    Poco::JSON::Stringifier::stringify(metadata_object, oss);
+    return removeEscapedSlashes(oss.str());
+}
+}
+
 
 using namespace Iceberg;
 
@@ -233,9 +243,10 @@ bool IcebergMetadata::update(const ContextPtr & local_context)
 
     updateState(local_context, metadata_object);
 
+    auto dump_metadata = [&]()->String { return dumpMetadataObjectToString(metadata_object); };
     insertRowToLogTable(
         local_context,
-        metadata_object,
+        dump_metadata,
         DB::IcebergMetadataLogLevel::Metadata,
         configuration_ptr->getRawPath().path,
         metadata_file_path,
@@ -763,9 +774,10 @@ DataLakeMetadataPtr IcebergMetadata::create(
 
     auto format_version = object->getValue<int>(f_format_version);
 
+    auto dump_metadata = [&]()->String { return dumpMetadataObjectToString(object); };
     insertRowToLogTable(
         local_context,
-        object,
+        dump_metadata,
         DB::IcebergMetadataLogLevel::Metadata,
         configuration_ptr->getRawPath().path,
         metadata_file_path,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -110,16 +110,6 @@ extern const SettingsBool allow_experimental_insert_into_iceberg;
 extern const SettingsBool allow_experimental_iceberg_compaction;
 }
 
-namespace
-{
-String dumpMetadataObjectToString(const Poco::JSON::Object::Ptr & metadata_object)
-{
-    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    Poco::JSON::Stringifier::stringify(metadata_object, oss);
-    return removeEscapedSlashes(oss.str());
-}
-}
-
 
 using namespace Iceberg;
 
@@ -245,7 +235,7 @@ bool IcebergMetadata::update(const ContextPtr & local_context)
 
     insertRowToLogTable(
         local_context,
-        dumpMetadataObjectToString(metadata_object),
+        metadata_object,
         DB::IcebergMetadataLogLevel::Metadata,
         configuration_ptr->getRawPath().path,
         metadata_file_path,
@@ -775,7 +765,7 @@ DataLakeMetadataPtr IcebergMetadata::create(
 
     insertRowToLogTable(
         local_context,
-        dumpMetadataObjectToString(object),
+        object,
         DB::IcebergMetadataLogLevel::Metadata,
         configuration_ptr->getRawPath().path,
         metadata_file_path,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -155,9 +155,10 @@ ManifestFileContent::ManifestFileContent(
     const String & path_to_manifest_file_)
     : path_to_manifest_file(path_to_manifest_file_)
 {
+    auto dump_metadata = [&]()->String { return manifest_file_deserializer.getMetadataContent(); };
     insertRowToLogTable(
         context,
-        manifest_file_deserializer.getMetadataContent(),
+        dump_metadata,
         DB::IcebergMetadataLogLevel::ManifestFileMetadata,
         common_path,
         path_to_manifest_file,
@@ -230,9 +231,10 @@ ManifestFileContent::ManifestFileContent(
 
     for (size_t i = 0; i < manifest_file_deserializer.rows(); ++i)
     {
+        auto dump_row_metadata = [&]()->String { return manifest_file_deserializer.getContent(i); };
         insertRowToLogTable(
             context,
-            manifest_file_deserializer.getContent(i),
+            dump_row_metadata,
             DB::IcebergMetadataLogLevel::ManifestFileEntry,
             common_path,
             path_to_manifest_file,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/StatelessMetadataFileGetter.cpp
@@ -148,9 +148,10 @@ ManifestFileCacheKeys getManifestList(
 
         ManifestFileCacheKeys manifest_file_cache_keys;
 
+        auto dump_metadata = [&]()->String { return manifest_list_deserializer.getMetadataContent(); };
         insertRowToLogTable(
             local_context,
-            manifest_list_deserializer.getMetadataContent(),
+            dump_metadata,
             DB::IcebergMetadataLogLevel::ManifestListMetadata,
             configuration_ptr->getRawPath().path,
             filename,
@@ -185,9 +186,10 @@ ManifestFileCacheKeys getManifestList(
             manifest_file_cache_keys.emplace_back(
                 manifest_file_name, added_sequence_number, added_snapshot_id.safeGet<Int64>(), content_type);
 
+            auto dump_row_metadata = [&]()->String { return manifest_list_deserializer.getContent(i); };
             insertRowToLogTable(
                 local_context,
-                manifest_list_deserializer.getContent(i),
+                dump_row_metadata,
                 DB::IcebergMetadataLogLevel::ManifestListEntry,
                 configuration_ptr->getRawPath().path,
                 filename,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -40,6 +40,8 @@
 #include <Storages/ObjectStorage/StorageObjectStorageSource.h>
 #include <Storages/ObjectStorage/Utils.h>
 
+#include <Common/ElapsedTimeProfileEventIncrement.h>
+
 using namespace DB;
 
 
@@ -65,6 +67,8 @@ namespace DB::DataLakeStorageSetting
 namespace ProfileEvents
 {
     extern const Event IcebergVersionHintUsed;
+    extern const Event IcebergJsonFileParsing;
+    extern const Event IcebergJsonFileParsingMicroseconds;
 }
 
 namespace DB::Setting
@@ -309,6 +313,9 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
         readJSONObjectPossiblyInvalid(json_str, *buf);
         return json_str;
     };
+
+    ProfileEvents::increment(ProfileEvents::IcebergJsonFileParsing);
+    ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::IcebergJsonFileParsingMicroseconds);
 
     String metadata_json_str;
     if (cache_ptr)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
More metrics for Iceberg, S3 and Azure

### Documentation entry for user-facing changes
New Iceberg profile metrics:
* `IcebergAvroFileParsing` - counter of parsed avro metadata files
* `IcebergAvroFileParsingMicroseconds` - time spent on parsing avro metadata files
* `IcebergJsonFileParsing` - counter of parsed json metadata files
* `IcebergJsonFileParsingMicroseconds` - time spent on parsing json metadata files

New S3 profile metrics:
* `S3ListObjectsMicroseconds` - time spent on ListObjects requests
* `S3HeadObjectMicroseconds` - time spent on HeadObject requests

New Azure profile metric:
* `AzureListObjectsMicroseconds` - time spent on ListObjects requests

Small optimization - `dumpMetadataObjectToString` called always, including case when `insertRowToLogTable` dumps nothing and exits after `iceberg_metadata_log_level` setting check. Now serialization is only when required.


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)