### PR TITLE
Fix segfault on unexpected node shutdown

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7104,9 +7104,6 @@ Use Shuffle aggregation strategy instead of PartialAggregation + Merge in distri
     DECLARE(Bool, allow_experimental_iceberg_read_optimization, true, R"(
 Allow Iceberg read optimization based on Iceberg metadata.
 )", EXPERIMENTAL) \
-    DECLARE(Bool, allow_retries_in_cluster_requests, false, R"(
-Allow retries in cluster request, when one node goes offline
-)", EXPERIMENTAL) \
     DECLARE(Bool, object_storage_remote_initiator, false, R"(
 Execute request to object storage as remote on one of object_storage_cluster nodes.
 )", EXPERIMENTAL) \
@@ -7227,6 +7224,7 @@ Sets the evaluation time to be used with promql dialect. 'auto' means the curren
     MAKE_OBSOLETE(M, Bool, allow_experimental_shared_set_join, true) \
     MAKE_OBSOLETE(M, UInt64, min_external_sort_block_bytes, 100_MiB) \
     MAKE_OBSOLETE(M, UInt64, distributed_cache_read_alignment, 0) \
+    MAKE_OBSOLETE(M, Bool, allow_retries_in_cluster_requests, false) \
     /** The section above is for obsolete settings. Do not add anything there. */
 #endif /// __CLION_IDE__
 

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -730,6 +730,15 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::processPacket(Packet packet
             break;
 
         case Protocol::Server::ConnectionLost:
+            if (extension && extension->task_iterator && extension->task_iterator->supportRerunTask() && extension->replica_info)
+            {
+                if (!replica_has_processed_data.contains(extension->replica_info->number_of_current_replica))
+                {
+                    finished = true;
+                    extension->task_iterator->rescheduleTasksFromReplica(extension->replica_info->number_of_current_replica);
+                    return ReadResult(Block{});
+                }
+            }
             packet.exception->rethrow();
             break;
 
@@ -998,6 +1007,11 @@ void RemoteQueryExecutor::setProfileInfoCallback(ProfileInfoCallback callback)
 {
     LockAndBlocker guard(was_cancelled_mutex);
     profile_info_callback = std::move(callback);
+}
+
+bool RemoteQueryExecutor::skipUnavailableShards() const
+{
+    return context->getSettingsRef()[Setting::skip_unavailable_shards];
 }
 
 bool RemoteQueryExecutor::needToSkipUnavailableShard() const

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -52,7 +52,6 @@ namespace Setting
     extern const SettingsBool use_hedged_requests;
     extern const SettingsBool push_external_roles_in_interserver_queries;
     extern const SettingsMilliseconds parallel_replicas_connect_timeout_ms;
-    extern const SettingsBool allow_retries_in_cluster_requests;
 }
 
 namespace ErrorCodes
@@ -83,7 +82,6 @@ RemoteQueryExecutor::RemoteQueryExecutor(
     , extension(extension_)
     , priority_func(priority_func_)
     , read_packet_type_separately(context->canUseParallelReplicasOnInitiator() && !context->getSettingsRef()[Setting::use_hedged_requests])
-    , allow_retries_in_cluster_requests(context->getSettingsRef()[Setting::allow_retries_in_cluster_requests])
 {
     if (stage == QueryProcessingStage::QueryPlan && !query_plan)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Query plan is not passed for QueryPlan processing stage");
@@ -468,8 +466,7 @@ int RemoteQueryExecutor::sendQueryAsync()
         read_context = std::make_unique<ReadContext>(
             *this,
             /*suspend_when_query_sent*/ true,
-            read_packet_type_separately,
-            allow_retries_in_cluster_requests);
+            read_packet_type_separately);
 
     /// If query already sent, do nothing. Note that we cannot use sent_query flag here,
     /// because we can still be in process of sending scalars or external tables.
@@ -542,8 +539,7 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::readAsync()
         read_context = std::make_unique<ReadContext>(
             *this,
             /*suspend_when_query_sent*/ false,
-            read_packet_type_separately,
-            allow_retries_in_cluster_requests);
+            read_packet_type_separately);
         recreate_read_context = false;
     }
 
