### PR TITLE
Antalya 25.8 - Move stateless crossout logic into clickhouse-test

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -449,6 +449,10 @@ def main():
             )
             force_ok_exit = True
 
+    broken_tests_handler_log = os.path.join(temp_dir, "broken_tests_handler.log")
+    if os.path.exists(broken_tests_handler_log):
+        debug_files.append(broken_tests_handler_log)
+
     Result.create_from(
         results=results,
         stopwatch=stop_watch,

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -354,6 +354,8 @@ def main():
         )
         res = results[-1].is_ok()
 
+    runner_options += f" --known-fails-file-path tests/broken_tests.yaml"
+
     test_result = None
     if res and JobStages.TEST in stages:
         stop_watch_ = Utils.Stopwatch()

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -135,7 +135,7 @@ class FTResultsProcessor:
                     test_end = False
                 elif (
                     len(test_results) > 0
-                    and test_results[-1][1] in ("FAIL", "SKIPPED")
+                    and test_results[-1][1] in ("FAIL", "SKIPPED", "BROKEN")
                     and not test_end
                 ):
                     test_results[-1][3].append(original_line)

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -14,6 +14,7 @@ FAIL_SIGN = "[ FAIL "
 TIMEOUT_SIGN = "[ Timeout! "
 UNKNOWN_SIGN = "[ UNKNOWN "
 SKIPPED_SIGN = "[ SKIPPED "
+BROKEN_SIGN = "[ BROKEN "
 HUNG_SIGN = "Found hung queries in processlist"
 SERVER_DIED_SIGN = "Server died, terminating all processes"
 SERVER_DIED_SIGN2 = "Server does not respond to health check"
@@ -31,101 +32,6 @@ RETRIES_SIGN = "Some tests were restarted"
 #     with open(status_file, "w", encoding="utf-8") as f:
 #         out = csv.writer(f, delimiter="\t")
 #         out.writerow(status)
-
-
-def get_broken_tests_rules() -> dict:
-    broken_tests_file_path = "tests/broken_tests.yaml"
-    if (
-        not os.path.isfile(broken_tests_file_path)
-        or os.path.getsize(broken_tests_file_path) == 0
-    ):
-        raise ValueError(
-            "There is something wrong with getting broken tests rules: "
-            f"file '{broken_tests_file_path}' is empty or does not exist."
-        )
-
-    with open(broken_tests_file_path, "r", encoding="utf-8") as broken_tests_file:
-        broken_tests = yaml.safe_load(broken_tests_file)
-
-    compiled_rules = {"exact": {}, "pattern": {}}
-
-    for test in broken_tests:
-        regex = test.get("regex") is True
-        rule = {
-            "reason": test["reason"],
-        }
-
-        if test.get("message"):
-            rule["message"] = re.compile(test["message"]) if regex else test["message"]
-
-        if test.get("not_message"):
-            rule["not_message"] = (
-                re.compile(test["not_message"]) if regex else test["not_message"]
-            )
-        if test.get("check_types"):
-            rule["check_types"] = test["check_types"]
-
-        if regex:
-            rule["regex"] = True
-            compiled_rules["pattern"][re.compile(test["name"])] = rule
-        else:
-            compiled_rules["exact"][test["name"]] = rule
-
-    print(
-        f"INFO: Compiled {len(compiled_rules['exact'])} exact rules and {len(compiled_rules['pattern'])} pattern rules"
-    )
-
-    return compiled_rules
-
-
-def test_is_known_fail(test_name, test_logs, known_broken_tests, test_options_string):
-    matching_rules = []
-
-    print(f"Checking known broken tests for failed test: {test_name}")
-    print("Potential matching rules:")
-    exact_rule = known_broken_tests["exact"].get(test_name)
-    if exact_rule:
-        print(f"{test_name} - {exact_rule}")
-        matching_rules.append(exact_rule)
-
-    for name_re, data in known_broken_tests["pattern"].items():
-        if name_re.fullmatch(test_name):
-            print(f"{name_re} - {data}")
-            matching_rules.append(data)
-
-    if not matching_rules:
-        return False
-
-    def matches_substring(substring, log, is_regex):
-        if log is None:
-            return False
-        if is_regex:
-            return bool(substring.search(log))
-        return substring in log
-
-    for rule_data in matching_rules:
-        if rule_data.get("check_types") and not any(
-            ct in test_options_string for ct in rule_data["check_types"]
-        ):
-            print(
-                f"Check types didn't match: '{rule_data['check_types']}' not in '{test_options_string}'"
-            )
-            continue  # check_types didn't match → skip rule
-
-        is_regex = rule_data.get("regex", False)
-        not_message = rule_data.get("not_message")
-        if not_message and matches_substring(not_message, test_logs, is_regex):
-            print(f"Skip rule: Not message matched: '{rule_data['not_message']}'")
-            continue  # not_message matched → skip rule
-        message = rule_data.get("message")
-        if message and not matches_substring(message, test_logs, is_regex):
-            print(f"Skip rule: Message didn't match: '{rule_data['message']}'")
-            continue
-
-        print(f"Test {test_name} matched rule: {rule_data}")
-        return rule_data["reason"]
-
-    return False
 
 
 class FTResultsProcessor:
