### PR TITLE
Antalya 25.8 Backport of #87444 - Make parquet reader v3 preserve decimal precision information

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp
+++ b/src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp
@@ -1045,7 +1045,7 @@ void SchemaConverter::processPrimitiveColumn(
         if (precision > max_precision)
             throw Exception(ErrorCodes::INCORRECT_DATA, "Parquet decimal type precision or scale is too big ({} digits) for physical type {}", precision, thriftToString(type));
 
-        out_inferred_type = createDecimal<DataTypeDecimal>(max_precision, scale);
+        out_inferred_type = createDecimal<DataTypeDecimal>(precision, scale);
         size_t output_size = out_inferred_type->getSizeOfValueInMemory();
         out_decoder.allow_stats = is_output_type_decimal(output_size, scale);
 

--- a/tests/queries/0_stateless/02845_parquet_odd_decimals.reference
+++ b/tests/queries/0_stateless/02845_parquet_odd_decimals.reference
@@ -1,1 +1,5 @@
 100
+col-1de12c05-5dd5-4fa7-9f93-33c43c9a4028	Decimal(20, 0)					
+col-5e1b97f1-dade-4c7d-b71b-e31d789e01a4	String					
+col-1de12c05-5dd5-4fa7-9f93-33c43c9a4028	Decimal(20, 0)					
+col-5e1b97f1-dade-4c7d-b71b-e31d789e01a4	String					

--- a/tests/queries/0_stateless/02845_parquet_odd_decimals.sh
+++ b/tests/queries/0_stateless/02845_parquet_odd_decimals.sh
@@ -11,3 +11,6 @@ ${CLICKHOUSE_CLIENT} --query="drop table if exists 02845_parquet_odd_decimals"
 ${CLICKHOUSE_CLIENT} --query="create table 02845_parquet_odd_decimals (\`col-1de12c05-5dd5-4fa7-9f93-33c43c9a4028\` Decimal(20, 0), \`col-5e1b97f1-dade-4c7d-b71b-e31d789e01a4\` String) engine Memory"
 ${CLICKHOUSE_CLIENT} --query="insert into 02845_parquet_odd_decimals from infile '$CUR_DIR/data_parquet/nine_byte_decimals_from_spark.parquet'"
 ${CLICKHOUSE_CLIENT} --query="select count() from 02845_parquet_odd_decimals"
+
+${CLICKHOUSE_LOCAL} --query="desc file('$CUR_DIR/data_parquet/nine_byte_decimals_from_spark.parquet') settings schema_inference_make_columns_nullable=0, input_format_parquet_use_native_reader_v3=0"
+${CLICKHOUSE_LOCAL} --query="desc file('$CUR_DIR/data_parquet/nine_byte_decimals_from_spark.parquet') settings schema_inference_make_columns_nullable=0, input_format_parquet_use_native_reader_v3=1"


### PR DESCRIPTION
Make parquet reader v3 preserve decimal precision information

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Backport of https://github.com/ClickHouse/ClickHouse/pull/87444 by @al13n321. 

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)