### PR TITLE
 25.8.13 Stable - Update Regression Hash

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4178,7 +4178,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester
-      commit: 4832cdbd813680ad663898586129ba7667e17f49
+      commit: 63e25a63dbe6e279590a018ee76e62d0725d3199
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -4190,7 +4190,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester-aarch64
-      commit: 4832cdbd813680ad663898586129ba7667e17f49
+      commit: 63e25a63dbe6e279590a018ee76e62d0725d3199
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4178,7 +4178,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester
-      commit: c07440a1ad14ffc5fc49ce90dff2f40c2e5f364d
+      commit: 4832cdbd813680ad663898586129ba7667e17f49
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -4190,7 +4190,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester-aarch64
-      commit: c07440a1ad14ffc5fc49ce90dff2f40c2e5f364d
+      commit: 4832cdbd813680ad663898586129ba7667e17f49
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4134,7 +4134,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester
-      commit: c07440a1ad14ffc5fc49ce90dff2f40c2e5f364d
+      commit: 4832cdbd813680ad663898586129ba7667e17f49
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -4146,7 +4146,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester-aarch64
-      commit: c07440a1ad14ffc5fc49ce90dff2f40c2e5f364d
+      commit: 4832cdbd813680ad663898586129ba7667e17f49
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4134,7 +4134,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester
-      commit: 4832cdbd813680ad663898586129ba7667e17f49
+      commit: 63e25a63dbe6e279590a018ee76e62d0725d3199
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -4146,7 +4146,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-on-demand, altinity-regression-tester-aarch64
-      commit: 4832cdbd813680ad663898586129ba7667e17f49
+      commit: 63e25a63dbe6e279590a018ee76e62d0725d3199
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1005,6 +1005,76 @@ jobs:
           name: ${{ env.SUITE }}-${{ matrix.STORAGE }}-${{ matrix.PART }}-${{ inputs.arch }}-artifacts
           path: ${{ env.artifact_paths}}
 
