### PR TITLE
Revert support for 'IN' in cluster requests

### DIFF
--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -573,7 +573,7 @@ QueryProcessingStage::Enum IStorageCluster::getQueryProcessingStage(
                 "object_storage_cluster_join_mode!='allow' is not supported without allow_experimental_analyzer=true");
 
         auto info = getQueryTreeInfo(query_info.query_tree, context);
-        if (info.has_join || info.has_cross_join || info.has_local_columns_in_where)
+        if (info.has_join || info.has_cross_join /*|| info.has_local_columns_in_where*/)
             return QueryProcessingStage::Enum::FetchColumns;
     }
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -724,6 +724,7 @@ def test_cluster_joins(started_cluster):
             FROM {CATALOG_NAME}.`{root_namespace}.{table_name}` AS t1
                 JOIN {CATALOG_NAME}.`{root_namespace}.{table_name_2}` AS t2
                 ON t1.tag=t2.id
+            WHERE t1.tag < 10 AND t2.id < 20
             ORDER BY ALL
             SETTINGS
                 object_storage_cluster='cluster_simple',
@@ -733,22 +734,22 @@ def test_cluster_joins(started_cluster):
 
     assert res == "Jack\tSparrow\nJohn\tDow\n"
 
-    res = node.query(
-        f"""
-            SELECT name
-            FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`
-            WHERE tag in (
-                SELECT id
-                FROM {CATALOG_NAME}.`{root_namespace}.{table_name_2}`
-            )
-            ORDER BY ALL
-            SETTINGS
-                object_storage_cluster='cluster_simple',
-                object_storage_cluster_join_mode='local'
-        """
-    )
+    #res = node.query(
+    #    f"""
+    #        SELECT name
+    #        FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`
+    #        WHERE tag in (
+    #            SELECT id
+    #            FROM {CATALOG_NAME}.`{root_namespace}.{table_name_2}`
+    #        )
+    #        ORDER BY ALL
+    #        SETTINGS
+    #            object_storage_cluster='cluster_simple',
+    #            object_storage_cluster_join_mode='local'
+    #    """
+    #)
 
