### PR TITLE
Fix nested namespace encoding in REST catalog for Iceberg

### DIFF
--- a/src/Databases/Iceberg/RestCatalog.cpp
+++ b/src/Databases/Iceberg/RestCatalog.cpp
@@ -84,6 +84,24 @@ std::string correctAPIURI(const std::string & uri)
     return std::filesystem::path(uri) / "v1";
 }
 
+/// Encode namespace for use in URL path.
+/// According to the Iceberg REST Catalog spec, multi-level namespaces
+/// should be joined with the unit separator character (0x1F) which is
+/// URL-encoded as %1F.
+/// https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
+String encodeNamespaceForURI(const String & namespace_name)
+{
+    String encoded;
+    for (const auto & ch : namespace_name)
+    {
+        if (ch == '.')
+            encoded += "%1F";
+        else
+            encoded.push_back(ch);
+    }
+    return encoded;
+}
+
 }
 
 std::string RestCatalog::Config::toString() const
@@ -468,7 +486,8 @@ RestCatalog::Namespaces RestCatalog::parseNamespaces(DB::ReadBuffer & buf, const
 
 DB::Names RestCatalog::getTables(const std::string & base_namespace, size_t limit) const
 {
-    const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / base_namespace / "tables";
+    auto encoded_namespace = encodeNamespaceForURI(base_namespace);
+    const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / encoded_namespace / "tables";
 
     auto buf = createReadBuffer(config.prefix / endpoint);
     return parseTables(*buf, base_namespace, limit);
@@ -562,7 +581,8 @@ bool RestCatalog::getTableMetadataImpl(
         headers.emplace_back("X-Iceberg-Access-Delegation", "vended-credentials");
     }
 
-    const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / namespace_name / "tables" / table_name;
+    auto encoded_namespace = encodeNamespaceForURI(namespace_name);
+    const std::string endpoint = std::filesystem::path(NAMESPACES_ENDPOINT) / encoded_namespace / "tables" / table_name;
     auto buf = createReadBuffer(config.prefix / endpoint, /* params */{}, headers);
 
     if (buf->eof())


### PR DESCRIPTION
## Summary

This PR fixes an issue where tables in hierarchical/nested Iceberg namespaces are not discoverable when using the REST catalog (e.g., Snowflake Polaris).

## Problem

When querying tables in nested namespaces like `teslasource.kafkav6.source-data`, ClickHouse constructs the URL path incorrectly:

```
❌ Current:  /namespaces/teslasource.kafkav6/tables
✅ Expected: /namespaces/teslasource%1Fkafkav6/tables
```

According to the [Iceberg REST Catalog OpenAPI spec](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml), multi-level namespaces should be joined with the unit separator character (`0x1F`) which is URL-encoded as `%1F`.

The current implementation uses a dot (`.`) separator, causing the Polaris API to return:
```json
{"error":{"message":"Namespace does not exist: teslasource.kafkav6","type":"NoSuchNamespaceException","code":404}}
```

## Changes

1. Added `encodeNamespaceForURI()` function that replaces `.` with `%1F` in namespace paths
2. Applied encoding in `getTables()` when constructing the tables endpoint
3. Applied encoding in `getTableMetadataImpl()` when constructing the table metadata endpoint

## Testing

Tested with Snowflake Polaris catalog containing 117 tables across 15 namespaces with nested sub-namespaces (e.g., `azugasource.kafkav2`, `teslasource.kafkav6`).

Before fix: `SHOW TABLES` returns 0 tables (all 404 errors in logs)
After fix: Tables in nested namespaces are discoverable

## Related

- Upstream ClickHouse already has this fix in `src/Databases/DataLake/RestCatalog.cpp`
- Similar issue reported in StarRocks: https://github.com/StarRocks/starrocks/issues/52451