@@ -734,18 +730,6 @@ RemoteQueryExecutor::ReadResult RemoteQueryExecutor::processPacket(Packet packet
             break;
 
         case Protocol::Server::ConnectionLost:
-            if (allow_retries_in_cluster_requests)
-            {
-                if (extension && extension->task_iterator && extension->task_iterator->supportRerunTask() && extension->replica_info)
-                {
-                    if (!replica_has_processed_data.contains(extension->replica_info->number_of_current_replica))
-                    {
-                        finished = true;
-                        extension->task_iterator->rescheduleTasksFromReplica(extension->replica_info->number_of_current_replica);
-                        return ReadResult(Block{});
-                    }
-                }
-            }
             packet.exception->rethrow();
             break;
 
@@ -1014,11 +998,6 @@ void RemoteQueryExecutor::setProfileInfoCallback(ProfileInfoCallback callback)
 {
     LockAndBlocker guard(was_cancelled_mutex);
     profile_info_callback = std::move(callback);
-}
-
-bool RemoteQueryExecutor::skipUnavailableShards() const
-{
-    return context->getSettingsRef()[Setting::skip_unavailable_shards];
 }
 
 bool RemoteQueryExecutor::needToSkipUnavailableShard() const

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -233,6 +233,8 @@ public:
 
     IConnections & getConnections() { return *connections; }
 
+    bool skipUnavailableShards() const;
+
     bool needToSkipUnavailableShard() const;
 
     bool isReplicaUnavailable() const { return extension && extension->parallel_reading_coordinator && connections->size() == 0; }

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -233,8 +233,6 @@ public:
 
     IConnections & getConnections() { return *connections; }
 
-    bool skipUnavailableShards() const;
-
     bool needToSkipUnavailableShard() const;
 
     bool isReplicaUnavailable() const { return extension && extension->parallel_reading_coordinator && connections->size() == 0; }
@@ -338,8 +336,6 @@ private:
     GetPriorityForLoadBalancing::Func priority_func;
 
     const bool read_packet_type_separately = false;
-
-    const bool allow_retries_in_cluster_requests = false;
 
     std::unordered_set<size_t> replica_has_processed_data;
 

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -22,13 +22,11 @@ namespace ErrorCodes
 RemoteQueryExecutorReadContext::RemoteQueryExecutorReadContext(
     RemoteQueryExecutor & executor_,
     bool suspend_when_query_sent_,
-    bool read_packet_type_separately_,
-    bool allow_retries_in_cluster_requests_)
+    bool read_packet_type_separately_)
     : AsyncTaskExecutor(std::make_unique<Task>(*this))
     , executor(executor_)
     , suspend_when_query_sent(suspend_when_query_sent_)
     , read_packet_type_separately(read_packet_type_separately_)