@@ -163,8 +69,6 @@ class FTResultsProcessor:
         test_results = []
         test_end = True
 
-        known_broken_tests = get_broken_tests_rules()
-
         with open(self.tests_output_file, "r", encoding="utf-8") as test_file:
             for line in test_file:
                 original_line = line
@@ -183,7 +87,13 @@ class FTResultsProcessor:
                     retries = True
                 if any(
                     sign in line
-                    for sign in (OK_SIGN, FAIL_SIGN, UNKNOWN_SIGN, SKIPPED_SIGN)
+                    for sign in (
+                        OK_SIGN,
+                        FAIL_SIGN,
+                        UNKNOWN_SIGN,
+                        SKIPPED_SIGN,
+                        BROKEN_SIGN,
+                    )
                 ):
                     test_name = line.split(" ")[2].split(":")[0]
 
@@ -216,6 +126,9 @@ class FTResultsProcessor:
                     elif SKIPPED_SIGN in line:
                         skipped += 1
                         test_results.append((test_name, "SKIPPED", test_time, []))
+                    elif BROKEN_SIGN in line:
+                        broken += 1
+                        test_results.append((test_name, "BROKEN", test_time, []))
                     else:
                         success += int(OK_SIGN in line)
                         test_results.append((test_name, "OK", test_time, []))
@@ -233,8 +146,6 @@ class FTResultsProcessor:
                 if DATABASE_SIGN in line:
                     test_end = True
 
-        test_options_string = ", ".join(self.test_options)
-
         test_results_ = []
         for test in test_results:
             try:
@@ -247,21 +158,6 @@ class FTResultsProcessor:
                         info="".join(test[3])[:16384],
                     )
                 )
-
-                if test[1] == "FAIL":
-                    broken_message = test_is_known_fail(
-                        test[0],
-                        test_results_[-1].info,
-                        known_broken_tests,
-                        test_options_string,
-                    )
-
-                    if broken_message:
-                        broken += 1
-                        failed -= 1
-                        test_results_[-1].set_status(Result.StatusExtended.BROKEN)
-                        test_results_[-1].set_label(Result.Label.BROKEN)
-                        test_results_[-1].info += "\nMarked as broken: " + broken_message
 
             except Exception as e:
                 print(f"ERROR: Failed to parse test results: {test}")

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -1,11 +1,6 @@
 import dataclasses
-import json
-import os
 import traceback
 from typing import List
-import re
-
-import yaml
 
 from praktika.result import Result
 

--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -57,6 +57,24 @@
   message: result differs with reference
   check_types:
   - msan
+- name: 02313_filesystem_cache_seeks
+  reason: fails when azure storage is not set up
+  message: 'DB::Exception: Unknown storage policy `azure_cache`'
+- name: 02286_drop_filesystem_cache
+  reason: fails when azure storage is not set up
+  message: 'DB::Exception: Unknown storage policy `azure_cache`'
+- name: 02242_system_filesystem_cache_log_table
+  reason: fails when azure storage is not set up
+  message: 'DB::Exception: Unknown storage policy `azure_cache`'
+- name: 02241_filesystem_cache_on_write_operations
+  reason: fails when azure storage is not set up
+  message: 'DB::Exception: Unknown storage policy `azure_cache`'
+- name: 02240_system_filesystem_cache_table
+  reason: fails when azure storage is not set up
+  message: 'DB::Exception: Unknown storage policy `azure_cache`'
+- name: 02226_filesystem_cache_profile_events
+  reason: fails when azure storage is not set up
+  message: 'DB::Exception: Unknown storage policy `azure_cache`'
 - name: 00024_random_counters
   reason: INVESTIGATE - random timeout
   message: Timeout! Killing process group

