### PR TITLE
Fix SYSTEM DROP FILESYSTEM CACHE ON CLUSTER

### DIFF
--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -163,7 +163,13 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
 
     print_keyword("SYSTEM") << " ";
     print_keyword(typeToString(type));
-    if (!cluster.empty())
+
+    std::unordered_set<Type> queries_with_on_cluster_at_end = {
+        Type::DROP_FILESYSTEM_CACHE,
+        Type::SYNC_FILESYSTEM_CACHE,
+    };
+
+    if (!queries_with_on_cluster_at_end.contains(type) && !cluster.empty())
         formatOnCluster(ostr, settings);
 
     switch (type)
@@ -519,6 +525,9 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
         case Type::END:
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unknown SYSTEM command");
     }
+
+    if (queries_with_on_cluster_at_end.contains(type) && !cluster.empty())
+        formatOnCluster(ostr, settings);
 }
 
 

--- a/tests/queries/0_stateless/03643_system_drop_filesystem_cache_on_cluster.reference
+++ b/tests/queries/0_stateless/03643_system_drop_filesystem_cache_on_cluster.reference
@@ -1,0 +1,2 @@
+localhost	9000	0		0	0
+localhost	9000	0		0	0

--- a/tests/queries/0_stateless/03643_system_drop_filesystem_cache_on_cluster.sh
+++ b/tests/queries/0_stateless/03643_system_drop_filesystem_cache_on_cluster.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel, no-object-storage, no-random-settings
+
+# set -x
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+
+disk_name="${CLICKHOUSE_TEST_UNIQUE_NAME}"
+$CLICKHOUSE_CLIENT -m --query """
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (a Int32, b String)
+ENGINE = MergeTree() ORDER BY tuple()
+SETTINGS disk = disk(name = '$disk_name', type = cache, max_size = '100Ki', path = ${CLICKHOUSE_TEST_UNIQUE_NAME}, disk = s3_disk);
+
+INSERT INTO test SELECT 1, 'test';
+"""
+
+$CLICKHOUSE_CLIENT --query """
+SYSTEM SYNC FILESYSTEM CACHE '$disk_name' ON CLUSTER 'test_shard_localhost';
+"""
+
+$CLICKHOUSE_CLIENT --query """
+SYSTEM DROP FILESYSTEM CACHE '$disk_name' ON CLUSTER 'test_shard_localhost';
+"""
+
+$CLICKHOUSE_CLIENT --query """
+DROP TABLE IF EXISTS test;
+"""


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix SYSTEM DROP FILESYSTEM CACHE ON CLUSTER

### Documentation entry for user-facing changes
Parser expects query

```
SYSTEM DROP FILESYSTEM CACHE 'cache_name' ON CLUSTER `cluster_name`
```

but in DDL cluster name is at end:

```
SYSTEM DROP FILESYSTEM CACHE ON CLUSTER `cluster_name` 'cache_name'
```

and query failed with error

```
clickhouse1 :) SYSTEM DROP FILESYSTEM CACHE 'cache' ON CLUSTER `clickhouse-cluster`

SYSTEM DROP FILESYSTEM CACHE ON CLUSTER `clickhouse-cluster` 'cache'

Query id: 48c41c7b-bb81-4b9e-a49a-fcd8b5a537cb

Row 1:
──────
host:                clickhouse2
port:                9000
status:              62
error:               Code: 62. DB::Exception: Syntax error: failed at position 62 ('cache'): 'cache'. Expected one of: ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.10.7 (official build))
num_hosts_remaining: 2
num_hosts_active:    0

Row 2:
──────
host:                clickhouse1
port:                9000
status:              62
error:               Code: 62. DB::Exception: Syntax error: failed at position 62 ('cache'): 'cache'. Expected one of: ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.10.7 (official build))
num_hosts_remaining: 1
num_hosts_active:    0

Row 3:
──────
host:                clickhouse3
port:                9000
status:              62
error:               Code: 62. DB::Exception: Syntax error: failed at position 62 ('cache'): 'cache'. Expected one of: ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.10.7 (official build))
num_hosts_remaining: 0
num_hosts_active:    0

3 rows in set. Elapsed: 0.099 sec.

Received exception from server (version 25.8.10):
Code: 62. DB::Exception: Received from localhost:9000. DB::Exception: There was an error on [clickhouse2:9000]: Code: 62. DB::Exception: Syntax error: failed at position 62 ('cache'): 'cache'. Expected one of: ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.10.7 (official build)). (SYNTAX_ERROR)
```

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)