### PR TITLE
25.3 ensure matching branch name in report queries

### DIFF
--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -163,7 +163,7 @@ def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
                     report_url as results_link,
                     task_url
                 FROM `gh-data`.checks
-                WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
+                WHERE commit_sha='{commit_sha}' AND head_ref IN ('{branch_name}', 'refs/tags/{branch_name}')
                 GROUP BY check_name, test_name, report_url, task_url
             )
             WHERE test_status IN ('FAIL', 'ERROR')
@@ -192,7 +192,7 @@ def get_checks_known_fails(
                 report_url as results_link,
                 task_url
             FROM `gh-data`.checks
-            WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
+            WHERE commit_sha='{commit_sha}' AND head_ref IN ('{branch_name}', 'refs/tags/{branch_name}')
             GROUP BY check_name, test_name, report_url, task_url
         )
         WHERE test_status='BROKEN'
@@ -229,7 +229,7 @@ def get_checks_errors(client: Client, commit_sha: str, branch_name: str):
                     report_url as results_link,
                     task_url
                 FROM `gh-data`.checks
-                WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
+                WHERE commit_sha='{commit_sha}' AND head_ref IN ('{branch_name}', 'refs/tags/{branch_name}')
                 GROUP BY check_name, test_name, report_url, task_url
             )
             WHERE job_status=='error'

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -163,7 +163,7 @@ def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
                     report_url as results_link,
                     task_url
                 FROM `gh-data`.checks
-                WHERE commit_sha='{commit_sha}'
+                WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
                 GROUP BY check_name, test_name, report_url, task_url
             )
             WHERE test_status IN ('FAIL', 'ERROR')
@@ -192,7 +192,7 @@ def get_checks_known_fails(
                 report_url as results_link,
                 task_url
             FROM `gh-data`.checks
-            WHERE commit_sha='{commit_sha}'
+            WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
             GROUP BY check_name, test_name, report_url, task_url
         )
         WHERE test_status='BROKEN'
@@ -229,7 +229,7 @@ def get_checks_errors(client: Client, commit_sha: str, branch_name: str):
                     report_url as results_link,
                     task_url
                 FROM `gh-data`.checks
-                WHERE commit_sha='{commit_sha}'
+                WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
                 GROUP BY check_name, test_name, report_url, task_url
             )
             WHERE job_status=='error'

--- a/tests/broken_tests.json
+++ b/tests/broken_tests.json
@@ -14,6 +14,9 @@
     "03203_hive_style_partitioning": {
         "reason": "INVESTIGATE - new fail in 24.12"
     },
+    "03315_executable_table_function_threads": {
+        "reason": "INVESTIGATE - unstable, timeout"
+    },
     "00988_expansion_aliases_limit": {
         "reason": "INVESTIGATE - Timeout on TSAN"
     },

--- a/tests/ci/clickhouse_helper.py
+++ b/tests/ci/clickhouse_helper.py
@@ -9,7 +9,12 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
-from env_helper import CLICKHOUSE_TEST_STAT_URL, CLICKHOUSE_TEST_STAT_PASSWORD, CLICKHOUSE_TEST_STAT_LOGIN
+from env_helper import (
+    GITHUB_REPOSITORY,
+    CLICKHOUSE_TEST_STAT_URL,
+    CLICKHOUSE_TEST_STAT_PASSWORD,
+    CLICKHOUSE_TEST_STAT_LOGIN,
+)
 from get_robot_token import get_parameter_from_ssm
 from pr_info import PRInfo
 from report import TestResults
@@ -212,11 +217,11 @@ def prepare_tests_results_for_clickhouse(
     report_url: str,
     check_name: str,
 ) -> List[dict]:
-    pull_request_url = "https://github.com/Altinity/ClickHouse/commits/master"
-    base_ref = "master"
-    head_ref = "master"
-    base_repo = pr_info.repo_full_name
-    head_repo = pr_info.repo_full_name
+    base_ref = pr_info.base_ref
+    base_repo = pr_info.base_name
+    head_ref = pr_info.head_ref
+    head_repo = pr_info.head_name
+    pull_request_url = f"https://github.com/{GITHUB_REPOSITORY}/commits/{head_ref}"
     if pr_info.number != 0:
         pull_request_url = pr_info.pr_html_url
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Add branch_name to db queries used by report to fix odd report behaviour and match logic in newer branches.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)