### PR TITLE
25.8.14 Backport of #89367: Crash in IN function where columns have different types and many columns are involved

### DIFF
--- a/src/Interpreters/sortBlock.cpp
+++ b/src/Interpreters/sortBlock.cpp
@@ -336,6 +336,10 @@ void checkSortedWithPermutation(const Block & block, const SortDescription & des
 void sortBlock(Block & block, const SortDescription & description, UInt64 limit, IColumn::PermutationSortStability stability)
 {
     IColumn::Permutation permutation;
+
+#ifndef NDEBUG
+    block.checkNumberOfRows();
+#endif
     getBlockSortPermutationImpl(block, description, stability, limit, permutation);
 
 #ifndef NDEBUG

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -1430,6 +1430,9 @@ bool KeyCondition::tryPrepareSetIndex(
 
     Columns transformed_set_columns = set_columns;
 
+    IColumn::Filter filter(transformed_set_columns.front()->size(), 1);
+    bool filter_used = false;
+
     for (size_t indexes_mapping_index = 0; indexes_mapping_index < indexes_mapping_size; ++indexes_mapping_index)
     {
         const auto & key_column_type = data_types[indexes_mapping_index];
@@ -1501,32 +1504,39 @@ bool KeyCondition::tryPrepareSetIndex(
         const NullMap & nullable_set_column_null_map = nullable_set_column_typed->getNullMapData();
         size_t nullable_set_column_null_map_size = nullable_set_column_null_map.size();
 
-        IColumn::Filter filter(nullable_set_column_null_map_size);
-
         if (set_column_null_map)
         {
             for (size_t i = 0; i < nullable_set_column_null_map_size; ++i)
             {
                 if (nullable_set_column_null_map_size < set_column_null_map->size())
-                    filter[i] = (*set_column_null_map)[i] || !nullable_set_column_null_map[i];
+                    filter[i] &= (*set_column_null_map)[i] || !nullable_set_column_null_map[i];
                 else
-                    filter[i] = !nullable_set_column_null_map[i];
+                    filter[i] &= !nullable_set_column_null_map[i];
             }
 
-            set_column = nullable_set_column_typed->filter(filter, 0);
+            set_column = nullable_set_column;
         }
         else
         {
             for (size_t i = 0; i < nullable_set_column_null_map_size; ++i)
-                filter[i] = !nullable_set_column_null_map[i];
+                filter[i] &= !nullable_set_column_null_map[i];
 
-            set_column = nullable_set_column_typed->getNestedColumn().filter(filter, 0);
+            set_column = nullable_set_column_typed->getNestedColumnPtr();
         }
+        filter_used = true;
 
         transformed_set_columns[set_element_index] = std::move(set_column);
     }
 
-    set_columns = std::move(transformed_set_columns);
+    if (filter_used)
+    {
+        for (size_t set_element_index = 0; set_element_index < transformed_set_columns.size(); ++set_element_index)
+            set_columns[set_element_index] = transformed_set_columns[set_element_index]->filter(filter, 0);
+    }
+    else
+    {
+        set_columns = std::move(transformed_set_columns);
+    }
 
     out.set_index = std::make_shared<MergeTreeSetIndex>(set_columns, std::move(indexes_mapping));
 

--- a/tests/queries/0_stateless/03635_in_function_different_types_many_columns.reference
+++ b/tests/queries/0_stateless/03635_in_function_different_types_many_columns.reference
@@ -1,0 +1,52 @@
+CreatingSets
+  Expression
+    Filter
+      ReadFromMergeTree
+      Indexes:
+        PrimaryKey
+          Keys:
+            value
+          Condition: (value in 5-element set)
+          Parts: 1/1
+          Granules: 1/1
+          Search Algorithm: generic exclusion search
+          Ranges: 1
+CreatingSets
+  Expression
+    Filter
+      ReadFromMergeTree
+      Indexes:
+        PrimaryKey
+          Keys:
+            value
+          Condition: (value in 0-element set)
+          Parts: 0/1
+          Granules: 0/1
+          Search Algorithm: generic exclusion search
+          Ranges: 0
+CreatingSets
+  Expression
+    Filter
+      ReadFromMergeTree
+      Indexes:
+        PrimaryKey
+          Keys:
+            value
+          Condition: (value in 5-element set)
+          Parts: 1/1
+          Granules: 1/1
+          Search Algorithm: generic exclusion search
+          Ranges: 1
+CreatingSets
+  Expression
+    Filter
+      ReadFromMergeTree
+      Indexes:
+        PrimaryKey
+          Keys:
+            value
+          Condition: (value in 0-element set)
+          Parts: 0/1
+          Granules: 0/1
+          Search Algorithm: generic exclusion search
+          Ranges: 0

--- a/tests/queries/0_stateless/03635_in_function_different_types_many_columns.sql
+++ b/tests/queries/0_stateless/03635_in_function_different_types_many_columns.sql
@@ -1,0 +1,18 @@
+-- Tags: no-parallel-replicas, no-random-merge-tree-settings
+-- followup to 02882_primary_key_index_in_function_different_types
+
+DROP TABLE IF EXISTS test_table;
+CREATE TABLE test_table
+(
+    id UInt64,
+    value UInt64
+) ENGINE=MergeTree ORDER BY (id, value) SETTINGS index_granularity = 8192, index_granularity_bytes = '1Mi';
+
+INSERT INTO test_table SELECT number, number FROM numbers(10);
+
+EXPLAIN indexes = 1, description=0 SELECT id FROM test_table WHERE (id, value) IN (SELECT '5', number FROM numbers(5));
+EXPLAIN indexes = 1, description=0 SELECT id FROM test_table WHERE (id, value) IN (SELECT 'not a number', number FROM numbers(5));
+EXPLAIN indexes = 1, description=0 SELECT id FROM test_table WHERE (id, value) IN (SELECT 42, 'not a number' UNION ALL SELECT 5, toString(number) FROM numbers(5));
+EXPLAIN indexes = 1, description=0 SELECT id FROM test_table WHERE (id, value) IN (SELECT '42', 'not a number' UNION ALL SELECT 'not a number', '42' FROM numbers(5));
+
+DROP TABLE test_table;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Possible crash/undefined behavior in IN function where primary key column types are different from IN function right side column types (https://github.com/ClickHouse/ClickHouse/pull/89367 by @ilejn)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [x] <!---ci_regression_common--> Fast suites (mostly <1h)
- [x] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [x] <!---ci_regression_alter--> Alter (1.5h)
- [x] <!---ci_regression_benchmark--> Benchmark (30m)
- [x] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [x] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [x] <!---ci_regression_rbac--> RBAC (1.5h)
- [x] <!---ci_regression_ssl_server--> SSL Server (1h)
- [x] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_tiered_storage--> Tiered Storage (2h)