### PR TITLE
25.8 Remove version auto-updating

### DIFF
--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -38,7 +38,6 @@ SET(VERSION_STRING {string})
 
     @classmethod
     def get_current_version_as_dict(cls):
-        # Return version as-is from the cmake file, without any git-based modifications
         version = get_version_from_repo()
         version = version.with_description(version.flavour)
         return version.as_dict()

--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -38,29 +38,10 @@ SET(VERSION_STRING {string})
 
     @classmethod
     def get_current_version_as_dict(cls):
-        version_from_file = read_versions()
-        try:
-            version = version_from_file
-            tweak = int(
-                Shell.get_output(
-                    f"git rev-list --count {version['githash']}..HEAD", verbose=True
-                )
-            )
-        except ValueError:
-            # Shallow checkout
-            tweak = 0
-
+        # Return version as-is from the cmake file, without any git-based modifications
         version = get_version_from_repo()
-        version.tweak += tweak
-
-        # relying on ClickHouseVersion to generate proper `description` and `string` with updated `tweak`` value.
         version = version.with_description(version.flavour)
-        version_dict = version.as_dict()
-
-        # preserve githash, not sure if that is goign to be usefull, but mimics original implementation
-        version_dict['githash'] = version_from_file['githash']
-
-        return version_dict
+        return version.as_dict()
 
     @classmethod
     def get_version(cls):

--- a/cmake/autogenerated_versions.txt
+++ b/cmake/autogenerated_versions.txt
@@ -11,7 +11,5 @@ SET(VERSION_DESCRIBE v25.8.12.20001.altinityantalya)
 SET(VERSION_STRING 25.8.12.20001.altinityantalya)
 # end of autochange
 
-# This is the 'base' tweak of the version, build scripts will
-# increment this by number of commits since previous tag.
 SET(VERSION_TWEAK 20001)
 SET(VERSION_FLAVOUR altinityantalya)

--- a/cmake/autogenerated_versions.txt
+++ b/cmake/autogenerated_versions.txt
@@ -7,11 +7,11 @@ SET(VERSION_MAJOR 25)
 SET(VERSION_MINOR 8)
 SET(VERSION_PATCH 12)
 SET(VERSION_GITHASH fa393206741c830da77b8f1bcf18c753161932c8)
-SET(VERSION_DESCRIBE v25.8.12.20000.altinityantalya)
-SET(VERSION_STRING 25.8.12.20000.altinityantalya)
+SET(VERSION_DESCRIBE v25.8.12.20001.altinityantalya)
+SET(VERSION_STRING 25.8.12.20001.altinityantalya)
 # end of autochange
 
 # This is the 'base' tweak of the version, build scripts will
 # increment this by number of commits since previous tag.
-SET(VERSION_TWEAK 20000)
+SET(VERSION_TWEAK 20001)
 SET(VERSION_FLAVOUR altinityantalya)

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -316,31 +316,6 @@ def get_version_from_repo(
         flavour=versions.get("flavour", None)
     )
 
-    # if this commit is tagged, use tag's version instead of something stored in cmake
-    if git is not None and git.latest_tag:
-        version_from_tag = get_version_from_tag(git.latest_tag)
-        logging.debug(f'Git latest tag: {git.latest_tag} ({git.commits_since_latest} commits ago)\n'
-            f'"new" tag: {git.new_tag} ({git.commits_since_new})\n'
-            f'current commit: {git.sha}\n'
-            f'current brach: {git.branch}'
-        )
-        if git.latest_tag and git.commits_since_latest == 0:
-            # Tag has a priority over the version written in CMake.
-            # Version must match (except tweak, flavour, description, etc.) to avoid accidental mess.
-            if not (version_from_tag.major == cmake_version.major \
-                    and version_from_tag.minor == cmake_version.minor \
-                    and version_from_tag.patch == cmake_version.patch):
-                raise RuntimeError(f"Version generated from tag ({version_from_tag}) should have same major, minor, and patch values as version generated from cmake ({cmake_version})")
-
-            # Don't need to reset version completely, mostly because revision part is not set in tag, but must be preserved
-            logging.debug(f"Resetting TWEAK and FLAVOUR of version from cmake {cmake_version} to values from tag: {version_from_tag.tweak}.{version_from_tag._flavour}")
-            cmake_version._flavour = version_from_tag._flavour
-            cmake_version.tweak = version_from_tag.tweak
-        else:
-            # We've had some number of commits since the latest (upstream) tag.
-            logging.debug(f"Bumping the TWEAK of version from cmake {cmake_version} by {git.commits_since_upstream}")
-            cmake_version.tweak = cmake_version.tweak + git.commits_since_upstream
-
     return cmake_version
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Remove functionality to automatically update version based on number of commits

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)