### PR TITLE
25.8.12 Stable: fix version tag

### DIFF
--- a/cmake/autogenerated_versions.txt
+++ b/cmake/autogenerated_versions.txt
@@ -7,11 +7,11 @@ SET(VERSION_MAJOR 25)
 SET(VERSION_MINOR 8)
 SET(VERSION_PATCH 12)
 SET(VERSION_GITHASH fa393206741c830da77b8f1bcf18c753161932c8)
-SET(VERSION_DESCRIBE v25.8.12.20000.altinitytest)
-SET(VERSION_STRING 25.8.12.20000.altinitytest)
+SET(VERSION_DESCRIBE v25.8.12.10000.altinitytest)
+SET(VERSION_STRING 25.8.12.10000.altinitytest)
 # end of autochange
 
 # This is the 'base' tweak of the version, build scripts will
 # increment this by number of commits since previous tag.
-SET(VERSION_TWEAK 20000)
-SET(VERSION_FLAVOUR altinityantalya)
+SET(VERSION_TWEAK 10000)
+SET(VERSION_FLAVOUR altinitytest)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)