### PR TITLE
Fix confusing cluster name and named collection name in cluster functions

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -396,7 +396,15 @@ void StorageObjectStorageCluster::updateQueryToSendIfNeeded(
     }
 
     ASTPtr object_storage_type_arg;
-    configuration->extractDynamicStorageType(args, context, &object_storage_type_arg);
+    if (cluster_name_in_settings)
+        configuration->extractDynamicStorageType(args, context, &object_storage_type_arg);
+    else
+    {
+        auto args_copy = args;
+        // Remove cluster name from args to avoid confusing cluster name and named collection name
+        args_copy.erase(args_copy.begin());
+        configuration->extractDynamicStorageType(args_copy, context, &object_storage_type_arg);
+    }
     ASTPtr settings_temporary_storage = nullptr;
     for (auto * it = args.begin(); it != args.end(); ++it)
     {

--- a/tests/integration/helpers/iceberg_utils.py
+++ b/tests/integration/helpers/iceberg_utils.py
@@ -196,6 +196,7 @@ def get_creation_expression(
     explicit_metadata_path="",
     storage_type_as_arg=False,
     storage_type_in_named_collection=False,
+    cluster_name_as_literal=True,
     additional_settings = [],
     **kwargs,
 ):
@@ -223,6 +224,8 @@ def get_creation_expression(
         settings_expression = " SETTINGS " + ",".join(settings_array)
     else:
         settings_expression = ""
+
+    cluster_name = "'cluster_simple'" if cluster_name_as_literal else "cluster_simple"
 
     storage_arg = storage_type
     engine_part = ""
@@ -252,7 +255,7 @@ def get_creation_expression(
 
         if run_on_cluster:
             assert table_function
-            return f"iceberg{engine_part}Cluster('cluster_simple', {storage_arg}, filename = 'iceberg_data/default/{table_name}/', format={format}, url = 'http://minio1:9001/{bucket}/')"
+            return f"iceberg{engine_part}Cluster({cluster_name}, {storage_arg}, filename = 'iceberg_data/default/{table_name}/', format={format}, url = 'http://minio1:9001/{bucket}/')"
         else:
             if table_function:
                 return f"iceberg{engine_part}({storage_arg}, filename = 'iceberg_data/default/{table_name}/', format={format}, url = 'http://minio1:9001/{bucket}/')"
@@ -271,7 +274,7 @@ def get_creation_expression(
         if run_on_cluster:
             assert table_function
             return f"""
-                iceberg{engine_part}Cluster('cluster_simple', {storage_arg}, container = '{cluster.azure_container_name}', storage_account_url = '{cluster.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]}', blob_path = '/iceberg_data/default/{table_name}/', format={format})
+                iceberg{engine_part}Cluster({cluster_name}, {storage_arg}, container = '{cluster.azure_container_name}', storage_account_url = '{cluster.env_variables["AZURITE_STORAGE_ACCOUNT_URL"]}', blob_path = '/iceberg_data/default/{table_name}/', format={format})
             """
         else:
             if table_function:
@@ -293,7 +296,7 @@ def get_creation_expression(
         if run_on_cluster:
             assert table_function
             return f"""
-                iceberg{engine_part}Cluster('cluster_simple', {storage_arg}, path = '/iceberg_data/default/{table_name}/', format={format})
+                iceberg{engine_part}Cluster({cluster_name}, {storage_arg}, path = '/iceberg_data/default/{table_name}/', format={format})
             """
         else:
             if table_function:

--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -412,7 +412,8 @@ def count_secondary_subqueries(started_cluster, query_id, expected, comment):
 
 @pytest.mark.parametrize("format_version", ["1", "2"])
 @pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
-def test_cluster_table_function(started_cluster, format_version, storage_type):
+@pytest.mark.parametrize("cluster_name_as_literal", [True, False])
+def test_cluster_table_function(started_cluster, format_version, storage_type, cluster_name_as_literal):
 
     instance = started_cluster.instances["node1"]
     spark = started_cluster.spark_session
@@ -471,7 +472,7 @@ def test_cluster_table_function(started_cluster, format_version, storage_type):
 
     # Regular Query only node1
     table_function_expr = get_creation_expression(
-        storage_type, TABLE_NAME, started_cluster, table_function=True
+        storage_type, TABLE_NAME, started_cluster, table_function=True, cluster_name_as_literal=cluster_name_as_literal
     )
     select_regular = (
         instance.query(f"SELECT * FROM {table_function_expr}").strip().split()
@@ -492,6 +493,7 @@ def test_cluster_table_function(started_cluster, format_version, storage_type):
             run_on_cluster=run_on_cluster,
             storage_type_as_arg=storage_type_as_arg,
             storage_type_in_named_collection=storage_type_in_named_collection,
+            cluster_name_as_literal=cluster_name_as_literal,
         )
         query_id = str(uuid.uuid4())
         settings = f"SETTINGS object_storage_cluster='cluster_simple'" if (alt_syntax and not run_on_cluster) else ""


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Solved #1228 
Fix confusing cluster name and named collection name in cluster functions

### Documentation entry for user-facing changes
This query failed with error `There is no named collection 'cluster'`
```
SELECT * FROM icebergCluster(cluster, connection)
```
but next queries works:
```
SELECT * FROM icebergS3Cluster(cluster, connection)
SELECT * FROM icebergCluster(cluster, connection, storage_type='s3')
SELECT * FROM icebergCluster('cluster', connection)
```


In query 
```
SELECT * FROM icebergCluster(cluster, connection)
```
first argument is a cluster name, second is a named collection name with storage parameters.
`icebergCluster` table function also can have named argument `storage_type` with type of storage - `s3`/`azure`/`hdfs`/`local`.
By default `storage_type` is `s3` to backward compatibility, `icebergCluster` was an alias for `icebergS3Cluster`.

If `storage_type` is not found in arguments, clickhouse tries to find it in named collection. This must be on early stage to select proper realization - `icebergS3Cluster`, `icebergAzureCluster`, etc.

So code tries to find named collection name in argument list, and interpret first identifier argument as name: https://github.com/Altinity/ClickHouse/blob/antalya-25.8/src/Storages/NamedCollectionsHelpers.cpp#L30

But in list `cluster, connection` cluster name is also identifier, and code chooses it as name of collection.

In this fix known cluster name is removed from arguments before named collection  finding.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)