-    assert res == "Jack\nJohn\n"
+    #assert res == "Jack\nJohn\n"
 
     res = node.query(
         f"""
@@ -756,6 +757,7 @@ def test_cluster_joins(started_cluster):
             FROM {CATALOG_NAME}.`{root_namespace}.{table_name}` AS t1
                 JOIN `{table_name_local}` AS t2
                 ON t1.tag=t2.id
+            WHERE t1.tag < 10 AND t2.id < 20
             ORDER BY ALL
             SETTINGS
                 object_storage_cluster='cluster_simple',
@@ -765,28 +767,29 @@ def test_cluster_joins(started_cluster):
 
     assert res == "Jack\tBlack\nJohn\tSilver\n"
 
-    res = node.query(
-        f"""
-            SELECT name
-            FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`
-            WHERE tag in (
-                SELECT id
-                FROM `{table_name_local}`
-            )
-            ORDER BY ALL
-            SETTINGS
-                object_storage_cluster='cluster_simple',
-                object_storage_cluster_join_mode='local'
-        """
-    )
+    #res = node.query(
+    #    f"""
+    #        SELECT name
+    #        FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`
+    #        WHERE tag in (
+    #            SELECT id
+    #            FROM `{table_name_local}`
+    #        )
+    #        ORDER BY ALL
+    #        SETTINGS
+    #            object_storage_cluster='cluster_simple',
+    #            object_storage_cluster_join_mode='local'
+    #    """
+    #)
 
-    assert res == "Jack\nJohn\n"
+    #assert res == "Jack\nJohn\n"
 
     res = node.query(
         f"""
             SELECT t1.name,t2.second_name
             FROM {CATALOG_NAME}.`{root_namespace}.{table_name}` AS t1
                 CROSS JOIN `{table_name_local}` AS t2
+            WHERE t1.tag < 10 AND t2.id < 20
             ORDER BY ALL
             SETTINGS
                 object_storage_cluster='cluster_simple',

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -1163,19 +1163,19 @@ def test_joins(started_cluster):
     res = list(map(str.split, result5.splitlines()))
     assert len(res) == 6
 
-    result6 = node.query(
-        f"""
-        SELECT name FROM
-            s3Cluster('cluster_simple',
-                'http://minio1:9001/root/data/{{clickhouse,database}}/*', 'minio', '{minio_secret_key}', 'CSV',
-                'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))')
-        WHERE value IN (SELECT id FROM join_table)
-        ORDER BY name
-        SETTINGS object_storage_cluster_join_mode='local';
-        """
-    )
-    res = list(map(str.split, result6.splitlines()))
-    assert len(res) == 25
+    #result6 = node.query(
+    #    f"""
+    #    SELECT name FROM
+    #        s3Cluster('cluster_simple',
+    #            'http://minio1:9001/root/data/{{clickhouse,database}}/*', 'minio', '{minio_secret_key}', 'CSV',
+    #            'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))')
+    #    WHERE value IN (SELECT id FROM join_table)
+    #    ORDER BY name
+    #    SETTINGS object_storage_cluster_join_mode='local';
+    #    """
+    #)
+    #res = list(map(str.split, result6.splitlines()))
+    #assert len(res) == 25
 
 
 def test_graceful_shutdown(started_cluster):

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -3623,6 +3623,7 @@ def test_cluster_joins(started_cluster, storage_type):
             FROM {creation_expression} AS t1
                 JOIN {creation_expression_2} AS t2
                 ON t1.tag=t2.id
+            WHERE t1.tag < 10 AND t2.id < 20
             ORDER BY ALL
             SETTINGS
                 object_storage_cluster='cluster_simple',
@@ -3632,22 +3633,22 @@ def test_cluster_joins(started_cluster, storage_type):
 
     assert res == "jack\tsparrow\njohn\tdow\n"
 
-    res = instance.query(
-        f"""
-            SELECT name
-            FROM {creation_expression}
-            WHERE tag in (
-                SELECT id
-                FROM {creation_expression_2}
-            )
-            ORDER BY ALL
-            SETTINGS
-                object_storage_cluster='cluster_simple',
-                object_storage_cluster_join_mode='local'
-        """
-    )
+    #res = instance.query(
+    #    f"""
+    #        SELECT name
+    #        FROM {creation_expression}
+    #        WHERE tag in (
+    #            SELECT id
+    #            FROM {creation_expression_2}
+    #        )
+    #        ORDER BY ALL
+    #        SETTINGS
+    #            object_storage_cluster='cluster_simple',
+    #            object_storage_cluster_join_mode='local'
+    #    """
+    #)
 
-    assert res == "jack\njohn\n"
+    #assert res == "jack\njohn\n"
 
     res = instance.query(
         f"""
@@ -3655,6 +3656,7 @@ def test_cluster_joins(started_cluster, storage_type):
             FROM {creation_expression} AS t1
                 JOIN `{TABLE_NAME_LOCAL}` AS t2
                 ON t1.tag=t2.id
+            WHERE t1.tag < 10 AND t2.id < 20
             ORDER BY ALL
             SETTINGS
                 object_storage_cluster='cluster_simple',
@@ -3664,28 +3666,29 @@ def test_cluster_joins(started_cluster, storage_type):
 
     assert res == "jack\tblack\njohn\tsilver\n"
 
-    res = instance.query(
-        f"""
-            SELECT name
-            FROM {creation_expression}
-            WHERE tag in (
-                SELECT id
-                FROM `{TABLE_NAME_LOCAL}`
-            )
-            ORDER BY ALL
-            SETTINGS
-                object_storage_cluster='cluster_simple',
-                object_storage_cluster_join_mode='local'
-        """
-    )
+    #res = instance.query(
+    #    f"""
+    #        SELECT name
+    #        FROM {creation_expression}
+    #        WHERE tag in (
+    #            SELECT id
+    #            FROM `{TABLE_NAME_LOCAL}`
+    #        )
+    #        ORDER BY ALL
+    #        SETTINGS
+    #            object_storage_cluster='cluster_simple',
+    #            object_storage_cluster_join_mode='local'
+    #    """
+    #)
 
-    assert res == "jack\njohn\n"
+    #assert res == "jack\njohn\n"
 
     res = instance.query(
         f"""
             SELECT t1.name,t2.second_name
             FROM {creation_expression} AS t1
                 CROSS JOIN `{TABLE_NAME_LOCAL}` AS t2
+            WHERE t1.tag < 10 AND t2.id < 20
             ORDER BY ALL
             SETTINGS
                 object_storage_cluster='cluster_simple',


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Revert support for 'IN' in cluster requests

### Documentation entry for user-facing changes
Race condition in queries
```
SELECT *
  FROM icebereg.table
  WHERE
    key IN (SELECT keys FROM local.table)
SETTINGS
  object_storage_cluster='swarm',
  object_storage_cluster_join_mode='local'
```
Turn off support until real fix.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)