### PR TITLE
25.8.13 Stable - Remove version auto-updating

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,6 +12,7 @@ on:
         default: false
   push:
     branches: ['antalya', 'releases/*', 'antalya-*']
+    tags: ['*']
 
 env:
   # Force the stdout and stderr streams to be unbuffered

--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -13,7 +13,8 @@ import tests.ci
 sys.path.append(os.path.abspath(tests.ci.__path__._path[0]))
 from tests.ci.version_helper import (
     read_versions,
-    get_version_from_repo
+    get_version_from_repo,
+    get_version_from_tag
 )
 
 class CHVersion:
@@ -38,7 +39,19 @@ SET(VERSION_STRING {string})
 
     @classmethod
     def get_current_version_as_dict(cls):
-        version = get_version_from_repo()
+        # Check if this is a tag push - if so, use the version from the tag
+        ref_type = os.getenv("GITHUB_REF_TYPE", "")
+        ref_name = os.getenv("GITHUB_REF_NAME", "")
+
+        if ref_type == "tag" and ref_name.startswith("v"):
+            print(f"Tag push detected: {ref_name}, extracting version from tag")
+            version = get_version_from_tag(ref_name)
+            # Get revision from cmake file since it's not in the tag
+            cmake_versions = read_versions()
+            version._revision = cmake_versions.get("revision", version._revision)
+        else:
+            version = get_version_from_repo()
+
         # relying on ClickHouseVersion to generate proper `description` and `string` with updated `tweak`` value.
         version = version.with_description(version.flavour)
         return version.as_dict()

--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -39,6 +39,7 @@ SET(VERSION_STRING {string})
 
     @classmethod
     def get_current_version_as_dict(cls):
+        version_from_file = read_versions()
         # Check if this is a tag push - if so, use the version from the tag
         ref_type = os.getenv("GITHUB_REF_TYPE", "")
         ref_name = os.getenv("GITHUB_REF_NAME", "")
@@ -47,15 +48,18 @@ SET(VERSION_STRING {string})
             print(f"Tag push detected: {ref_name}, extracting version from tag")
             version = get_version_from_tag(ref_name)
             # Get revision from cmake file since it's not in the tag
-            cmake_versions = read_versions()
-            version._revision = cmake_versions.get("revision", version._revision)
+            version._revision = version_from_file.get("revision", version._revision)
         else:
             version = get_version_from_repo()
 
         # relying on ClickHouseVersion to generate proper `description` and `string` with updated `tweak`` value.
         version = version.with_description(version.flavour)
-        return version.as_dict()
+        version_dict = version.as_dict()
 
+        # preserve githash, not sure if that is goign to be usefull, but mimics original implementation
+        version_dict['githash'] = version_from_file['githash']
+
+        return version_dict
 
     @classmethod
     def get_version(cls):

--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -38,29 +38,11 @@ SET(VERSION_STRING {string})
 
     @classmethod
     def get_current_version_as_dict(cls):
-        version_from_file = read_versions()
-        try:
-            version = version_from_file
-            tweak = int(
-                Shell.get_output(
-                    f"git rev-list --count {version['githash']}..HEAD", verbose=True
-                )
-            )
-        except ValueError:
-            # Shallow checkout
-            tweak = 0
-
         version = get_version_from_repo()
-        version.tweak += tweak
-
         # relying on ClickHouseVersion to generate proper `description` and `string` with updated `tweak`` value.
         version = version.with_description(version.flavour)
-        version_dict = version.as_dict()
+        return version.as_dict()
 
-        # preserve githash, not sure if that is goign to be usefull, but mimics original implementation
-        version_dict['githash'] = version_from_file['githash']
-
-        return version_dict
 
     @classmethod
     def get_version(cls):

--- a/ci/praktika/parser.py
+++ b/ci/praktika/parser.py
@@ -45,6 +45,7 @@ class WorkflowYaml:
     name: str
     event: str
     branches: List[str]
+    tags: List[str]
     jobs: List[JobYaml]
     additional_jobs: List[str]
     job_to_config: Dict[str, JobYaml]
@@ -74,6 +75,7 @@ class WorkflowConfigParser:
             name=self.workflow_name,
             event=config.event,
             branches=[],
+            tags=config.tags,
             jobs=[],
             additional_jobs=[],
             secret_names_gh=[],

--- a/ci/praktika/workflow.py
+++ b/ci/praktika/workflow.py
@@ -28,6 +28,7 @@ class Workflow:
         additional_jobs: List[str] = field(default_factory=list)
         branches: List[str] = field(default_factory=list)
         base_branches: List[str] = field(default_factory=list)
+        tags: List[str] = field(default_factory=list)
         artifacts: List[Artifact.Config] = field(default_factory=list)
         dockers: List[Docker.Config] = field(default_factory=list)
         secrets: List[Secret.Config] = field(default_factory=list)

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -43,7 +43,7 @@ on:
         type: boolean
         default: false
   {EVENT}:
-    branches: [{BRANCHES}]
+    branches: [{BRANCHES}]{TAGS}
 
 env:
   # Force the stdout and stderr streams to be unbuffered
@@ -428,6 +428,9 @@ class PullRequestPushYamlGen:
             Workflow.Event.PUSH,
         ):
             base_template = YamlGenerator.Templates.TEMPLATE_PULL_REQUEST_0
