### PR TITLE
25.8.16 Stable Backport of #90059: Unblock ttl part drops for cold volumes

### DIFF
--- a/src/Storages/MergeTree/Compaction/MergePredicates/DistributedMergePredicate.h
+++ b/src/Storages/MergeTree/Compaction/MergePredicates/DistributedMergePredicate.h
@@ -82,6 +82,9 @@ public:
         if (left.info.isPatch() != right.info.isPatch())
             return std::unexpected(PreformattedMessage::create("One of parts ({}, {}) is patch part and another is regular part", left.name, right.name));
 
+        if (left.is_in_volume_where_merges_avoid || right.is_in_volume_where_merges_avoid)
+            return std::unexpected(PreformattedMessage::create("One of parts ({}, {}) lies on volume where merges should be avoided", left.name, right.name));
+
         int64_t left_max_block = left.info.max_block;
         int64_t right_min_block = right.info.min_block;
         chassert(left_max_block < right_min_block);

--- a/src/Storages/MergeTree/Compaction/MergePredicates/MergeTreeMergePredicate.cpp
+++ b/src/Storages/MergeTree/Compaction/MergePredicates/MergeTreeMergePredicate.cpp
@@ -37,6 +37,9 @@ std::expected<void, PreformattedMessage> MergeTreeMergePredicate::canMergeParts(
     if (left.info.isPatch() != right.info.isPatch())
         return std::unexpected(PreformattedMessage::create("One of parts ({}, {}) is patch part and another is regular part", left.name, right.name));
 
+    if (left.is_in_volume_where_merges_avoid || right.is_in_volume_where_merges_avoid)
+        return std::unexpected(PreformattedMessage::create("One of parts ({}, {}) lies on volume where merges should be avoided", left.name, right.name));
+
     if (left.projection_names != right.projection_names)
     {
         return std::unexpected(PreformattedMessage::create(

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/TTLMergeSelector.cpp
@@ -213,6 +213,9 @@ time_t TTLRowDeleteMergeSelector::getTTLForPart(const PartProperties & part) con
 
 bool TTLRowDeleteMergeSelector::canConsiderPart(const PartProperties & part) const
 {
+    if (part.is_in_volume_where_merges_avoid)
+        return false;
+
     if (!part.general_ttl_info.has_value())
         return false;
 
@@ -231,6 +234,9 @@ time_t TTLRecompressMergeSelector::getTTLForPart(const PartProperties & part) co
 
 bool TTLRecompressMergeSelector::canConsiderPart(const PartProperties & part) const
 {
+    if (part.is_in_volume_where_merges_avoid)
+        return false;
+
     if (!part.recompression_ttl_info.has_value())
         return false;
 

--- a/src/Storages/MergeTree/Compaction/PartProperties.cpp
+++ b/src/Storages/MergeTree/Compaction/PartProperties.cpp
@@ -67,6 +67,7 @@ std::set<std::string> getCalculatedProjectionNames(const MergeTreeDataPartPtr & 
 PartProperties buildPartProperties(
     const MergeTreeDataPartPtr & part,
     const StorageMetadataPtr & metadata_snapshot,
+    const StoragePolicyPtr & storage_policy,
     time_t current_time)
 {
     return PartProperties{
@@ -74,6 +75,7 @@ PartProperties buildPartProperties(
         .info = part->info,
         .projection_names = getCalculatedProjectionNames(part),
         .all_ttl_calculated_if_any = part->checkAllTTLCalculated(metadata_snapshot),
+        .is_in_volume_where_merges_avoid = !part->shallParticipateInMerges(storage_policy),
         .size = part->getExistingBytesOnDisk(),
         .age = current_time - part->modification_time,
         .general_ttl_info = buildGeneralTTLInfo(metadata_snapshot, part),

--- a/src/Storages/MergeTree/Compaction/PartProperties.h
+++ b/src/Storages/MergeTree/Compaction/PartProperties.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <Storages/MergeTree/MergeTreePartInfo.h>
+
+#include <Disks/IStoragePolicy.h>
+
 #include <Core/UUID.h>
 
 #include <optional>
@@ -24,6 +27,7 @@ struct PartProperties
     const std::set<std::string> projection_names = {};
 
     const bool all_ttl_calculated_if_any = false;
+    const bool is_in_volume_where_merges_avoid = false;
 
     /// Size of data part in bytes.
     const size_t size = 0;
@@ -56,6 +60,7 @@ using PartsRangeView = std::span<const PartProperties>;
 PartProperties buildPartProperties(
     const MergeTreeDataPartPtr & part,
     const StorageMetadataPtr & metadata_snapshot,
+    const StoragePolicyPtr & storage_policy,
     time_t current_time);
 
 }

--- a/src/Storages/MergeTree/Compaction/PartsCollectors/Common.cpp
+++ b/src/Storages/MergeTree/Compaction/PartsCollectors/Common.cpp
@@ -6,7 +6,10 @@ namespace DB
 {
 
 PartsRanges constructPartsRanges(
-    std::vector<MergeTreeDataPartsVector> && ranges, const StorageMetadataPtr & metadata_snapshot, const time_t & current_time)
+    std::vector<MergeTreeDataPartsVector> && ranges,
+    const StorageMetadataPtr & metadata_snapshot,
+    const StoragePolicyPtr & storage_policy,
+    const time_t & current_time)
 {
     PartsRanges properties_ranges;
     properties_ranges.reserve(ranges.size());
@@ -17,7 +20,7 @@ PartsRanges constructPartsRanges(
         properties_ranges.reserve(range.size());
 
         for (const auto & part : range)
-            properties_range.push_back(buildPartProperties(part, metadata_snapshot, current_time));
+            properties_range.push_back(buildPartProperties(part, metadata_snapshot, storage_policy, current_time));
 
         properties_ranges.push_back(std::move(properties_range));
     }

--- a/src/Storages/MergeTree/Compaction/PartsCollectors/Common.h
+++ b/src/Storages/MergeTree/Compaction/PartsCollectors/Common.h
@@ -55,7 +55,10 @@ std::expected<void, PreformattedMessage> checkAllPartsSatisfyPredicate(const std
 }
 
 PartsRanges constructPartsRanges(
-    std::vector<MergeTreeDataPartsVector> && ranges, const StorageMetadataPtr & metadata_snapshot, const time_t & current_time);
+    std::vector<MergeTreeDataPartsVector> && ranges,
+    const StorageMetadataPtr & metadata_snapshot,
+    const StoragePolicyPtr & storage_policy,
+    const time_t & current_time);
 
 MergeTreeDataPartsVector filterByPartitions(
     MergeTreeDataPartsVector && parts, const std::optional<PartitionIdsHint> & partitions_to_keep);

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -300,10 +300,11 @@ MergeSelectorChoices chooseMergesFrom(
 
         for (size_t i = 0; i < choices.size(); ++i)
         {
+            const auto & merge_type = choices[i].merge_type;
             const auto & range = choices[i].range;
             const auto & range_patches = choices[i].range_patches;
             ProfileEvents::increment(ProfileEvents::MergerMutatorSelectRangePartsCount, range.size());
-            LOG_TRACE(log, "Merge #{} with {} parts from {} to {} with {} patches", i, range.size(), range.front().name, range.back().name, range_patches.size());
+            LOG_TRACE(log, "Merge #{} type {} with {} parts from {} to {} with {} patches", i, merge_type, range.size(), range.front().name, range.back().name, range_patches.size());
         }
     }
 

--- a/tests/integration/test_no_merges_volume_ttl/configs/storage_config.xml
+++ b/tests/integration/test_no_merges_volume_ttl/configs/storage_config.xml
@@ -1,0 +1,25 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <with_merges>
+                <path>/with_merges/</path>
+            </with_merges>
+            <no_merges>
+                <path>/no_merges/</path>
+            </no_merges>
+        </disks>
+        <policies>
+            <hot_cold_separation_policy>
+                <volumes>
+                    <with_merges>
+                        <disk>with_merges</disk>
+                    </with_merges>
+                    <no_merges>
+                        <disk>no_merges</disk>
+                        <prefer_not_to_merge>true</prefer_not_to_merge>
+                    </no_merges>
+                </volumes>
+            </hot_cold_separation_policy>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_no_merges_volume_ttl/test.py
+++ b/tests/integration/test_no_merges_volume_ttl/test.py
@@ -1,0 +1,80 @@
+import pytest
+import time
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/storage_config.xml"],
+    tmpfs=["/with_merges:size=200M", "/no_merges:size=200M"],
+)
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+def wait_parts_count(table, expected_number_of_parts):
+    for i in range(100):
+        print(f"Waiting {expected_number_of_parts} for table {table}. Iteration: {i}")
+        parts_count = int(node.query(f"select count() from system.parts where table = '{table}' and active"))
+
+        if parts_count == expected_number_of_parts:
+            break
+
+        time.sleep(1)
+
+    assert int(node.query(f"select count() from system.parts where table = '{table}' and active")) == expected_number_of_parts
+
+
+def test_no_merges_volume_ttl_merge(start_cluster):
+    node.query("create table t (time DateTime) engine = MergeTree order by tuple() ttl time settings storage_policy='hot_cold_separation_policy', merge_with_ttl_timeout=0")
+    table_uuid = node.query("select uuid from system.tables where table = 't'").strip()
+
+    node.query("system stop merges t")
+    node.query("insert into t values (now() - interval 1 day)")
+    assert node.query("select path from system.parts where table = 't' and active").strip() == f"/with_merges/store/{table_uuid[:3]}/{table_uuid}/all_1_1_0/"
+    assert int(node.query("select count() from t").strip()) == 1
+
+    node.query("alter table t move partition () to volume 'no_merges'")
+    assert node.query("select path from system.parts where table = 't' and active").strip() == f"/no_merges/store/{table_uuid[:3]}/{table_uuid}/all_1_1_0/"
+    assert int(node.query("select count() from t").strip()) == 1
+
+    node.query("system start merges t")
+    wait_parts_count("t", 0)
+
+    assert int(node.query("select count() from t").strip()) == 0
+    node.query("drop table t sync")
+
+
+def test_no_merges_volume_no_regular_merges(start_cluster):
+    node.query("create table t (a UInt64) engine = MergeTree order by tuple() settings storage_policy='hot_cold_separation_policy'")
+
+    node.query("system stop merges t")
+    node.query("insert into t select number from numbers(50) settings max_block_size=1, min_insert_block_size_bytes=1")
+    assert int(node.query("select count() from t").strip()) == 50
+    assert int(node.query("select count() from system.parts where table = 't' and active").strip()) == 50
+
+    node.query("alter table t move partition () to volume 'no_merges'")
+    assert int(node.query("select count() from t").strip()) == 50
+    assert int(node.query("select count() from system.parts where table = 't' and active").strip()) == 50
+
+    node.query("system start merges t")
+    node.query("optimize table t")
+    node.query("optimize table t")
+    node.query("optimize table t")
+    node.query("optimize table t")
+    node.query("optimize table t final")
+    node.query("optimize table t final")
+    node.query("optimize table t final")
+    node.query("optimize table t final")
+
+    assert int(node.query("select count() from t").strip()) == 50
+    assert int(node.query("select count() from system.parts where table = 't' and active").strip()) == 50
+    node.query("drop table t sync")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Split part ranges by volume characteristics to enable TTL drop merges for cold volumes. After this patch, parts with a max TTL < now will be removed from cold storage. The algorithm will schedule only single part drops. (https://github.com/ClickHouse/ClickHouse/pull/90059 by @Michicosun)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [x] <!---ci_regression_common--> Fast suites (mostly <1h)
- [x] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [x] <!---ci_regression_alter--> Alter (1.5h)
- [x] <!---ci_regression_benchmark--> Benchmark (30m)
- [x] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [x] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [x] <!---ci_regression_rbac--> RBAC (1.5h)
- [x] <!---ci_regression_ssl_server--> SSL Server (1h)
- [x] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_tiered_storage--> Tiered Storage (2h)