### PR TITLE
Antalya-25.8 Write documentation for local testing

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -17,6 +17,8 @@ I recommend not running suites with the `s3 storage` option as that requires ext
 python -m ci.praktika run "Stateless tests (amd_debug, sequential)"
 ```
 
+Logs can be found in `ci/tmp` and `ci/tmp/var/log/clickhouse-server`.
+
 ### One Test
 
 Running a single test can be done with bare `clickhouse-test` or with the `praktika` utility.
@@ -37,6 +39,8 @@ then, in another window:
 ```sh
 tests/clickhouse-test -b ci/tmp/clickhouse 03222_pr_asan_index_granularity
 ```
+
+Logs will get written into the `tests/queries/0_stateless` folder.
 
 #### praktika
 
@@ -61,6 +65,8 @@ https://github.com/ClickHouse/ClickHouse/blob/master/tests/integration/README.md
 python -m ci.praktika run "Integration tests (amd_binary, 4/5)"
 ```
 
+Logs can be found in `ci/tmp` and `ci/tmp/var/log/clickhouse-server`.
+
 ### One Test
 
 ```sh
@@ -71,5 +77,7 @@ cd tests/integration
 Docker images may or may not need to be specified. Get the tags by examining ci logs.
 Search logs for `integration-test`, look for `"altinityinfra/integration-tests-runner": "72c567235d2f7658765b"`
 and `"altinityinfra/integration-test": "9c789665fa1f2c3b60a8"`
+
+Logs are written to the local dir, which is `tests/integration` in this example.
 
 Note: `runner` has been removed from 25.9 onwards.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,1 +1,75 @@
-Find CI documents and instructions on running CI checks locally [here](https://clickhouse.com/docs/development/continuous-integration).
+# Local Testing
+
+Upstream provides a utility `praktika`, which is used to run tests both locally and in CI.
+
+## Stateless
+
+### Suite
+
+Fast Test is self-contained and can be run with no extra setup.
+```sh
+python -m ci.praktika run "Fast test"
+```
+
+The stateless suites expect an executable `clickhouse` binary in `ci/tmp`
+I recommend not running suites with the `s3 storage` option as that requires extra setup.
+```sh
+python -m ci.praktika run "Stateless tests (amd_debug, sequential)"
+```
+
+### One Test
+
+Running a single test can be done with bare `clickhouse-test` or with the `praktika` utility.
+
+#### clickhouse-test
+
+https://clickhouse.com/docs/development/tests#running-a-test-locally
+
+Start Clickhouse server,
+
+```sh
+cd ci/tmp
+./clickhouse server
+```
+
+then, in another window:
+
+```sh
+tests/clickhouse-test -b ci/tmp/clickhouse 03222_pr_asan_index_granularity
+```
+
+#### praktika
+
+```sh
+python -m ci.praktika run "Stateless tests (amd_debug, sequential)" --test 01107_atomic_db_detach_attach
+```
+
+You must specify the name of a job from the PR workflow to instruct praktika on the necessary configuration.
+
+## Integration
+
+### Suite
+
+https://github.com/ClickHouse/ClickHouse/blob/master/tests/integration/README.md
+
+> The runner searches in this order and uses the first found:
+> ./ci/tmp/clickhouse
+> ./build/programs/clickhouse
+> ./clickhouse
+
+```sh
+python -m ci.praktika run "Integration tests (amd_binary, 4/5)"
+```
+
+### One Test
+
+```sh
+cd tests/integration
+./runner --docker-image-version 72c567235d2f7658765b --docker-compose-images-tags=altinityinfra/integration-test:9c789665fa1f2c3b60a8 --binary ../../ci/tmp/clickhouse 'test_storage_hudi/test.py::test_types'
+```
+
+Docker images may or may not need to be specified. Get the tags by examining ci logs.
+Search logs for `integration-test`, look for `"altinityinfra/integration-tests-runner": "72c567235d2f7658765b"`
+and `"altinityinfra/integration-test": "9c789665fa1f2c3b60a8"`
+
+Note: `runner` has been removed from 25.9 onwards.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)