### PR TITLE
25.8 Backport of #91067: Safer hints for missing grants in exception messages

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -1972,6 +1972,7 @@ Settings for optional improvements in the access control system.
 | `settings_constraints_replace_previous`         | Sets whether a constraint in a settings profile for some setting will cancel actions of the previous constraint (defined in other profiles) for that setting, including fields which are not set by the new constraint. It also enables the `changeable_in_readonly` constraint type.                                                                                                                                                                                                                            | `true`  |
 | `table_engines_require_grant`                   | Sets whether creating a table with a specific table engine requires a grant.                                                                                                                                                                                                                                                                                                                                                                                                                                     | `false` |
 | `role_cache_expiration_time_seconds`            | Sets the number of seconds since last access, that a role is stored in the Role Cache.                                                                                                                                                                                                                                                                                                                                                                                                                           | `600`   |
+| `missing_grants_hints`                          | Controls whether `ACCESS_DENIED` errors include the missing-grant hint. Possible values: `always` — always show the required grant; `require_show` — show only if the user has the corresponding `SHOW` privilege for the object (default); `never` — never include detailed hints.                                                                                                                                            | `require_show` |
 
 Example:
 
@@ -1984,6 +1985,7 @@ Example:
     <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
     <table_engines_require_grant>false</table_engines_require_grant>
     <role_cache_expiration_time_seconds>600</role_cache_expiration_time_seconds>
