### PR TITLE
25.8 Fix integ crossout

### DIFF
--- a/ci/jobs/scripts/integration_tests_runner.py
+++ b/ci/jobs/scripts/integration_tests_runner.py
@@ -583,9 +583,13 @@ class ClickhouseIntegrationTestsRunner:
                     test_logs = extract_fail_logs(log_path)
                     test_log = test_logs.get(failed_test.split("::")[-1])
                     if test_log is None:
+                        # Log extraction can fail if the fail was in the teardown
                         log_file.write(
-                            f"WARNING: Test '{failed_test}' has no logs among {test_logs.keys()}\n"
+                            f"WARNING: Test '{failed_test}' has no logs among {list(test_logs.keys())}, assuming log extraction failed, proceeding with full log\n"
                         )
+                        with open(log_path, "r", encoding="utf-8") as f:
+                            test_log = f.read()
+
                     known_fail_reason = test_is_known_fail(
                         failed_test, test_log, log_file
                     )

--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -57,6 +57,21 @@
   message: result differs with reference
   check_types:
   - msan
+- name: 00024_random_counters
+  reason: INVESTIGATE - random timeout
+  message: Timeout! Killing process group
+- name: test_storage_s3_queue/test_5.py::test_migration[1-s3queue_]
+  reason: KNOWN - Sometimes fails due to test order
+  message: 'Failed: Timeout >900.0s'
+- name: test_storage_s3_queue/test_5.py::test_migration[3-s3queue_]
+  reason: KNOWN - Sometimes fails due to test order
+  message: 'Failed: Timeout >900.0s'
+- name: test_storage_s3_queue/test_5.py::test_migration[1-]
+  reason: KNOWN - Sometimes fails due to test order
+  message: 'Failed: Timeout >900.0s'
+- name: test_storage_s3_queue/test_5.py::test_migration[3-]
+  reason: KNOWN - Sometimes fails due to test order
+  message: 'Failed: Timeout >900.0s'
 - name: test_scheduler_cpu_preemptive/test.py::test_downscaling[cpu-slot-preemption-timeout-1ms]
   reason: INVESTIGATE - Unstable on tsan, asan
   message: 'Failed: Timeout >900.0s'
@@ -87,6 +102,12 @@
 - name: test_storage_s3_queue/test_0.py::test_streaming_to_many_views[ordered]
   reason: 'KNOWN - Unstable upstream'
 - name: test_storage_s3_queue/test_2.py::test_shards_distributed[unordered-1]
+  reason: 'KNOWN - Unstable upstream'
+- name: test_storage_s3_queue/test_2.py::test_shards_distributed[unordered-8]
+  reason: 'KNOWN - Unstable upstream'
+- name: test_storage_s3_queue/test_2.py::test_shards_distributed[ordered-1]
+  reason: 'KNOWN - Unstable upstream'
+- name: test_storage_s3_queue/test_2.py::test_shards_distributed[ordered-2]
   reason: 'KNOWN - Unstable upstream'
 - name: test_storage_s3_queue/test_4.py::test_list_and_delete_race
   reason: 'KNOWN - Unstable upstream'
@@ -163,7 +184,7 @@
      |Timeout exceeded while receiving data from server\.
      |DB::Exception: Estimated query execution time \((\d+\.\d+) seconds\) is too long\.
      |curl: \(28\) Operation timed out'
-  not_message: 'Sanitizer trap'
+  not_message: 'Sanitizer trap|Sanitizer assert'
   regex: true
   check_types:
   - tsan


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Fix crossout not working when the error occurred during teardown.
Crossout a few more known fails.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)