-    , allow_retries_in_cluster_requests(allow_retries_in_cluster_requests_)
 {
     if (-1 == pipe2(pipe_fd, O_NONBLOCK))
         throw ErrnoException(ErrorCodes::CANNOT_OPEN_FILE, "Cannot create pipe");
@@ -59,49 +57,21 @@ void RemoteQueryExecutorReadContext::Task::run(AsyncCallback async_callback, Sus
     if (read_context.executor.needToSkipUnavailableShard())
         return;
 
-    try
+    while (true)
     {
-        while (true)
+        read_context.has_read_packet_part = PacketPart::None;
+
+        if (read_context.read_packet_type_separately)
         {
-            try
-            {
-                read_context.has_read_packet_part = PacketPart::None;
-
-                if (read_context.read_packet_type_separately)
-                {
-                    read_context.packet.type = read_context.executor.getConnections().receivePacketTypeUnlocked(async_callback);
-                    read_context.has_read_packet_part = PacketPart::Type;
-                    suspend_callback();
-                }
-                read_context.packet = read_context.executor.getConnections().receivePacketUnlocked(async_callback);
-                read_context.has_read_packet_part = PacketPart::Body;
-                if (read_context.packet.type == Protocol::Server::Data)
-                    read_context.has_data_packets = true;
-            }
-            catch (const Exception & e)
-            {
-                /// If cluster node unxepectedly shutted down (kill/segfault/power off/etc.) socket just closes.
-                /// If initiator did not process any data packets before, this fact can be ignored.
-                /// Unprocessed tasks will be executed on other nodes.
-                if (e.code() == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF
-                    && !read_context.has_data_packets.load() && read_context.executor.skipUnavailableShards())
-                {
-                    read_context.has_read_packet_part = PacketPart::None;
-                }
-                else
-                    throw;
-            }
-
+            read_context.packet.type = read_context.executor.getConnections().receivePacketTypeUnlocked(async_callback);
+            read_context.has_read_packet_part = PacketPart::Type;
             suspend_callback();
         }
-    }
-    catch (const Exception &)
-    {
-        if (!read_context.allow_retries_in_cluster_requests)
-            throw;
-        read_context.packet.type = Protocol::Server::ConnectionLost;
-        read_context.packet.exception = std::make_unique<Exception>(getCurrentExceptionMessageAndPattern(true), getCurrentExceptionCode());
+        read_context.packet = read_context.executor.getConnections().receivePacketUnlocked(async_callback);
         read_context.has_read_packet_part = PacketPart::Body;
+        if (read_context.packet.type == Protocol::Server::Data)
+            read_context.has_data_packets = true;
+
         suspend_callback();
     }
 }

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.cpp
@@ -57,22 +57,42 @@ void RemoteQueryExecutorReadContext::Task::run(AsyncCallback async_callback, Sus
     if (read_context.executor.needToSkipUnavailableShard())
         return;
 
-    while (true)
+    try
     {
-        read_context.has_read_packet_part = PacketPart::None;
-
-        if (read_context.read_packet_type_separately)
+        while (true)
         {
-            read_context.packet.type = read_context.executor.getConnections().receivePacketTypeUnlocked(async_callback);
-            read_context.has_read_packet_part = PacketPart::Type;
+            read_context.has_read_packet_part = PacketPart::None;
+
+            if (read_context.read_packet_type_separately)
+            {
+                read_context.packet.type = read_context.executor.getConnections().receivePacketTypeUnlocked(async_callback);
+                read_context.has_read_packet_part = PacketPart::Type;
+                suspend_callback();
+            }
+            read_context.packet = read_context.executor.getConnections().receivePacketUnlocked(async_callback);
+            read_context.has_read_packet_part = PacketPart::Body;
+            if (read_context.packet.type == Protocol::Server::Data)
+                read_context.has_data_packets = true;
+
             suspend_callback();
         }
-        read_context.packet = read_context.executor.getConnections().receivePacketUnlocked(async_callback);
-        read_context.has_read_packet_part = PacketPart::Body;
-        if (read_context.packet.type == Protocol::Server::Data)
-            read_context.has_data_packets = true;
-
-        suspend_callback();
+    }
+    catch (const Exception & e)
+    {
+        /// If cluster node unxepectedly shutted down (kill/segfault/power off/etc.) socket just closes.
+        /// If initiator did not process any data packets before, this fact can be ignored.
+        /// Unprocessed tasks will be executed on other nodes.
+        if (e.code() == ErrorCodes::ATTEMPT_TO_READ_AFTER_EOF
+            && !read_context.has_data_packets.load()
+            && read_context.executor.skipUnavailableShards())
+        {
+            read_context.packet.type = Protocol::Server::ConnectionLost;
+            read_context.packet.exception = std::make_unique<Exception>(getCurrentExceptionMessageAndPattern(true), getCurrentExceptionCode());
+            read_context.has_read_packet_part = PacketPart::Body;
+            suspend_callback();
+        }
+        else
+            throw;
     }
 }
 

--- a/src/QueryPipeline/RemoteQueryExecutorReadContext.h
+++ b/src/QueryPipeline/RemoteQueryExecutorReadContext.h
@@ -28,8 +28,7 @@ public:
     explicit RemoteQueryExecutorReadContext(
         RemoteQueryExecutor & executor_,
         bool suspend_when_query_sent_,
-        bool read_packet_type_separately_,
-        bool allow_retries_in_cluster_requests_);
+        bool read_packet_type_separately_);
 
     ~RemoteQueryExecutorReadContext() override;
 
@@ -112,7 +111,6 @@ private:
     bool suspend_when_query_sent = false;
     bool is_query_sent = false;
     const bool read_packet_type_separately = false;
-    const bool allow_retries_in_cluster_requests = false;
 };
 
 }


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Solved #1200 
Fix segfault on unexpected node shutdown

### Documentation entry for user-facing changes
Setting `allow_retries_in_cluster_requests` actually useless, and trying to process caused segfault.
Logic behind `allow_retries_in_cluster_requests` is based on the assumption that swarm nodes send first data packet only when already processed some portion of data. But in real world nodes send first packet immediately without any data, but only with header (column list) - https://github.com/Altinity/ClickHouse/blob/antalya-25.8/src/Server/TCPHandler.cpp#L1296
This makes this setting useless.
Segfault is a result of incorrect continue of reading after exception in `RemoteQueryExecutorReadContext::Task::run`.
Removing `allow_retries_in_cluster_requests` also removes this try-catch block, which fixes the problem.
EOF catched without continue reading, possible if node shutdowned in short period of time between getting subquery and answering "end of work" in case when swarm mode turned off.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)