--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -77,7 +77,7 @@
   message: 'DB::Exception: Unknown storage policy `azure_cache`'
 - name: 00024_random_counters
   reason: INVESTIGATE - random timeout
-  message: Timeout! Killing process group
+  message: Timeout! Processes left in process group
 - name: test_storage_s3_queue/test_5.py::test_migration[1-s3queue_]
   reason: KNOWN - Sometimes fails due to test order
   message: 'Failed: Timeout >900.0s'

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2330,15 +2330,11 @@ class TestCase:
                     )
                     if known_fail_reason:
                         result.status = TestStatus.BROKEN
-                        if "Database: " in result.description.splitlines()[-1]:
-                            result.description = result.description.replace(
-                                "Database: ",
-                                f"Marked as broken: {known_fail_reason}\nDatabase: ",
-                            )
-                        else:
-                            result.description += (
-                                f"\nMarked as broken: {known_fail_reason}"
-                            )
+
+                        # Place the message on the second line
+                        result.description.replace(
+                            "\n", f"\nMarked as broken: {known_fail_reason}\n", count=1
+                        )
 
             if self.name in suite.blacklist_check:
                 if result.status == TestStatus.OK:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -88,8 +88,7 @@ TEST_MAX_RUN_TIME_IN_SECONDS = 180
 
 
 @lru_cache(maxsize=1)
