### PR TITLE
Preserve the entire format settings object in export part manifest

### DIFF
--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -468,7 +468,7 @@ It is currently only implemented in StorageObjectStorage.
         Block & /* block_with_partition_values */,
         std::string & /* destination_file_path */,
         bool /* overwrite_if_exists */,
-        const std::optional<FormatSettings> & /* format_settings */
+        const std::optional<FormatSettings> & /* format_settings */,
         ContextPtr /* context */)
     {
       throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Import is not implemented for storage {}", getName());

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -468,6 +468,7 @@ It is currently only implemented in StorageObjectStorage.
         Block & /* block_with_partition_values */,
         std::string & /* destination_file_path */,
         bool /* overwrite_if_exists */,
+        const std::optional<FormatSettings> & /* format_settings */
         ContextPtr /* context */)
     {
       throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Import is not implemented for storage {}", getName());

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -47,6 +47,7 @@
 #include <Disks/SingleDiskVolume.h>
 #include <Disks/TemporaryFileOnDisk.h>
 #include <Disks/createVolume.h>
+#include <Formats/FormatFactory.h>
 #include <IO/Operators.h>
 #include <IO/S3Common.h>
 #include <IO/SharedThreadPools.h>
@@ -6241,13 +6242,12 @@ void MergeTreeData::exportPartToTable(const PartitionCommand & command, ContextP
                         part_name, getStorageID().getFullTableName());
 
     {
+        const auto format_settings = getFormatSettings(query_context);
         MergeTreeExportManifest manifest(
             dest_storage->getStorageID(),
             part,
             query_context->getSettingsRef()[Setting::export_merge_tree_part_overwrite_file_if_exists],
-            query_context->getSettingsRef()[Setting::output_format_parallel_formatting],
-            query_context->getSettingsRef()[Setting::output_format_parquet_parallel_encoding],
-            query_context->getSettingsRef()[Setting::max_threads]);
+            format_settings);
 
         std::lock_guard lock(export_manifests_mutex);
 
@@ -6293,16 +6293,12 @@ void MergeTreeData::exportPartToTableImpl(
 
     try
     {
-        auto context_copy = Context::createCopy(local_context);
-        context_copy->setSetting("output_format_parallel_formatting", manifest.parallel_formatting);
-        context_copy->setSetting("output_format_parquet_parallel_encoding", manifest.parquet_parallel_encoding);
-        context_copy->setSetting("max_threads", manifest.max_threads);
-
         sink = destination_storage->import(
             manifest.data_part->name + "_" + manifest.data_part->checksums.getTotalChecksumHex(),
             block_with_partition_values,
             destination_file_path,
             manifest.overwrite_file_if_exists,
+            format_settings,
             context_copy);
     }
     catch (const Exception & e)

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6298,8 +6298,8 @@ void MergeTreeData::exportPartToTableImpl(
             block_with_partition_values,
             destination_file_path,
             manifest.overwrite_file_if_exists,
-            format_settings,
-            context_copy);
+            manifest.format_settings,
+            local_context);
     }
     catch (const Exception & e)
     {

--- a/src/Storages/MergeTree/MergeTreeExportManifest.h
+++ b/src/Storages/MergeTree/MergeTreeExportManifest.h
@@ -13,24 +13,17 @@ struct MergeTreeExportManifest
         const StorageID & destination_storage_id_,
         const DataPartPtr & data_part_,
         bool overwrite_file_if_exists_,
-        bool parallel_formatting_,
-        bool parallel_formatting_parquet_,
-        std::size_t max_threads_)
+        const FormatSettings & format_settings_)
         : destination_storage_id(destination_storage_id_),
           data_part(data_part_),
           overwrite_file_if_exists(overwrite_file_if_exists_),
-          parallel_formatting(parallel_formatting_),
-          parquet_parallel_encoding(parallel_formatting_parquet_),
-          max_threads(max_threads_),
+          format_settings(format_settings_)
           create_time(time(nullptr)) {}
 
     StorageID destination_storage_id;
     DataPartPtr data_part;
     bool overwrite_file_if_exists;
-    bool parallel_formatting;
-    /// parquet has a different setting for parallel formatting
-    bool parquet_parallel_encoding;
-    std::size_t max_threads;
+    FormatSettings format_settings;
 
     time_t create_time;
     mutable bool in_progress = false;