+  S3Export:
+    if: |
+      fromJson(inputs.workflow_config).custom_data.ci_regression_jobs[0] == null ||
+      contains(fromJson(inputs.workflow_config).custom_data.ci_regression_jobs, 's3')
+    strategy:
+      fail-fast: false
+      matrix:
+        PART: [part, partition]
+    needs: [runner_labels_setup]
+    runs-on: ${{ fromJson(needs.runner_labels_setup.outputs.runner_labels) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    steps:
+      - name: Checkout regression repo
+        uses: actions/checkout@v4
+        with:
+          repository: Altinity/clickhouse-regression
+          ref: ${{ inputs.commit }}
+      - name: Set envs
+        run: |
+          cat >> "$GITHUB_ENV" << 'EOF'
+          REPORTS_PATH=${{ runner.temp }}/reports_dir
+          SUITE=s3
+          PART=${{ matrix.PART }}
+          EOF
+      - name: Setup
+        run: .github/setup.sh
+      - name: Get deb url
+        env:
+          S3_BASE_URL: https://altinity-build-artifacts.s3.amazonaws.com/
+          PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+        run: |
+          mkdir -p $REPORTS_PATH
+          cat > $REPORTS_PATH/workflow_config.json << 'EOF'
+          ${{ inputs.workflow_config }}
+          EOF
+          
+          python3 .github/get-deb-url.py --github-env $GITHUB_ENV --workflow-config $REPORTS_PATH/workflow_config.json --s3-base-url $S3_BASE_URL --pr-number $PR_NUMBER --branch-name ${{ github.ref_name }} --commit-hash ${{ inputs.build_sha }} --binary
+
+      - name: Run ${{ env.SUITE }} suite
+        id: run_suite
+        run:  EXITCODE=0;
+              python3
+              -u ${{ env.SUITE }}/regression.py
+              --clickhouse-binary-path ${{ env.clickhouse_path }}
+              --storage minio
+              --attr project="$GITHUB_REPOSITORY" project.id="$GITHUB_REPOSITORY_ID" package="${{ env.clickhouse_path }}" version="${{ env.version }}" user.name="$GITHUB_ACTOR" repository="https://github.com/Altinity/clickhouse-regression" commit.hash="$(git rev-parse HEAD)" job.name="$GITHUB_JOB (${{ matrix.PART }})" job.retry=$GITHUB_RUN_ATTEMPT job.url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" arch="$(uname -i)"
+              --only ":/try*" "minio/export tests/export ${{ matrix.PART }}/*"
+              ${{ env.args }} || EXITCODE=$?;
+              .github/add_link_to_logs.sh;
+              exit $EXITCODE
+      - name: Set Commit Status
+        if: always()
+        run: python3 .github/set_builds_status.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_OUTCOME: ${{ steps.run_suite.outcome }}
+          SUITE_NAME: "Regression ${{ inputs.arch }} S3 Export ${{ matrix.PART }}"
+      - name: Create and upload logs
+        if: always()
+        run: .github/create_and_upload_logs.sh 1
+      - name: Upload logs to regression results database
+        if: always()
+        timeout-minutes: 20
+        run: .github/upload_results_to_database.sh 1
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ${{ env.SUITE }}-export-${{ matrix.PART }}-${{ inputs.arch }}-artifacts
+          path: ${{ env.artifact_paths}}
+
   TieredStorage:
     if: |
       fromJson(inputs.workflow_config).custom_data.ci_regression_jobs[0] == null ||

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -35,7 +35,7 @@ class AltinityWorkflowTemplates:
           echo "Workflow Run Report: [View Report]($REPORT_LINK)" >> $GITHUB_STEP_SUMMARY
 """
     # Additional jobs
-    REGRESSION_HASH = "c07440a1ad14ffc5fc49ce90dff2f40c2e5f364d"
+    REGRESSION_HASH = "4832cdbd813680ad663898586129ba7667e17f49"
     ALTINITY_JOBS = {
         "GrypeScan": r"""
   GrypeScanServer:

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -35,7 +35,7 @@ class AltinityWorkflowTemplates:
           echo "Workflow Run Report: [View Report]($REPORT_LINK)" >> $GITHUB_STEP_SUMMARY
 """
     # Additional jobs
-    REGRESSION_HASH = "4832cdbd813680ad663898586129ba7667e17f49"
+    REGRESSION_HASH = "63e25a63dbe6e279590a018ee76e62d0725d3199"
     ALTINITY_JOBS = {
         "GrypeScan": r"""
   GrypeScanServer:

--- a/cmake/autogenerated_versions.txt
+++ b/cmake/autogenerated_versions.txt
@@ -7,11 +7,11 @@ SET(VERSION_MAJOR 25)
 SET(VERSION_MINOR 8)
 SET(VERSION_PATCH 13)
 SET(VERSION_GITHASH 25db09bd0a09eb1576ae0ba56f6e52d9f2c4651e)
-SET(VERSION_DESCRIBE v25.8.13.10000.altinitytest)
-SET(VERSION_STRING 25.8.13.10000.altinitytest)
+SET(VERSION_DESCRIBE v25.8.13.20000.altinitytest)
+SET(VERSION_STRING 25.8.13.20000.altinitytest)
 # end of autochange
 
 # This is the 'base' tweak of the version, build scripts will
 # increment this by number of commits since previous tag.
-SET(VERSION_TWEAK 10000)
-SET(VERSION_FLAVOUR altinitytest)
+SET(VERSION_TWEAK 20000)
+SET(VERSION_FLAVOUR altinityantalya)

--- a/cmake/autogenerated_versions.txt
+++ b/cmake/autogenerated_versions.txt
@@ -7,11 +7,11 @@ SET(VERSION_MAJOR 25)
 SET(VERSION_MINOR 8)
 SET(VERSION_PATCH 13)
 SET(VERSION_GITHASH 25db09bd0a09eb1576ae0ba56f6e52d9f2c4651e)
-SET(VERSION_DESCRIBE v25.8.13.20000.altinitytest)
-SET(VERSION_STRING 25.8.13.20000.altinitytest)
+SET(VERSION_DESCRIBE v25.8.13.10000.altinitytest)
+SET(VERSION_STRING 25.8.13.10000.altinitytest)
 # end of autochange
 
 # This is the 'base' tweak of the version, build scripts will
 # increment this by number of commits since previous tag.
-SET(VERSION_TWEAK 20000)
-SET(VERSION_FLAVOUR altinityantalya)
+SET(VERSION_TWEAK 10000)
+SET(VERSION_FLAVOUR altinitytest)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)