+    <missing_grants_hints>require_show</missing_grants_hints>
 </access_control_improvements>
 ```
 

--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -834,6 +834,14 @@
              however you can change this behaviour by setting this to true -->
         <table_engines_require_grant>false</table_engines_require_grant>
 
+        <!-- Controls whether ACCESS_DENIED errors include missing-grant hints.
+             Possible values:
+               always       - always include required grant details (may leak schema to users without SHOW).
+               require_show - include details only if the user has the relevant SHOW privilege (default).
+               never        - never include required grant details, always return a generic denial.
+             -->
+        <missing_grants_hints>require_show</missing_grants_hints>
+
         <!-- Number of seconds since last access a role is stored in the Role Cache -->
         <role_cache_expiration_time_seconds>600</role_cache_expiration_time_seconds>
     </access_control_improvements>

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -27,6 +27,7 @@
 
 #include <Poco/AccessExpireCache.h>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string.hpp>
 #include <filesystem>
 #include <mutex>
 
@@ -306,6 +307,21 @@ void AccessControl::setupFromMainConfig(const Poco::Util::AbstractConfiguration 
     setSettingsConstraintsReplacePrevious(config_.getBool("access_control_improvements.settings_constraints_replace_previous", true));
     setTableEnginesRequireGrant(config_.getBool("access_control_improvements.table_engines_require_grant", false));
     setEnableReadWriteGrants(config_.getBool("access_control_improvements.enable_read_write_grants", false));
+    {
+        const auto mode = config_.getString("access_control_improvements.missing_grants_hints", "require_show");
+        auto normalized = boost::algorithm::to_lower_copy(mode);
+        if (normalized == "always")
+            setMissingGrantsHintsLevel(MissingGrantsHintsLevel::Always);
+        else if (normalized == "require_show")
+            setMissingGrantsHintsLevel(MissingGrantsHintsLevel::RequireShow);
+        else if (normalized == "never")
+            setMissingGrantsHintsLevel(MissingGrantsHintsLevel::Never);
+        else
+        {
+            LOG_WARNING(getLogger(), "Unknown value '{}' for access_control_improvements.missing_grants_hints, using 'require_show'", mode);
+            setMissingGrantsHintsLevel(MissingGrantsHintsLevel::RequireShow);
+        }
+    }
 
     /// Set `true` by default because the feature is backward incompatible only when older version replicas are in the same cluster.
     setEnableUserNameAccessType(config_.getBool("access_control_improvements.enable_user_name_access_type", true));

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -195,6 +195,16 @@ public:
     void setSelectFromInformationSchemaRequiresGrant(bool enable) { select_from_information_schema_requires_grant = enable; }
     bool doesSelectFromInformationSchemaRequireGrant() const { return select_from_information_schema_requires_grant; }
 
+    enum class MissingGrantsHintsLevel : uint8_t
+    {
+        Always,        /// Always show detailed missing-grant info.
+        RequireShow,   /// Show details only when SHOW grants are present.
+        Never          /// Never show details.
+    };
+
+    void setMissingGrantsHintsLevel(MissingGrantsHintsLevel level) { missing_grants_hints_level = level; }
+    MissingGrantsHintsLevel getMissingGrantsHintsLevel() const { return missing_grants_hints_level; }
+
     void setSettingsConstraintsReplacePrevious(bool enable) { settings_constraints_replace_previous = enable; }
     bool doesSettingsConstraintsReplacePrevious() const { return settings_constraints_replace_previous; }
 
@@ -284,6 +294,7 @@ private:
     std::atomic_bool on_cluster_queries_require_cluster_grant = false;
     std::atomic_bool select_from_system_db_requires_grant = false;
     std::atomic_bool select_from_information_schema_requires_grant = false;
+    std::atomic<MissingGrantsHintsLevel> missing_grants_hints_level = MissingGrantsHintsLevel::RequireShow;
     std::atomic_bool settings_constraints_replace_previous = false;
     std::atomic_bool table_engines_require_grant = false;
     std::atomic_int bcrypt_workfactor = 12;

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -75,6 +75,125 @@ namespace
         return ids;
     }
 
+    /// Determines whether it is safe to reveal a missing-grant hint to the user.
+    /// Conservative: if we cannot confidently map the required scope to a SHOW privilege,
+    /// we return false (do not show details).
+    bool canRevealGrantHint(const AccessRightsElement & required, const AccessRights & explicit_rights)
+    {
+        const auto & flags = required.access_flags;
+
+        /// Conservative: if we cannot map to a single SHOW privilege, hide the hint.
+        if (flags.isGlobalWithParameter())
+        {
+            /// Global with parameter but no specific parameter (any): safe to reveal.
+            if (required.anyParameter())
+                return true;
+
+            switch (flags.getParameterType())
+            {
+                case AccessFlags::USER_NAME:
+                case AccessFlags::DEFINER:
+                {
+                    /// Roles are also encoded as USER_NAME parameter type. Require role-specific SHOW for role ops,
+                    /// otherwise require SHOW USERS for user ops.
+                    static const AccessFlags role_flags = AccessType::CREATE_ROLE
+                        | AccessType::ALTER_ROLE
+                        | AccessType::DROP_ROLE
+                        | AccessType::ROLE_ADMIN;
+
+                    const bool role_grant = static_cast<bool>(flags & role_flags);
+                    if (role_grant)
+                        return explicit_rights.isGranted(AccessType::SHOW_ROLES) || explicit_rights.isGranted(AccessType::SHOW_ROLES, required.parameter);
+
+                    return explicit_rights.isGranted(AccessType::SHOW_USERS) || explicit_rights.isGranted(AccessType::SHOW_USERS, required.parameter);
+                }
+                case AccessFlags::NAMED_COLLECTION:
+                {
+                    const auto & param = required.parameter.empty() ? required.database : required.parameter;
+                    return explicit_rights.isGranted(AccessType::SHOW_NAMED_COLLECTIONS, param)
+                        || explicit_rights.isGranted(AccessType::SHOW_NAMED_COLLECTIONS_SECRETS, param)
+                        || explicit_rights.isGranted(AccessType::SHOW_NAMED_COLLECTIONS)
+                        || explicit_rights.isGranted(AccessType::SHOW_NAMED_COLLECTIONS_SECRETS);
+                }
+                case AccessFlags::SOURCE:
+                case AccessFlags::TABLE_ENGINE:
+                    /// For source/table-engine parameters we don't have SHOW-equivalent;
+                    /// revealing the required grant is acceptable.
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        const bool has_specific_columns = !required.anyColumn();
+        const bool has_specific_table = !required.anyTable();
+        const bool has_specific_database = !required.anyDatabase();
+
+        /// Global or “any” scope (no specific db/table/column):
+        /// require SHOW for access-management entities to avoid leaking names of the objects.
+        if (!has_specific_columns && !has_specific_table && !has_specific_database)
+        {
+            static const AccessFlags quotas_flags = AccessType::CREATE_QUOTA
+                | AccessType::ALTER_QUOTA
+                | AccessType::DROP_QUOTA;
+
+            if (static_cast<bool>(flags & quotas_flags))
+                return explicit_rights.isGranted(AccessType::SHOW_QUOTAS);
+
+            static const AccessFlags profiles_flags = AccessType::CREATE_SETTINGS_PROFILE
+                | AccessType::ALTER_SETTINGS_PROFILE
+                | AccessType::DROP_SETTINGS_PROFILE;
+
+            if (static_cast<bool>(flags & profiles_flags))
+                return explicit_rights.isGranted(AccessType::SHOW_SETTINGS_PROFILES);
+
+            return true;
+        }
+
+        /// If a table is mentioned (with or without columns), require SHOW at table scope (or dictionary scope).
+        if (has_specific_table)
+        {
+            const bool is_dictionary_scope = static_cast<bool>(flags & AccessFlags::allDictionaryFlags());
+
+            if (is_dictionary_scope)
+            {
+                const bool can_show_dict = explicit_rights.isGranted(AccessType::SHOW_DICTIONARIES, required.database, required.table)
+                    || explicit_rights.isGranted(AccessType::SHOW_DICTIONARIES);
+
+                return can_show_dict;
+            }
+            else
+            {
+                const bool can_show_table = explicit_rights.isGranted(AccessType::SHOW_TABLES, required.database, required.table)
+                    || explicit_rights.isGranted(AccessType::SHOW_TABLES);
+
+                if (!can_show_table)
+                    return false;
+
+                /// Column-level hints for tables require SHOW COLUMNS.
+                if (has_specific_columns)
+                {
+                    if (!explicit_rights.isGranted(AccessType::SHOW_COLUMNS, required.database, required.table)
+                        && !explicit_rights.isGranted(AccessType::SHOW_COLUMNS))
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        /// Database-only scope (no table): require SHOW DATABASES on that db.
+        if (has_specific_database)
+        {
+            if (!required.database.empty())
+                return explicit_rights.isGranted(AccessType::SHOW_DATABASES, required.database);
+
+            /// Empty database name: fall back to global SHOW DATABASES.
+            return explicit_rights.isGranted(AccessType::SHOW_DATABASES);
+        }
+
+        return true;
+    }
+
     /// Helper for using in templates.
     std::string_view getDatabase() { return {}; }
 
@@ -623,6 +742,7 @@ bool ContextAccess::checkAccessImplHelper(const ContextPtr & context, AccessFlag
     }
 
     auto acs = getAccessRightsWithImplicit();
+    auto explicit_acs = getAccessRights();
     bool granted;
     if constexpr (wildcard)
     {
@@ -641,15 +761,34 @@ bool ContextAccess::checkAccessImplHelper(const ContextPtr & context, AccessFlag
 
     if (!granted)
     {
+        const auto hints_level = access_control->getMissingGrantsHintsLevel();
+        auto should_show_details = [&](const AccessRightsElement & required) -> bool
+        {
+            if (hints_level == AccessControl::MissingGrantsHintsLevel::Never)
+                return false;
+
+            if (hints_level == AccessControl::MissingGrantsHintsLevel::Always)
+                return true;
+
+            bool result = canRevealGrantHint(required, *explicit_acs);
+            return result;
+        };
+
         auto access_denied_no_grant = [&]<typename... FmtArgs>(AccessFlags access_flags, FmtArgs && ...fmt_args)
         {
+            AccessRightsElement required_access{access_flags, fmt_args...};
+            bool show_details = should_show_details(required_access);
+
             if (grant_option && acs->isGranted(access_flags, fmt_args...))
             {
+                if (!show_details)
+                    return access_denied(ErrorCodes::ACCESS_DENIED, "{}: Not enough privileges.");
+
                 return access_denied(ErrorCodes::ACCESS_DENIED,
                     "{}: Not enough privileges. "
                     "The required privileges have been granted, but without grant option. "
                     "To execute this query, it's necessary to have the grant {} WITH GRANT OPTION",
-                    AccessRightsElement{access_flags, fmt_args...}.toStringWithoutOptions());
+                    required_access.toStringWithoutOptions());
             }
 
             AccessRights difference;
@@ -659,16 +798,21 @@ bool ContextAccess::checkAccessImplHelper(const ContextPtr & context, AccessFlag
 
             if (difference == original_rights)
             {
+                if (!show_details)
+                    return access_denied(ErrorCodes::ACCESS_DENIED, "{}: Not enough privileges.");
+
                 return access_denied(ErrorCodes::ACCESS_DENIED,
                     "{}: Not enough privileges. To execute this query, it's necessary to have the grant {}",
-                    AccessRightsElement{access_flags, fmt_args...}.toStringWithoutOptions() + (grant_option ? " WITH GRANT OPTION" : ""));
+                    required_access.toStringWithoutOptions() + (grant_option ? " WITH GRANT OPTION" : ""));
             }
 
+            if (!show_details)
+                return access_denied(ErrorCodes::ACCESS_DENIED, "{}: Not enough privileges.");
 
             return access_denied(ErrorCodes::ACCESS_DENIED,
                 "{}: Not enough privileges. To execute this query, it's necessary to have the grant {}. "
                 "(Missing permissions: {}){}",
-                AccessRightsElement{access_flags, fmt_args...}.toStringWithoutOptions() + (grant_option ? " WITH GRANT OPTION" : ""),
+                required_access.toStringWithoutOptions() + (grant_option ? " WITH GRANT OPTION" : ""),
                 difference.getElements().toStringWithoutOptions(),
                 grant_option ? ". You can try to use the `GRANT CURRENT GRANTS(...)` statement" : "");
         };

--- a/tests/integration/test_access_denied_verbose_grant_hints/__init__.py
+++ b/tests/integration/test_access_denied_verbose_grant_hints/__init__.py
@@ -1,0 +1,1 @@
+# Make this directory a package to avoid pytest module name clashes with other test.py files.

--- a/tests/integration/test_access_denied_verbose_grant_hints/configs/always.xml
+++ b/tests/integration/test_access_denied_verbose_grant_hints/configs/always.xml
@@ -1,0 +1,5 @@
+<yandex>
+    <access_control_improvements>
+        <missing_grants_hints>always</missing_grants_hints>
+    </access_control_improvements>
+</yandex>

--- a/tests/integration/test_access_denied_verbose_grant_hints/configs/never.xml
+++ b/tests/integration/test_access_denied_verbose_grant_hints/configs/never.xml
@@ -1,0 +1,5 @@
+<yandex>
+    <access_control_improvements>
+        <missing_grants_hints>never</missing_grants_hints>
+    </access_control_improvements>
+</yandex>

--- a/tests/integration/test_access_denied_verbose_grant_hints/configs/require_show.xml
+++ b/tests/integration/test_access_denied_verbose_grant_hints/configs/require_show.xml
@@ -1,0 +1,6 @@
+<yandex>
+    <access_control_improvements>
+        <missing_grants_hints>require_show</missing_grants_hints>
+        <access_management>1</access_management>
+    </access_control_improvements>
+</yandex>

--- a/tests/integration/test_access_denied_verbose_grant_hints/test.py
+++ b/tests/integration/test_access_denied_verbose_grant_hints/test.py
@@ -1,0 +1,258 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+
+cluster = ClickHouseCluster(__file__)
+node_show = cluster.add_instance(
+    "node_show",
+    main_configs=["configs/always.xml"],
+)
+node_hide = cluster.add_instance(
+    "node_hide",
+    main_configs=["configs/never.xml"],
+)
+node_require = cluster.add_instance(
+    "node_require",
+    main_configs=["configs/require_show.xml"],
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_show_mode_exposes_details():
+    node_show.query("DROP TABLE IF EXISTS t_show")
+    node_show.query("CREATE TABLE t_show(x UInt32) ENGINE = Memory")
+    node_show.query("CREATE USER OR REPLACE u_show")
+
+    err = node_show.query_and_get_error("SELECT * FROM t_show", user="u_show")
+    assert "necessary to have the grant SELECT" in err
+
+
+def test_hide_mode_masks_details():
+    node_hide.query("DROP TABLE IF EXISTS t_hide")
+    node_hide.query("CREATE TABLE t_hide(x UInt32) ENGINE = Memory")
+    node_hide.query("CREATE USER OR REPLACE u_hide")
+
+    err = node_hide.query_and_get_error("SELECT * FROM t_hide", user="u_hide")
+    assert "Not enough privileges" in err
+    assert "necessary to have the grant" not in err
+
+
+def test_require_show_requires_show_privilege_for_details():
+    node_require.query("DROP TABLE IF EXISTS t_require")
+    node_require.query("CREATE TABLE t_require(x UInt32) ENGINE = Memory")
+    node_require.query("CREATE USER OR REPLACE u_require")
+
+    err = node_require.query_and_get_error("SELECT * FROM t_require", user="u_require")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW DATABASES ON *.* TO u_require")
+    node_require.query("GRANT SHOW TABLES ON default.t_require TO u_require")
+    node_require.query("GRANT SHOW COLUMNS ON default.t_require TO u_require")
+    err = node_require.query_and_get_error("SELECT * FROM t_require", user="u_require")
+    assert "necessary to have the grant SELECT" in err
+
+
+def test_require_show_requires_show_privilege_for_dictionary_hints():
+    node_require.query("DROP DICTIONARY IF EXISTS dict_require")
+    node_require.query(
+        """
+        CREATE DICTIONARY dict_require (id UInt64, value UInt64)
+        PRIMARY KEY id
+        SOURCE(CLICKHOUSE(TABLE 'system.one'))
+        LAYOUT(FLAT())
+        LIFETIME(MIN 0 MAX 0)
+        """
+    )
+    node_require.query("CREATE USER OR REPLACE u_dict")
+
+    err = node_require.query_and_get_error("SELECT * FROM dict_require", user="u_dict")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW DATABASES ON *.* TO u_dict")
+    node_require.query("GRANT SHOW DICTIONARIES ON default.dict_require TO u_dict")
+    node_require.query("GRANT SHOW TABLES ON default.dict_require TO u_dict")
+    node_require.query("GRANT SHOW COLUMNS ON default.dict_require TO u_dict")
+
+    err = node_require.query_and_get_error("SELECT * FROM dict_require", user="u_dict")
+    assert "necessary to have the grant SELECT" in err
+
+
+def test_require_show_requires_show_privilege_for_access_management_hints():
+    node_require.query("CREATE USER OR REPLACE u_manage")
+
+    err = node_require.query_and_get_error("CREATE USER u_new", user="u_manage")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW USERS ON *.* TO u_manage")
+    err = node_require.query_and_get_error("CREATE USER u_new", user="u_manage")
+    assert "necessary to have the grant CREATE USER" in err
+
+
+def test_require_show_requires_all_levels_for_table_hint():
+    node_require.query("DROP TABLE IF EXISTS t_levels")
+    node_require.query("CREATE TABLE t_levels(x UInt32) ENGINE = Memory")
+    node_require.query("CREATE USER OR REPLACE u_levels")
+
+    # Missing all SHOW: generic error.
+    err = node_require.query_and_get_error("SELECT * FROM t_levels", user="u_levels")
+    assert "necessary to have the grant" not in err
+
+    # Table SHOW without database SHOW: still generic.
+    node_require.query("GRANT SHOW TABLES ON default.t_levels TO u_levels")
+    err = node_require.query_and_get_error("SELECT * FROM t_levels", user="u_levels")
+    assert "necessary to have the grant" not in err
+
+    # Database SHOW without table SHOW: still generic.
+    node_require.query("REVOKE SHOW TABLES ON default.t_levels FROM u_levels")
+    node_require.query("GRANT SHOW DATABASES ON *.* TO u_levels")
+    err = node_require.query_and_get_error("SELECT * FROM t_levels", user="u_levels")
+    assert "necessary to have the grant" not in err
+
+    # Both database and table SHOW but no SHOW COLUMNS: still generic (column names are revealed in hint).
+    node_require.query("GRANT SHOW TABLES ON *.* TO u_levels")
+    node_require.query("GRANT SHOW TABLES ON default.t_levels TO u_levels")
+    err = node_require.query_and_get_error("SELECT * FROM t_levels", user="u_levels")
+    assert "necessary to have the grant" not in err
+
+    # Add SHOW COLUMNS: detailed hint.
+    node_require.query("GRANT SHOW COLUMNS ON default.t_levels TO u_levels")
+    err = node_require.query_and_get_error("SELECT * FROM t_levels", user="u_levels")
+    assert "necessary to have the grant SELECT" in err
+
+
+def test_require_show_requires_show_columns_for_column_hints():
+    node_require.query("DROP TABLE IF EXISTS t_cols")
+    node_require.query("CREATE TABLE t_cols(x UInt32, y UInt32) ENGINE = Memory")
+    node_require.query("CREATE USER OR REPLACE u_cols")
+
+    # Database + table SHOW but no SHOW COLUMNS: generic.
+    node_require.query("GRANT SHOW DATABASES ON *.* TO u_cols")
+    node_require.query("GRANT SHOW TABLES ON default.t_cols TO u_cols")
+    err = node_require.query_and_get_error("SELECT x FROM t_cols", user="u_cols")
+    assert "necessary to have the grant" not in err
+
+    # Add SHOW COLUMNS: detailed.
+    node_require.query("GRANT SHOW COLUMNS ON default.t_cols TO u_cols")
+    err = node_require.query_and_get_error("SELECT x FROM t_cols", user="u_cols")
+    assert "necessary to have the grant SELECT" in err
+
+
+def test_require_show_for_roles_and_users():
+    node_require.query("CREATE USER OR REPLACE u_role_tests")
+
+    # No SHOW: generic.
+    err = node_require.query_and_get_error("CREATE ROLE r1", user="u_role_tests")
+    assert "necessary to have the grant" not in err
+
+    # SHOW USERS alone: still generic for roles.
+    node_require.query("GRANT SHOW USERS ON *.* TO u_role_tests")
+    err = node_require.query_and_get_error("CREATE ROLE r1", user="u_role_tests")
+    assert "necessary to have the grant" not in err
+
+    # SHOW ROLES: detailed for role grant.
+    node_require.query("GRANT SHOW ROLES ON *.* TO u_role_tests")
+    err = node_require.query_and_get_error("CREATE ROLE r1", user="u_role_tests")
+    assert "necessary to have the grant CREATE ROLE" in err
+
+    # For users, SHOW USERS should be enough.
+    node_require.query("GRANT SHOW USERS ON *.* TO u_role_tests")
+    err = node_require.query_and_get_error("CREATE USER u_new2", user="u_role_tests")
+    assert "necessary to have the grant CREATE USER" in err
+
+
+def test_require_show_for_quotas_and_profiles():
+    node_require.query("DROP QUOTA IF EXISTS q1")
+    node_require.query("DROP SETTINGS PROFILE IF EXISTS p1")
+    node_require.query("CREATE USER OR REPLACE u_quota")
+
+    err = node_require.query_and_get_error("CREATE QUOTA q1", user="u_quota")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW QUOTAS ON *.* TO u_quota")
+    err = node_require.query_and_get_error("CREATE QUOTA q1", user="u_quota")
+    assert "necessary to have the grant CREATE QUOTA" in err
+
+    node_require.query("CREATE USER OR REPLACE u_profile")
+
+    err = node_require.query_and_get_error("CREATE SETTINGS PROFILE p1", user="u_profile")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW PROFILES ON *.* TO u_profile")
+    err = node_require.query_and_get_error("CREATE SETTINGS PROFILE p1", user="u_profile")
+    assert ("necessary to have the grant CREATE PROFILE" in err) or ("necessary to have the grant CREATE SETTINGS PROFILE" in err)
+
+
+def test_require_show_for_database_scope():
+    node_require.query("DROP DATABASE IF EXISTS db_scope")
+    node_require.query("CREATE USER OR REPLACE u_db_scope")
+
+    err = node_require.query_and_get_error("CREATE DATABASE db_scope", user="u_db_scope")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW DATABASES ON db_scope.* TO u_db_scope")
+    err = node_require.query_and_get_error("CREATE DATABASE db_scope", user="u_db_scope")
+    assert "necessary to have the grant CREATE DATABASE" in err
+
+
+def test_require_show_for_named_collections():
+    node_require.query("CREATE USER OR REPLACE u_named")
+
+    err = node_require.query_and_get_error("CREATE NAMED COLLECTION nc1 AS url='s3://bucket'", user="u_named")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW NAMED COLLECTIONS ON *.* TO u_named")
+    err = node_require.query_and_get_error("CREATE NAMED COLLECTION nc1 AS url='s3://bucket'", user="u_named")
+    assert "necessary to have the grant CREATE NAMED COLLECTION" in err
+
+
+def test_require_show_for_definer_actions():
+    node_require.query("CREATE USER OR REPLACE u_definer")
+
+    err = node_require.query_and_get_error("CREATE USER u_definer_target HOST ANY IDENTIFIED WITH plaintext_password BY 'a' DEFAULT ROLE NONE", user="u_definer")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW USERS ON *.* TO u_definer")
+    err = node_require.query_and_get_error("CREATE USER u_definer_target HOST ANY IDENTIFIED WITH plaintext_password BY 'a' DEFAULT ROLE NONE", user="u_definer")
+    assert "necessary to have the grant CREATE USER" in err
+
+
+def test_require_show_with_any_parameter_global():
+    node_require.query("CREATE USER OR REPLACE u_any_param")
+
+    err = node_require.query_and_get_error("CREATE SETTINGS PROFILE prof_any TO u_any_param", user="u_any_param")
+    assert "necessary to have the grant" not in err
+
+    node_require.query("GRANT SHOW PROFILES ON *.* TO u_any_param")
+    err = node_require.query_and_get_error("CREATE SETTINGS PROFILE prof_any TO u_any_param", user="u_any_param")
+    assert ("necessary to have the grant CREATE PROFILE" in err) or ("necessary to have the grant CREATE SETTINGS PROFILE" in err)
+
+
+def test_require_show_for_table_like_dictionary_columns():
+    node_require.query("DROP DICTIONARY IF EXISTS dict_cols")
+    node_require.query(
+        """
+        CREATE DICTIONARY dict_cols (id UInt64, value UInt64)
+        PRIMARY KEY id
+        SOURCE(CLICKHOUSE(TABLE 'system.one'))
+        LAYOUT(FLAT())
+        LIFETIME(MIN 0 MAX 0)
+        """
+    )
+    node_require.query("CREATE USER OR REPLACE u_dict_cols")
+
+    node_require.query("GRANT SHOW DATABASES ON *.* TO u_dict_cols")
+    node_require.query("GRANT SHOW DICTIONARIES ON default.dict_cols TO u_dict_cols")
+    node_require.query("GRANT SHOW TABLES ON *.* TO u_dict_cols")
+    node_require.query("GRANT SHOW COLUMNS ON default.dict_cols TO u_dict_cols")
+
+    err = node_require.query_and_get_error("SELECT id FROM dict_cols", user="u_dict_cols")
+    assert "necessary to have the grant SELECT" in err


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Adds the `access_control_improvements.missing_grants_hints` server setting to control whether `ACCESS_DENIED` errors include missing-grant details (#91067 by @filimonov)

### Documentation entry for user-facing changes
### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)