+            tags_formatted = ", ".join(
+                [f"'{tag}'" for tag in self.workflow_config.tags]
+            ) if self.workflow_config.tags else ""
             format_kwargs = {
                 "BRANCHES": ", ".join(
                     [f"'{branch}'" for branch in self.workflow_config.branches]
@@ -438,6 +441,7 @@ class PullRequestPushYamlGen:
                     # if not Settings.USE_CUSTOM_GH_AUTH
                     # else ""
                 ),
+                "TAGS": f"\n    tags: [{tags_formatted}]" if tags_formatted else "",
             }
             if self.workflow_config.event in (Workflow.Event.PULL_REQUEST,):
                 ENV_CHECKOUT_REFERENCE = (

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -9,6 +9,7 @@ workflow = Workflow.Config(
     name="MasterCI",
     event=Workflow.Event.PUSH,
     branches=[BASE_BRANCH, "releases/*", "antalya-*"],
+    tags=["*"],
     jobs=[
         # *JobConfigs.tidy_build_arm_jobs,
         *JobConfigs.build_jobs,

--- a/cmake/autogenerated_versions.txt
+++ b/cmake/autogenerated_versions.txt
@@ -7,11 +7,9 @@ SET(VERSION_MAJOR 25)
 SET(VERSION_MINOR 8)
 SET(VERSION_PATCH 13)
 SET(VERSION_GITHASH 25db09bd0a09eb1576ae0ba56f6e52d9f2c4651e)
-SET(VERSION_DESCRIBE v25.8.13.20000.altinitytest)
-SET(VERSION_STRING 25.8.13.20000.altinitytest)
+SET(VERSION_DESCRIBE v25.8.13.10001.altinitytest)
+SET(VERSION_STRING 25.8.13.10001.altinitytest)
 # end of autochange
 
-# This is the 'base' tweak of the version, build scripts will
-# increment this by number of commits since previous tag.
-SET(VERSION_TWEAK 20000)
-SET(VERSION_FLAVOUR altinityantalya)
+SET(VERSION_TWEAK 10001)
+SET(VERSION_FLAVOUR altinitytest)

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -316,31 +316,6 @@ def get_version_from_repo(
         flavour=versions.get("flavour", None)
     )
 
-    # if this commit is tagged, use tag's version instead of something stored in cmake
-    if git is not None and git.latest_tag:
-        version_from_tag = get_version_from_tag(git.latest_tag)
-        logging.debug(f'Git latest tag: {git.latest_tag} ({git.commits_since_latest} commits ago)\n'
-            f'"new" tag: {git.new_tag} ({git.commits_since_new})\n'
-            f'current commit: {git.sha}\n'
-            f'current brach: {git.branch}'
-        )
-        if git.latest_tag and git.commits_since_latest == 0:
-            # Tag has a priority over the version written in CMake.
-            # Version must match (except tweak, flavour, description, etc.) to avoid accidental mess.
-            if not (version_from_tag.major == cmake_version.major \
-                    and version_from_tag.minor == cmake_version.minor \
-                    and version_from_tag.patch == cmake_version.patch):
-                raise RuntimeError(f"Version generated from tag ({version_from_tag}) should have same major, minor, and patch values as version generated from cmake ({cmake_version})")
-
-            # Don't need to reset version completely, mostly because revision part is not set in tag, but must be preserved
-            logging.debug(f"Resetting TWEAK and FLAVOUR of version from cmake {cmake_version} to values from tag: {version_from_tag.tweak}.{version_from_tag._flavour}")
-            cmake_version._flavour = version_from_tag._flavour
-            cmake_version.tweak = version_from_tag.tweak
-        else:
-            # We've had some number of commits since the latest (upstream) tag.
-            logging.debug(f"Bumping the TWEAK of version from cmake {cmake_version} by {git.commits_since_upstream}")
-            cmake_version.tweak = cmake_version.tweak + git.commits_since_upstream
-
     return cmake_version
 
 

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -316,6 +316,27 @@ def get_version_from_repo(
         flavour=versions.get("flavour", None)
     )
 
+    # If this commit is tagged, use tag's version instead of something stored in cmake
+    if git is not None and git.latest_tag:
+        version_from_tag = get_version_from_tag(git.latest_tag)
+        logging.debug(f'Git latest tag: {git.latest_tag} ({git.commits_since_latest} commits ago)\n'
+            f'"new" tag: {git.new_tag} ({git.commits_since_new})\n'
+            f'current commit: {git.sha}\n'
+            f'current brach: {git.branch}'
+        )
+        if git.latest_tag and git.commits_since_latest == 0:
+            # Tag has a priority over the version written in CMake.
+            # Version must match (except tweak, flavour, description, etc.) to avoid accidental mess.
+            if not (version_from_tag.major == cmake_version.major \
+                    and version_from_tag.minor == cmake_version.minor \
+                    and version_from_tag.patch == cmake_version.patch \
+                    and version_from_tag.tweak == cmake_version.tweak):
+                raise RuntimeError(f"Version generated from tag ({version_from_tag}) should have same major, minor, patch, and tweak values as version generated from cmake ({cmake_version})")
+
+            # Don't need to reset version completely, mostly because revision part is not set in tag, but must be preserved
+            logging.debug(f"Resetting FLAVOUR of version from cmake {cmake_version} to values from tag: {version_from_tag._flavour}")
+            cmake_version._flavour = version_from_tag._flavour
+
     return cmake_version
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Remove version updating with amount of commits made.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)