### PR TITLE
(maybe) Fix zero‑copy unlock check before part dir move

### DIFF
--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -747,6 +747,11 @@ void DataPartStorageOnDiskBase::remove(
 
         try
         {
+            /// Evaluate can_remove_callback before moving the directory so zero-copy reference checks
+            /// use the current (existing) path. We intentionally don't update part_dir to avoid races.
+            if (!can_remove_description)
+                can_remove_description.emplace(can_remove_callback());
+
             disk->moveDirectory(from, to);
             /// NOTE: we intentionally don't update part_dir here because it would cause a data race
             /// with concurrent readers (e.g. system.parts table queries calling getFullPath()).


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Make zero‑copy cleanup check the correct directory before it is moved, so shared blobs aren’t deleted while other replicas still need them ( regression after https://github.com/ClickHouse/ClickHouse/pull/94262 ).

### Documentation entry for user-facing changes

(I hope) fixes https://github.com/Altinity/ClickHouse/issues/1338

#### What went wrong

A data part is removed in two steps:

1. The part directory is renamed to delete_tmp_*.
2. Then the system decides whether it can delete the shared blobs (for zero‑copy) and clears the files.

In PR https://github.com/ClickHouse/ClickHouse/pull/94262, we stopped updating the internal path (part_dir) after step 1 to fix a data race with system.parts.

That was correct for the race, but it had a side effect:

- The zero‑copy cleanup logic checks a small file (references) inside the part directory to decide whether it’s safe to delete shared blobs.
- After the rename, the directory has moved, but part_dir still points to the old location, so the check fails.
- When the check fails, the code assumes “this is a temporary part” and deletes blobs without asking ZooKeeper.

Result: a replica can delete blobs that other replicas still need, causing fetch failures and permanent missing parts.

#### What the fix does

 Before we rename the directory, we now evaluate the zero‑copy delete decision and keep the result.

 That way:

 - the refcount file is checked at the correct path (before move),
 - and we still do not update part_dir, so the data‑race fix from #94262 remains intact.

 #### Why 94262 introduced the regression

94262 removed part_dir updates during removal to fix a data race with system.parts.
That means any logic that depends on part_dir after the directory is renamed will now read a stale path.

Zero‑copy cleanup is exactly such logic.

#### Why only zero‑copy is affected

Non‑zero‑copy disks don’t use refcount files or ZooKeeper locks.
The cleanup simply deletes files and never checks shared blob ownership.

So only zero‑copy paths care about that missing references file.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)