### PR TITLE
Antalya 25.8: Fix build after oauth

### DIFF
--- a/src/Access/TokenProcessors.h
+++ b/src/Access/TokenProcessors.h
@@ -213,9 +213,6 @@ public:
 
     bool resolveAndValidate(TokenCredentials & credentials) const override;
 private:
-    const String expected_issuer;
-    const String expected_audience;
-    const bool allow_no_expiration;
     Poco::URI userinfo_endpoint;
     Poco::URI token_introspection_endpoint;
 

--- a/src/Access/TokenProcessorsOpaque.cpp
+++ b/src/Access/TokenProcessorsOpaque.cpp
@@ -265,8 +265,6 @@ OpenIdTokenProcessor::OpenIdTokenProcessor(const String & processor_name_,
                                            const String & jwks_uri_,
                                            UInt64 jwks_cache_lifetime_)
         : ITokenProcessor(processor_name_, token_cache_lifetime_, username_claim_, groups_claim_),
-          expected_issuer(expected_issuer_), expected_audience(expected_audience_),
-          allow_no_expiration(allow_no_expiration_),
           userinfo_endpoint(userinfo_endpoint_), token_introspection_endpoint(token_introspection_endpoint_)
 {
     if (!jwks_uri_.empty())
@@ -296,9 +294,7 @@ OpenIdTokenProcessor::OpenIdTokenProcessor(const String & processor_name_,
                                            const String & openid_config_endpoint_,
                                            UInt64 verifier_leeway_,
                                            UInt64 jwks_cache_lifetime_)
-    : ITokenProcessor(processor_name_, token_cache_lifetime_, username_claim_, groups_claim_),
-      expected_issuer(expected_issuer_), expected_audience(expected_audience_),
-      allow_no_expiration(allow_no_expiration_)
+    : ITokenProcessor(processor_name_, token_cache_lifetime_, username_claim_, groups_claim_)
 {
     const picojson::object openid_config = getObjectFromURI(Poco::URI(openid_config_endpoint_));
 


### PR DESCRIPTION
Follow-up for https://github.com/Altinity/ClickHouse/pull/1078. Fix build by removing unused vars.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)