--- a/src/Storages/MergeTree/MergeTreeExportManifest.h
+++ b/src/Storages/MergeTree/MergeTreeExportManifest.h
@@ -17,7 +17,7 @@ struct MergeTreeExportManifest
         : destination_storage_id(destination_storage_id_),
           data_part(data_part_),
           overwrite_file_if_exists(overwrite_file_if_exists_),
-          format_settings(format_settings_)
+          format_settings(format_settings_),
           create_time(time(nullptr)) {}
 
     StorageID destination_storage_id;

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -483,6 +483,7 @@ SinkToStoragePtr StorageObjectStorage::import(
     Block & block_with_partition_values,
     std::string & destination_file_path,
     bool overwrite_if_exists,
+    const std::optional<FormatSettings> & format_settings_
     ContextPtr local_context)
 {
     std::string partition_key;
@@ -508,7 +509,7 @@ SinkToStoragePtr StorageObjectStorage::import(
         destination_file_path,
         object_storage,
         configuration,
-        std::nullopt, /// passing nullopt to force rebuild for format_settings based on query context
+        format_settings_ ? format_settings_ : format_settings,
         std::make_shared<const Block>(getInMemoryMetadataPtr()->getSampleBlock()),
         local_context);
 }

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -483,7 +483,7 @@ SinkToStoragePtr StorageObjectStorage::import(
     Block & block_with_partition_values,
     std::string & destination_file_path,
     bool overwrite_if_exists,
-    const std::optional<FormatSettings> & format_settings_
+    const std::optional<FormatSettings> & format_settings_,
     ContextPtr local_context)
 {
     std::string partition_key;

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -86,6 +86,7 @@ public:
         Block & /* block_with_partition_values */,
         std::string & /* destination_file_path */,
         bool /* overwrite_if_exists */,
+        const std::optional<FormatSettings> & /* format_settings_ */
         ContextPtr /* context */) override;
 
     void truncate(

--- a/src/Storages/ObjectStorage/StorageObjectStorage.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.h
@@ -86,7 +86,7 @@ public:
         Block & /* block_with_partition_values */,
         std::string & /* destination_file_path */,
         bool /* overwrite_if_exists */,
-        const std::optional<FormatSettings> & /* format_settings_ */
+        const std::optional<FormatSettings> & /* format_settings_ */,
         ContextPtr /* context */) override;
 
     void truncate(

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -576,7 +576,7 @@ SinkToStoragePtr StorageObjectStorageCluster::import(
     Block & block_with_partition_values,
     std::string & destination_file_path,
     bool overwrite_if_exists,
-    const std::optional<FormatSettings> & format_settings_
+    const std::optional<FormatSettings> & format_settings_,
     ContextPtr context)
 {
     if (pure_storage)

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -1,3 +1,4 @@
+#include <optional>
 #include <Storages/ObjectStorage/StorageObjectStorageCluster.h>
 
 #include <Common/Exception.h>
@@ -575,12 +576,13 @@ SinkToStoragePtr StorageObjectStorageCluster::import(
     Block & block_with_partition_values,
     std::string & destination_file_path,
     bool overwrite_if_exists,
+    const std::optional<FormatSettings> & format_settings_
     ContextPtr context)
 {
     if (pure_storage)
-        return pure_storage->import(file_name, block_with_partition_values, destination_file_path, overwrite_if_exists, context);
+        return pure_storage->import(file_name, block_with_partition_values, destination_file_path, overwrite_if_exists, format_settings_, context);
     
-    return IStorageCluster::import(file_name, block_with_partition_values, destination_file_path, overwrite_if_exists, context);
+    return IStorageCluster::import(file_name, block_with_partition_values, destination_file_path, overwrite_if_exists, format_settings_, context);
 }
 
 void StorageObjectStorageCluster::readFallBackToPure(

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.h
@@ -130,6 +130,7 @@ public:
         Block & /* block_with_partition_values */,
         std::string & /* destination_file_path */,
         bool /* overwrite_if_exists */,
+        const std::optional<FormatSettings> & /* format_settings_ */
         ContextPtr /* context */) override;
     bool prefersLargeBlocks() const override;
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.h
@@ -130,7 +130,7 @@ public:
         Block & /* block_with_partition_values */,
         std::string & /* destination_file_path */,
         bool /* overwrite_if_exists */,
-        const std::optional<FormatSettings> & /* format_settings_ */
+        const std::optional<FormatSettings> & /* format_settings_ */,
         ContextPtr /* context */) override;
     bool prefersLargeBlocks() const override;
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Preserve the entire format settings object in export part manifest

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)