### PR TITLE
Fix export partition ordering unit test

### DIFF
--- a/src/Storages/MergeTree/tests/gtest_export_partition_ordering.cpp
+++ b/src/Storages/MergeTree/tests/gtest_export_partition_ordering.cpp
@@ -26,18 +26,21 @@ TEST_F(ExportPartitionOrderingTest, IterationOrderMatchesCreateTime)
     manifest1.partition_id = "2020";
     manifest1.destination_database = "db1";
     manifest1.destination_table = "table1";
+    manifest1.transaction_id = "tx1";
     manifest1.create_time = base_time + 300; // Latest
     
     ExportReplicatedMergeTreePartitionManifest manifest2;
     manifest2.partition_id = "2021";
     manifest2.destination_database = "db1";
     manifest2.destination_table = "table1";
+    manifest1.transaction_id = "tx2";
     manifest2.create_time = base_time + 100; // Middle
     
     ExportReplicatedMergeTreePartitionManifest manifest3;
     manifest3.partition_id = "2022";
     manifest3.destination_database = "db1";
     manifest3.destination_table = "table1";
+    manifest1.transaction_id = "tx3";
     manifest3.create_time = base_time; // Oldest
 
     ExportReplicatedMergeTreePartitionTaskEntry entry1{manifest1, ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING, {}};

--- a/src/Storages/MergeTree/tests/gtest_export_partition_ordering.cpp
+++ b/src/Storages/MergeTree/tests/gtest_export_partition_ordering.cpp
@@ -33,14 +33,14 @@ TEST_F(ExportPartitionOrderingTest, IterationOrderMatchesCreateTime)
     manifest2.partition_id = "2021";
     manifest2.destination_database = "db1";
     manifest2.destination_table = "table1";
-    manifest1.transaction_id = "tx2";
+    manifest2.transaction_id = "tx2";
     manifest2.create_time = base_time + 100; // Middle
     
     ExportReplicatedMergeTreePartitionManifest manifest3;
     manifest3.partition_id = "2022";
     manifest3.destination_database = "db1";
     manifest3.destination_table = "table1";
-    manifest1.transaction_id = "tx3";
+    manifest3.transaction_id = "tx3";
     manifest3.create_time = base_time; // Oldest
 
     ExportReplicatedMergeTreePartitionTaskEntry entry1{manifest1, ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING, {}};


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix ut

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)