### PR TITLE
25.8.14 Stable backport of #90243: Fix crash in StorageDistributed when parsing malformed shard directory names

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1690,9 +1690,11 @@ Cluster::Addresses StorageDistributed::parseAddresses(const std::string & name) 
                 continue;
             }
 
-            if (address.replica_index > replicas)
+            if (address.replica_index == 0 || address.replica_index > replicas)
             {
-                LOG_ERROR(log, "No shard with replica_index={} ({})", address.replica_index, name);
+                LOG_ERROR(log, "Invalid replica_index={} for directory '{}' (cluster has {} replicas for shard {}). "
+                               "Expected directory format: 'shardN_replicaM' or 'shardN_all_replicas'",
+                                address.replica_index, dirname, replicas, address.shard_index);
                 continue;
             }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix crash in StorageDistributed when parsing malformed shard directory names (https://github.com/ClickHouse/ClickHouse/pull/90243 by @AVMusorin)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [x] <!---ci_regression_common--> Fast suites (mostly <1h)
- [x] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [x] <!---ci_regression_alter--> Alter (1.5h)
- [x] <!---ci_regression_benchmark--> Benchmark (30m)
- [x] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [x] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [x] <!---ci_regression_rbac--> RBAC (1.5h)
- [x] <!---ci_regression_ssl_server--> SSL Server (1h)
- [x] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_tiered_storage--> Tiered Storage (2h)