### PR TITLE
25.8.14 Stable backport of #90761: Fix access validation for ALTER UPDATE with remote table function

### DIFF
--- a/tests/queries/0_stateless/03727_alter_with_localhost_remote.sql
+++ b/tests/queries/0_stateless/03727_alter_with_localhost_remote.sql
@@ -1,0 +1,30 @@
+-- Tags: no-replicated-database, no-parallel
+
+DROP USER IF EXISTS test_03727;
+CREATE USER test_03727;
+
+CREATE TABLE normal
+(
+    n Int32,
+    s String
+)
+ENGINE = MergeTree()
+ORDER BY n;
+
+CREATE TABLE secret
+(
+    s String
+)
+ENGINE = MergeTree()
+ORDER BY s;
+
+INSERT INTO normal VALUES (1, '');
+INSERT INTO secret VALUES ('secret');
+
+GRANT ALTER UPDATE ON normal TO test_03727;
+GRANT READ ON REMOTE to test_03727;
+GRANT CREATE TEMPORARY TABLE ON *.* TO test_03727;
+
+EXECUTE AS test_03727 ALTER TABLE normal UPDATE s = (SELECT * FROM remote('localhost', currentDatabase(), 'secret') LIMIT 1) WHERE n=1; -- { serverError ACCESS_DENIED }
+
+DROP USER IF EXISTS test_03727;


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix access validation for `ALTER UPDATE` queries when a `remote` table function is used with `localhost` as a target host (https://github.com/ClickHouse/ClickHouse/pull/90761 by @pufit)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [x] <!---ci_regression_common--> Fast suites (mostly <1h)
- [x] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [x] <!---ci_regression_alter--> Alter (1.5h)
- [x] <!---ci_regression_benchmark--> Benchmark (30m)
- [x] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [x] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [x] <!---ci_regression_rbac--> RBAC (1.5h)
- [x] <!---ci_regression_ssl_server--> SSL Server (1h)
- [x] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_tiered_storage--> Tiered Storage (2h)