### PR TITLE
24.8.14 Backport of #95301: Fix sparse column aggregation with sum() and timeseries

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSum.h
+++ b/src/AggregateFunctions/AggregateFunctionSum.h
@@ -566,7 +566,8 @@ public:
         size_t to = std::lower_bound(offsets.begin(), offsets.end(), row_end) - offsets.begin();
 
         for (size_t i = from; i < to; ++i)
-            add(places[offsets[i]] + place_offset, &values, i + 1, arena);
+            if (places[offsets[i]])
+                add(places[offsets[i]] + place_offset, &values, i + 1, arena);
     }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena *) const override

--- a/tests/queries/0_stateless/03811_sparse_column_aggregation_with_sum.sql
+++ b/tests/queries/0_stateless/03811_sparse_column_aggregation_with_sum.sql
@@ -1,0 +1,21 @@
+CREATE TABLE 03811_sparse_column_aggregation_with_sum(key UInt128, val UInt16) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO 03811_sparse_column_aggregation_with_sum
+    SELECT number, number % 10000 = 0 FROM numbers(100000)
+    SETTINGS min_insert_block_size_rows = 1000,
+             max_block_size =1000,
+             max_threads = 2;
+
+SELECT key, sum(val) AS c
+FROM 03811_sparse_column_aggregation_with_sum
+GROUP BY key
+ORDER BY c DESC
+LIMIT 100
+FORMAT Null
+SETTINGS group_by_overflow_mode = 'any',
+         max_rows_to_group_by = 100,
+         group_by_two_level_threshold_bytes = 1,
+         group_by_two_level_threshold = 1,
+         max_threads = 2;
+
+DROP TABLE 03811_sparse_column_aggregation_with_sum;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix aggregation of sparse columns for `sum` and timeseries when `group_by_overflow_mode` is set to `any` (https://github.com/ClickHouse/ClickHouse/pull/95301 by @mkmkme)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [x] <!---ci_regression_common--> Fast suites (mostly <1h)
- [x] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [x] <!---ci_regression_alter--> Alter (1.5h)
- [x] <!---ci_regression_benchmark--> Benchmark (30m)
- [x] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [x] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [x] <!---ci_regression_rbac--> RBAC (1.5h)
- [x] <!---ci_regression_ssl_server--> SSL Server (1h)
- [x] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_tiered_storage--> Tiered Storage (2h)