-def get_broken_tests_rules() -> dict:
-    broken_tests_file_path = "tests/broken_tests.yaml"
+def get_broken_tests_rules(broken_tests_file_path: str) -> dict:
     if (
         not os.path.isfile(broken_tests_file_path)
         or os.path.getsize(broken_tests_file_path) == 0
@@ -129,10 +128,10 @@ def get_broken_tests_rules() -> dict:
     return compiled_rules
 
 
-def test_is_known_fail(test_name, test_logs, build_flags):
+def test_is_known_fail(test_name, test_logs, build_flags, broken_tests_file_path):
     matching_rules = []
 
-    known_broken_tests = get_broken_tests_rules()
+    known_broken_tests = get_broken_tests_rules(broken_tests_file_path)
 
     # print(f"Checking known broken tests for failed test: {test_name}")
     # print("Potential matching rules:")
@@ -2321,13 +2320,17 @@ class TestCase:
             if result.status == TestStatus.FAIL:
                 result.description = self.add_info_about_settings(result.description)
 
-                # Check if the test is known to fail
-                known_fail_reason = test_is_known_fail(
-                    self.name, result.description, args.build_flags
-                )
-                if known_fail_reason:
-                    result.status = TestStatus.BROKEN
-                    result.description += f"Marked as broken: {known_fail_reason}"
+                if args.known_fails_file_path:
+                    # Check if the test is known to fail
+                    known_fail_reason = test_is_known_fail(
+                        self.name,
+                        result.description,
+                        args.build_flags,
+                        args.known_fails_file_path,
+                    )
+                    if known_fail_reason:
+                        result.status = TestStatus.BROKEN
+                        result.description += f"Marked as broken: {known_fail_reason}"
 
             if self.name in suite.blacklist_check:
                 if result.status == TestStatus.OK:
@@ -3817,6 +3820,8 @@ def parse_args():
     parser = ArgumentParser(description="ClickHouse functional tests")
     parser.add_argument("-q", "--queries", help="Path to queries dir")
     parser.add_argument("--tmp", help="Path to tmp dir")
+
+    parser.add_argument("--known-fails-file-path", help="Path to known fails file")
 
     parser.add_argument(
         "-b",

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -162,6 +162,8 @@ def test_is_known_fail(test_name, test_logs, build_flags, broken_tests_file_path
         if not matching_rules:
             return False
 
+        log_file.write(f"First line of test logs: {test_logs.splitlines()[0]}\n")
+
         for rule_data in matching_rules:
             if rule_data.get("check_types") and not any(
                 ct in build_flags for ct in rule_data["check_types"]

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2335,7 +2335,7 @@ class TestCase:
                     # Check if the test is known to fail
                     known_fail_reason = test_is_known_fail(
                         self.name,
-                        result.description,
+                        result.reason.value + result.description,
                         args.build_flags,
                         args.known_fails_file_path,
                     )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2337,7 +2337,7 @@ class TestCase:
                     # Check if the test is known to fail
                     known_fail_reason = test_is_known_fail(
                         self.name,
-                        result.reason.value + result.description,
+                        f"Reason: {result.reason.value} {result.description}",
                         args.build_flags,
                         args.known_fails_file_path,
                     )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -131,23 +131,6 @@ def get_broken_tests_rules(broken_tests_file_path: str) -> dict:
 def test_is_known_fail(test_name, test_logs, build_flags, broken_tests_file_path):
     matching_rules = []
 
-    known_broken_tests = get_broken_tests_rules(broken_tests_file_path)
-
-    # print(f"Checking known broken tests for failed test: {test_name}")
-    # print("Potential matching rules:")
-    exact_rule = known_broken_tests["exact"].get(test_name)
-    if exact_rule:
-        # print(f"{test_name} - {exact_rule}")
-        matching_rules.append(exact_rule)
-
-    for name_re, data in known_broken_tests["pattern"].items():
-        if name_re.fullmatch(test_name):
-            # print(f"{name_re} - {data}")
-            matching_rules.append(data)
-
-    if not matching_rules:
-        return False
-
     def matches_substring(substring, log, is_regex):
         if log is None:
             return False
@@ -155,29 +138,57 @@ def test_is_known_fail(test_name, test_logs, build_flags, broken_tests_file_path
             return bool(substring.search(log))
         return substring in log
 
-    for rule_data in matching_rules:
-        if rule_data.get("check_types") and not any(
-            ct in build_flags for ct in rule_data["check_types"]
-        ):
-            # print(
-            #     f"Check types didn't match: '{rule_data['check_types']}' not in '{build_flags}'"
-            # )
-            continue  # check_types didn't match → skip rule
+    broken_tests_log = "ci/tmp/broken_tests_handler.log"
 
-        is_regex = rule_data.get("regex", False)
-        not_message = rule_data.get("not_message")
-        if not_message and matches_substring(not_message, test_logs, is_regex):
-            # print(f"Skip rule: Not message matched: '{rule_data['not_message']}'")
-            continue  # not_message matched → skip rule
-        message = rule_data.get("message")
-        if message and not matches_substring(message, test_logs, is_regex):
-            # print(f"Skip rule: Message didn't match: '{rule_data['message']}'")
-            continue
+    with open(broken_tests_log, "a") as log_file:
+        try:
+            known_broken_tests = get_broken_tests_rules(broken_tests_file_path)
+        except Exception as e:
+            log_file.write(f"Error getting broken tests rules: {e}\n")
+            return False
 
-        # print(f"Test {test_name} matched rule: {rule_data}")
-        return rule_data["reason"]
+        log_file.write(f"Checking known broken tests for failed test: {test_name}\n")
+        log_file.write("Potential matching rules:\n")
+        exact_rule = known_broken_tests["exact"].get(test_name)
+        if exact_rule:
+            log_file.write(f"{test_name} - {exact_rule}\n")
+            matching_rules.append(exact_rule)
 
-    return False
+        for name_re, data in known_broken_tests["pattern"].items():
+            if name_re.fullmatch(test_name):
+                log_file.write(f"{name_re} - {data}\n")
+                matching_rules.append(data)
+
+        if not matching_rules:
+            return False
+
+        for rule_data in matching_rules:
+            if rule_data.get("check_types") and not any(
+                ct in build_flags for ct in rule_data["check_types"]
+            ):
+                log_file.write(
+                    f"Check types didn't match: '{rule_data['check_types']}' not in '{build_flags}'\n"
+                )
+                continue  # check_types didn't match → skip rule
+
+            is_regex = rule_data.get("regex", False)
+            not_message = rule_data.get("not_message")
+            if not_message and matches_substring(not_message, test_logs, is_regex):
+                log_file.write(
+                    f"Skip rule: Not message matched: '{rule_data['not_message']}'\n"
+                )
+                continue  # not_message matched → skip rule
+            message = rule_data.get("message")
+            if message and not matches_substring(message, test_logs, is_regex):
+                log_file.write(
+                    f"Skip rule: Message didn't match: '{rule_data['message']}'\n"
+                )
+                continue
+
+            log_file.write(f"Test {test_name} matched rule: {rule_data}\n")
+            return rule_data["reason"]
+
+        return False
 
 
 class SharedEngineReplacer:
@@ -2332,8 +2343,8 @@ class TestCase:
                         result.status = TestStatus.BROKEN
 
                         # Place the message on the second line
-                        result.description.replace(
-                            "\n", f"\nMarked as broken: {known_fail_reason}\n", count=1
+                        result.description = result.description.replace(
+                            "\n", f"\nMarked as broken: {known_fail_reason}\n", 1
                         )
 
             if self.name in suite.blacklist_check:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2330,7 +2330,15 @@ class TestCase:
                     )
                     if known_fail_reason:
                         result.status = TestStatus.BROKEN
-                        result.description += f"Marked as broken: {known_fail_reason}"
+                        if "Database: " in result.description.splitlines()[-1]:
+                            result.description = result.description.replace(
+                                "Database: ",
+                                f"Marked as broken: {known_fail_reason}\nDatabase: ",
+                            )
+                        else:
+                            result.description += (
+                                f"\nMarked as broken: {known_fail_reason}"
+                            )
 
             if self.name in suite.blacklist_check:
                 if result.status == TestStatus.OK:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -11,6 +11,10 @@ import copy
 import enum
 import glob
 
+# For processing the broken tests rules
+from functools import lru_cache
+import yaml
+
 # Not requests, to avoid requiring extra dependency.
 import http.client
 import io
@@ -81,6 +85,100 @@ TEST_FILE_EXTENSIONS = [".sql", ".sql.j2", ".sh", ".py", ".expect"]
 VERSION_PATTERN = r"^((\d+\.)?(\d+\.)?(\d+\.)?\d+)$"
 
 TEST_MAX_RUN_TIME_IN_SECONDS = 180
+
+
+@lru_cache(maxsize=1)
+def get_broken_tests_rules() -> dict:
+    broken_tests_file_path = "tests/broken_tests.yaml"
+    if (
+        not os.path.isfile(broken_tests_file_path)
+        or os.path.getsize(broken_tests_file_path) == 0
+    ):
+        raise ValueError(
+            "There is something wrong with getting broken tests rules: "
+            f"file '{broken_tests_file_path}' is empty or does not exist."
+        )
+
+    with open(broken_tests_file_path, "r", encoding="utf-8") as broken_tests_file:
+        broken_tests = yaml.safe_load(broken_tests_file)
+
+    compiled_rules = {"exact": {}, "pattern": {}}
+
+    for test in broken_tests:
+        regex = test.get("regex") is True
+        rule = {
+            "reason": test["reason"],
+        }
+
+        if test.get("message"):
+            rule["message"] = re.compile(test["message"]) if regex else test["message"]
+
+        if test.get("not_message"):
+            rule["not_message"] = (
+                re.compile(test["not_message"]) if regex else test["not_message"]
+            )
+        if test.get("check_types"):
+            rule["check_types"] = test["check_types"]
+
+        if regex:
+            rule["regex"] = True
+            compiled_rules["pattern"][re.compile(test["name"])] = rule
+        else:
+            compiled_rules["exact"][test["name"]] = rule
+
+    return compiled_rules
+
+
+def test_is_known_fail(test_name, test_logs, build_flags):
+    matching_rules = []
+
+    known_broken_tests = get_broken_tests_rules()
+
+    # print(f"Checking known broken tests for failed test: {test_name}")
+    # print("Potential matching rules:")
+    exact_rule = known_broken_tests["exact"].get(test_name)
+    if exact_rule:
+        # print(f"{test_name} - {exact_rule}")
+        matching_rules.append(exact_rule)
+
+    for name_re, data in known_broken_tests["pattern"].items():
+        if name_re.fullmatch(test_name):
+            # print(f"{name_re} - {data}")
+            matching_rules.append(data)
+
+    if not matching_rules:
+        return False
+
+    def matches_substring(substring, log, is_regex):
+        if log is None:
+            return False
+        if is_regex:
+            return bool(substring.search(log))
+        return substring in log
+
+    for rule_data in matching_rules:
+        if rule_data.get("check_types") and not any(
+            ct in build_flags for ct in rule_data["check_types"]
+        ):
+            # print(
+            #     f"Check types didn't match: '{rule_data['check_types']}' not in '{build_flags}'"
+            # )
+            continue  # check_types didn't match → skip rule
+
+        is_regex = rule_data.get("regex", False)
+        not_message = rule_data.get("not_message")
+        if not_message and matches_substring(not_message, test_logs, is_regex):
+            # print(f"Skip rule: Not message matched: '{rule_data['not_message']}'")
+            continue  # not_message matched → skip rule
+        message = rule_data.get("message")
+        if message and not matches_substring(message, test_logs, is_regex):
+            # print(f"Skip rule: Message didn't match: '{rule_data['message']}'")
+            continue
+
+        # print(f"Test {test_name} matched rule: {rule_data}")
+        return rule_data["reason"]
+
+    return False
 
 
 class SharedEngineReplacer:
@@ -918,6 +1016,7 @@ class TestStatus(enum.Enum):
     OK = "OK"
     SKIPPED = "SKIPPED"
     NOT_FAILED = "NOT_FAILED"
+    BROKEN = "BROKEN"
 
 
 class FailureReason(enum.Enum):
@@ -2222,6 +2321,14 @@ class TestCase:
             if result.status == TestStatus.FAIL:
                 result.description = self.add_info_about_settings(result.description)
 
+                # Check if the test is known to fail
+                known_fail_reason = test_is_known_fail(
+                    self.name, result.description, args.build_flags
+                )
+                if known_fail_reason:
+                    result.status = TestStatus.BROKEN
+                    result.description += f"Marked as broken: {known_fail_reason}"
+
             if self.name in suite.blacklist_check:
                 if result.status == TestStatus.OK:
                     result.status = TestStatus.NOT_FAILED
@@ -2726,6 +2833,11 @@ def run_tests_array(
         + colored(" NOT_FAILED ", args, "red", attrs=["bold"])
         + CL_SQUARE_BRACKET
     )
+    MSG_BROKEN = (
+        OP_SQUARE_BRACKET
+        + colored(" BROKEN ", args, "cyan", attrs=["bold"])
+        + CL_SQUARE_BRACKET
+    )
 
     MESSAGES = {
         TestStatus.FAIL: MSG_FAIL,
@@ -2733,12 +2845,14 @@ def run_tests_array(
         TestStatus.OK: MSG_OK,
         TestStatus.SKIPPED: MSG_SKIPPED,
         TestStatus.NOT_FAILED: MSG_NOT_FAILED,
+        TestStatus.BROKEN: MSG_BROKEN,
     }
 
     passed_total = 0
     skipped_total = 0
     failures_total = 0
     failures_chain = 0
+    broken_total = 0
     start_time = datetime.now()
 
     client_options = get_additional_client_options(args)
@@ -2833,6 +2947,8 @@ def run_tests_array(
                     raise ServerDied("Server died")
             elif test_result.status == TestStatus.SKIPPED:
                 skipped_total += 1
+            elif test_result.status == TestStatus.BROKEN:
+                broken_total += 1
 
         except KeyboardInterrupt as e:
             print(colored("Break tests execution", args, "red"))
@@ -2848,6 +2964,7 @@ def run_tests_array(
             colored(
                 f"\nHaving {failures_total} errors! {passed_total} tests passed."
                 f" {skipped_total} tests skipped."
+                f" {broken_total} broken tests."
                 f" {(datetime.now() - start_time).total_seconds():.2f} s elapsed"
                 f" ({multiprocessing.current_process().name}).",
                 args,

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -167,7 +167,7 @@ def test_is_known_fail(test_name, test_logs, build_flags, broken_tests_file_path
                 ct in build_flags for ct in rule_data["check_types"]
             ):
                 log_file.write(
-                    f"Check types didn't match: '{rule_data['check_types']}' not in '{build_flags}'\n"
+                    f"Skip rule: Check types didn't match: '{rule_data['check_types']}' not in '{build_flags}'\n"
                 )
                 continue  # check_types didn't match → skip rule
 
@@ -185,7 +185,7 @@ def test_is_known_fail(test_name, test_logs, build_flags, broken_tests_file_path
                 )
                 continue
 
-            log_file.write(f"Test {test_name} matched rule: {rule_data}\n")
+            log_file.write(f"Matched rule: {rule_data}\n")
             return rule_data["reason"]
 
         return False


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Moving the crossout logic into clickhouse-test allows for the broken tests list to function locally and show BROKEN status in actions logs.

Added a new `clickhouse-test` argument `--known-fails-file-path`

This PR is required for #1185 

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)