### PR TITLE
Release CI/CD: Automated support for binary with symtable

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -126,8 +126,8 @@ jobs:
 
       - name: Process multiarch manifest
         run: |
-          echo "Re-tag multiarch image $IMAGE to altinityinfra/$COMPONENT:$NEW_TAG"
-          docker buildx imagetools create --tag "altinityinfra/$COMPONENT:$NEW_TAG" "$IMAGE"
+          echo "Re-tag multiarch image $IMAGE to altinity/$COMPONENT:$NEW_TAG"
+          docker buildx imagetools create --tag "altinity/$COMPONENT:$NEW_TAG" "$IMAGE"
 
           # Create directory for image archives
           mkdir -p image_archives
@@ -136,15 +136,15 @@ jobs:
           for PLATFORM in "linux/amd64" "linux/arm64"; do
             echo "Pulling and saving image for $PLATFORM..."
             # Pull the specific platform image
-            docker pull --platform $PLATFORM "altinityinfra/$COMPONENT:$NEW_TAG"
+            docker pull --platform $PLATFORM "altinity/$COMPONENT:$NEW_TAG"
 
             # Save the image to a tar file
             ARCH=$(echo $PLATFORM | cut -d'/' -f2)
-            docker save "altinityinfra/$COMPONENT:$NEW_TAG" -o "image_archives/${COMPONENT}-${NEW_TAG}-${ARCH}.tar"
+            docker save "altinity/$COMPONENT:$NEW_TAG" -o "image_archives/${COMPONENT}-${NEW_TAG}-${ARCH}.tar"
           done
 
           # Save manifest inspection
-          docker buildx imagetools inspect "altinityinfra/$COMPONENT:$NEW_TAG" > image_archives/manifest.txt
+          docker buildx imagetools inspect "altinity/$COMPONENT:$NEW_TAG" > image_archives/manifest.txt
 
           # Compress the archives
           cd image_archives

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -75,7 +75,22 @@ jobs:
 
           # Check if binary has symbol table (not stripped)
           echo "Checking if binary has symtable..."
-          docker cp "$CONTAINER_ID:/usr/bin/clickhouse" /tmp/clickhouse-check
+          # Try common binary locations
+          BINARY_PATH=""
+          for path in "/usr/bin/clickhouse" "/usr/bin/$COMPONENT"; do
+            if docker cp "$CONTAINER_ID:$path" /tmp/clickhouse-check 2>/dev/null; then
+              BINARY_PATH="$path"
+              break
+            fi
+          done
+
+          if [ -z "$BINARY_PATH" ]; then
+            echo "✗ Could not find clickhouse binary in container"
+            docker rm "$CONTAINER_ID"
+            exit 1
+          fi
+
+          echo "Found binary at $BINARY_PATH"
           if readelf -S /tmp/clickhouse-check | grep -q '\.symtab'; then
             echo "✓ Binary has symtable"
           else

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -69,9 +69,27 @@ jobs:
           echo "Pulling the image"
           docker pull $IMAGE
 
+          # Create container for version and symtable checks
+          echo "Creating container for checks..."
+          CONTAINER_ID=$(docker create $IMAGE $COMPONENT --version)
+
+          # Check if binary has symbol table (not stripped)
+          echo "Checking if binary has symtable..."
+          docker cp "$CONTAINER_ID:/usr/bin/clickhouse" /tmp/clickhouse-check
+          if readelf -S /tmp/clickhouse-check | grep -q '\.symtab'; then
+            echo "✓ Binary has symtable"
+          else
+            echo "✗ Binary is missing symtable"
+            docker rm "$CONTAINER_ID"
+            rm -f /tmp/clickhouse-check
+            exit 1
+          fi
+          rm -f /tmp/clickhouse-check
+
           # Get version and clean it up
           echo "Getting version from image..."
-          VERSION_OUTPUT=$(docker run --rm $IMAGE $COMPONENT --version)
+          VERSION_OUTPUT=$(docker start -a "$CONTAINER_ID")
+          docker rm "$CONTAINER_ID"
           echo "Raw version output: $VERSION_OUTPUT"
 
           # Extract just the version number

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -111,8 +111,8 @@ jobs:
 
       - name: Process multiarch manifest
         run: |
-          echo "Re-tag multiarch image $IMAGE to altinity/$COMPONENT:$NEW_TAG"
-          docker buildx imagetools create --tag "altinity/$COMPONENT:$NEW_TAG" "$IMAGE"
+          echo "Re-tag multiarch image $IMAGE to altinityinfra/$COMPONENT:$NEW_TAG"
+          docker buildx imagetools create --tag "altinityinfra/$COMPONENT:$NEW_TAG" "$IMAGE"
 
           # Create directory for image archives
           mkdir -p image_archives
@@ -121,15 +121,15 @@ jobs:
           for PLATFORM in "linux/amd64" "linux/arm64"; do
             echo "Pulling and saving image for $PLATFORM..."
             # Pull the specific platform image
-            docker pull --platform $PLATFORM "altinity/$COMPONENT:$NEW_TAG"
+            docker pull --platform $PLATFORM "altinityinfra/$COMPONENT:$NEW_TAG"
 
             # Save the image to a tar file
             ARCH=$(echo $PLATFORM | cut -d'/' -f2)
-            docker save "altinity/$COMPONENT:$NEW_TAG" -o "image_archives/${COMPONENT}-${NEW_TAG}-${ARCH}.tar"
+            docker save "altinityinfra/$COMPONENT:$NEW_TAG" -o "image_archives/${COMPONENT}-${NEW_TAG}-${ARCH}.tar"
           done
 
           # Save manifest inspection
-          docker buildx imagetools inspect "altinity/$COMPONENT:$NEW_TAG" > image_archives/manifest.txt
+          docker buildx imagetools inspect "altinityinfra/$COMPONENT:$NEW_TAG" > image_archives/manifest.txt
 
           # Compress the archives
           cd image_archives

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -326,7 +326,7 @@ jobs:
           sudo apt-add-repository --yes --update ppa:ansible/ansible
           sudo apt-get install -y ansible
           sudo ln -s /usr/bin/createrepo_c /usr/bin/createrepo
-          pip3 install boto3 botocore natsort
+          pip3 install boto3 botocore natsort --break-system-packages
 
       - name: Download packages
         run: |

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -331,12 +331,13 @@ jobs:
       - name: Install required packages
         run: |
           echo "Installing required packages..."
+          sudo add-apt-repository -y universe
           sudo apt-get update
           sudo apt-get install -y software-properties-common python3-pip dpkg-sig apt-utils gnupg rpm createrepo-c file
           sudo apt-add-repository --yes --update ppa:ansible/ansible
           sudo apt-get install -y ansible
           sudo ln -s /usr/bin/createrepo_c /usr/bin/createrepo
-          pip3 install boto3 botocore
+          pip3 install boto3 botocore natsort
 
       - name: Set up GPG passphrase
         run: |

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -328,11 +328,16 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: debug
+        run: |
+          lsb_release -a
+
       - name: Install required packages
         run: |
           echo "Installing required packages..."
           sudo add-apt-repository -y universe
           sudo apt-get update
+          apt-cache policy dpkg-sig
           sudo apt-get install -y software-properties-common python3-pip dpkg-sig apt-utils gnupg rpm createrepo-c file
           sudo apt-add-repository --yes --update ppa:ansible/ansible
           sudo apt-get install -y ansible

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -121,7 +121,7 @@ jobs:
 
           tar -xvf clickhouse-common-static.tgz
 
-          if readelf -S "clickhouse-common-static-${{ inputs.package_version }}-arm64/usr/bin/clickhouse" | grep -q '\.symtab'; then
+          if readelf -S "clickhouse-common-static-${{ inputs.package_version }}/usr/bin/clickhouse" | grep -q '\.symtab'; then
             echo "✓ Binary has symtable"
           else
             echo "✗ Binary is missing symtable"
@@ -225,7 +225,7 @@ jobs:
 
           tar -xvf clickhouse-common-static.tgz
 
-          if readelf -S "clickhouse-common-static-${{ inputs.package_version }}-amd64/usr/bin/clickhouse" | grep -q '\.symtab'; then
+          if readelf -S "clickhouse-common-static-${{ inputs.package_version }}/usr/bin/clickhouse" | grep -q '\.symtab'; then
             echo "✓ Binary has symtable"
           else
             echo "✗ Binary is missing symtable"

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -319,10 +319,10 @@ jobs:
           echo "Installing required packages..."
           sudo add-apt-repository -y universe
           sudo apt-get update
+          sudo apt-get install -y software-properties-common python3-pip apt-utils gnupg rpm createrepo-c file wget
           wget -q http://archive.ubuntu.com/ubuntu/pool/universe/d/dpkg-sig/dpkg-sig_0.13.1+nmu4_all.deb
           sudo dpkg -i dpkg-sig_0.13.1+nmu4_all.deb || sudo apt-get install -f -y
           rm dpkg-sig_0.13.1+nmu4_all.deb
-          sudo apt-get install -y software-properties-common python3-pip apt-utils gnupg rpm createrepo-c file
           sudo apt-add-repository --yes --update ppa:ansible/ansible
           sudo apt-get install -y ansible
           sudo ln -s /usr/bin/createrepo_c /usr/bin/createrepo

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -314,6 +314,20 @@ jobs:
           repository: Altinity/ClickHouse
           path: ClickHouse
 
+      - name: Install required packages
+        run: |
+          echo "Installing required packages..."
+          sudo add-apt-repository -y universe
+          sudo apt-get update
+          wget -q http://archive.ubuntu.com/ubuntu/pool/universe/d/dpkg-sig/dpkg-sig_0.13.1+nmu4_all.deb
+          sudo dpkg -i dpkg-sig_0.13.1+nmu4_all.deb || sudo apt-get install -f -y
+          rm dpkg-sig_0.13.1+nmu4_all.deb
+          sudo apt-get install -y software-properties-common python3-pip apt-utils gnupg rpm createrepo-c file
+          sudo apt-add-repository --yes --update ppa:ansible/ansible
+          sudo apt-get install -y ansible
+          sudo ln -s /usr/bin/createrepo_c /usr/bin/createrepo
+          pip3 install boto3 botocore natsort
+
       - name: Download packages
         run: |
           if ! aws s3 sync "${DEST_URL}/packages/ARM_PACKAGES/" /home/runner/.cache/tmp/packages --exact-timestamps; then
@@ -327,22 +341,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: debug
-        run: |
-          lsb_release -a
-
-      - name: Install required packages
-        run: |
-          echo "Installing required packages..."
-          sudo add-apt-repository -y universe
-          sudo apt-get update
-          apt-cache policy dpkg-sig
-          sudo apt-get install -y software-properties-common python3-pip dpkg-sig apt-utils gnupg rpm createrepo-c file
-          sudo apt-add-repository --yes --update ppa:ansible/ansible
-          sudo apt-get install -y ansible
-          sudo ln -s /usr/bin/createrepo_c /usr/bin/createrepo
-          pip3 install boto3 botocore natsort
 
       - name: Set up GPG passphrase
         run: |

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -217,7 +217,7 @@ jobs:
 
 
           echo "Downloading clickhouse-common-static tar..."
-          if ! aws s3 cp "${SRC_URL}/${ARM_PATH}/clickhouse-common-static-${{ inputs.package_version }}-amd64.tgz" clickhouse-common-static.tgz; then
+          if ! aws s3 cp "${DEST_URL}/packages/AMD_PACKAGES/clickhouse-common-static-${{ inputs.package_version }}-amd64.tgz" clickhouse-common-static.tgz; then
             echo "Failed to download clickhouse-common-static tar"
             exit 1
           fi

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -102,15 +102,43 @@ jobs:
           echo "Running clickhouse binary..."
           ./clickhouse -q'q'
 
-          echo "Stripping the binary..."
-          strip clickhouse -o clickhouse-stripped
+          echo "Downloading clickhouse-stripped binary..."
+          if ! aws s3 cp "${SRC_URL}/${ARM_PATH}/clickhouse-stripped" clickhouse-stripped; then
+            echo "Failed to download clickhouse-stripped binary"
+            exit 1
+          fi
 
+          chmod +x clickhouse-stripped
+
+          echo "Running clickhouse-stripped binary..."
+          ./clickhouse-stripped -q'q'
+
+          echo "Downloading clickhouse-common-static tar..."
+          if ! aws s3 cp "${SRC_URL}/${ARM_PATH}/clickhouse-common-static-${{ inputs.package_version }}-arm64.tgz" clickhouse-common-static.tgz; then
+            echo "Failed to download clickhouse-common-static tar"
+            exit 1
+          fi
+
+          tar -xvf clickhouse-common-static.tgz
+
+          if readelf -S "clickhouse-common-static-${{ inputs.package_version }}-arm64/usr/bin/clickhouse" | grep -q '\.symtab'; then
+            echo "✓ Binary has symtable"
+          else
+            echo "✗ Binary is missing symtable"
+            exit 1
+          fi
+
+          if ! aws s3 cp "${SRC_URL}/${ARM_PATH}/clickhouse-common-static.tar" clickhouse-common-static.tar; then
           echo "Uploading processed binaries..."
           if ! aws s3 cp clickhouse "${SRC_URL}/${ARM_PATH}/arm64-bin/non-self-extracting/"; then
             echo "Failed to upload clickhouse binary"
             exit 1
           fi
           if ! aws s3 cp clickhouse-stripped "${SRC_URL}/${ARM_PATH}/arm64-bin/non-self-extracting/"; then
+            echo "Failed to upload stripped clickhouse binary"
+            exit 1
+          fi
+          if ! aws s3 cp clickhouse-common-static-${{ inputs.package_version }}-arm64/usr/bin/clickhouse "${SRC_URL}/${ARM_PATH}/arm64-bin/non-self-extracting/clickhouse-with-symtable"; then
             echo "Failed to upload stripped clickhouse binary"
             exit 1
           fi
@@ -177,8 +205,32 @@ jobs:
           echo "Running clickhouse binary..."
           ./clickhouse -q'q'
 
-          echo "Stripping the binary..."
-          strip clickhouse -o clickhouse-stripped
+          echo "Downloading clickhouse-stripped binary..."
+          if ! aws s3 cp "${DEST_URL}/packages/AMD_PACKAGES/amd64-bin/clickhouse-stripped" clickhouse-stripped; then
+            echo "Failed to download clickhouse-stripped binary"
+            exit 1
+          fi
+
+          chmod +x clickhouse-stripped
+
+          echo "Running clickhouse-stripped binary..."
+          ./clickhouse-stripped -q'q'
+
+
+          echo "Downloading clickhouse-common-static tar..."
+          if ! aws s3 cp "${SRC_URL}/${ARM_PATH}/clickhouse-common-static-${{ inputs.package_version }}-amd64.tgz" clickhouse-common-static.tgz; then
+            echo "Failed to download clickhouse-common-static tar"
+            exit 1
+          fi
+
+          tar -xvf clickhouse-common-static.tgz
+
+          if readelf -S "clickhouse-common-static-${{ inputs.package_version }}-amd64/usr/bin/clickhouse" | grep -q '\.symtab'; then
+            echo "✓ Binary has symtable"
+          else
+            echo "✗ Binary is missing symtable"
+            exit 1
+          fi
 
           echo "Uploading processed binaries..."
           if ! aws s3 cp clickhouse "${DEST_URL}/packages/AMD_PACKAGES/amd64-bin/non-self-extracting/"; then
@@ -186,6 +238,10 @@ jobs:
             exit 1
           fi
           if ! aws s3 cp clickhouse-stripped "${DEST_URL}/packages/AMD_PACKAGES/amd64-bin/non-self-extracting/"; then
+            echo "Failed to upload stripped clickhouse binary"
+            exit 1
+          fi
+          if ! aws s3 cp clickhouse-common-static-${{ inputs.package_version }}-amd64/usr/bin/clickhouse "${DEST_URL}/packages/AMD_PACKAGES/amd64-bin/non-self-extracting/clickhouse-with-symtable"; then
             echo "Failed to upload stripped clickhouse binary"
             exit 1
           fi

--- a/.github/workflows/sign_and_release.yml
+++ b/.github/workflows/sign_and_release.yml
@@ -128,7 +128,6 @@ jobs:
             exit 1
           fi
 
-          if ! aws s3 cp "${SRC_URL}/${ARM_PATH}/clickhouse-common-static.tar" clickhouse-common-static.tar; then
           echo "Uploading processed binaries..."
           if ! aws s3 cp clickhouse "${SRC_URL}/${ARM_PATH}/arm64-bin/non-self-extracting/"; then
             echo "Failed to upload clickhouse binary"
@@ -138,8 +137,8 @@ jobs:
             echo "Failed to upload stripped clickhouse binary"
             exit 1
           fi
-          if ! aws s3 cp clickhouse-common-static-${{ inputs.package_version }}-arm64/usr/bin/clickhouse "${SRC_URL}/${ARM_PATH}/arm64-bin/non-self-extracting/clickhouse-with-symtable"; then
-            echo "Failed to upload stripped clickhouse binary"
+          if ! aws s3 cp "clickhouse-common-static-${{ inputs.package_version }}/usr/bin/clickhouse" "${SRC_URL}/${ARM_PATH}/arm64-bin/non-self-extracting/clickhouse-with-symtable"; then
+            echo "Failed to upload clickhouse-with-symtable binary"
             exit 1
           fi
 
@@ -241,7 +240,7 @@ jobs:
             echo "Failed to upload stripped clickhouse binary"
             exit 1
           fi
-          if ! aws s3 cp clickhouse-common-static-${{ inputs.package_version }}-amd64/usr/bin/clickhouse "${DEST_URL}/packages/AMD_PACKAGES/amd64-bin/non-self-extracting/clickhouse-with-symtable"; then
+          if ! aws s3 cp clickhouse-common-static-${{ inputs.package_version }}/usr/bin/clickhouse "${DEST_URL}/packages/AMD_PACKAGES/amd64-bin/non-self-extracting/clickhouse-with-symtable"; then
             echo "Failed to upload stripped clickhouse binary"
             exit 1
           fi

--- a/tests/ci/release/packaging/ansible/roles/update_bin_repo/tasks/main.yml
+++ b/tests/ci/release/packaging/ansible/roles/update_bin_repo/tasks/main.yml
@@ -15,6 +15,7 @@
       mv /home/runner/.cache/tmp/packages/{{ item }}-bin/clickhouse-stripped {{ local_repo_path }}/{{ repo_prefix }}bin-repo/{{ item }}/v{{ pkgver }}/self-extracting/clickhouse-stripped
       mv /home/runner/.cache/tmp/packages/{{ item }}-bin/non-self-extracting/clickhouse {{ local_repo_path }}/{{ repo_prefix }}bin-repo/{{ item }}/v{{ pkgver }}/non-self-extracting/clickhouse
       mv /home/runner/.cache/tmp/packages/{{ item }}-bin/non-self-extracting/clickhouse-stripped {{ local_repo_path }}/{{ repo_prefix }}bin-repo/{{ item }}/v{{ pkgver }}/non-self-extracting/clickhouse-stripped
+      mv /home/runner/.cache/tmp/packages/{{ item }}-bin/non-self-extracting/clickhouse-with-symtable {{ local_repo_path }}/{{ repo_prefix }}bin-repo/{{ item }}/v{{ pkgver }}/non-self-extracting/clickhouse-with-symtable
   loop:
     - amd64
     - arm64
@@ -27,10 +28,12 @@
     - amd64/v{{ pkgver }}/self-extracting/clickhouse-stripped
     - amd64/v{{ pkgver }}/non-self-extracting/clickhouse
     - amd64/v{{ pkgver }}/non-self-extracting/clickhouse-stripped
+    - amd64/v{{ pkgver }}/non-self-extracting/clickhouse-with-symtable
     - arm64/v{{ pkgver }}/self-extracting/clickhouse
     - arm64/v{{ pkgver }}/self-extracting/clickhouse-stripped
     - arm64/v{{ pkgver }}/non-self-extracting/clickhouse
     - arm64/v{{ pkgver }}/non-self-extracting/clickhouse-stripped
+    - arm64/v{{ pkgver }}/non-self-extracting/clickhouse-with-symtable
   when: (pkgver | regex_replace('^(\\d+).*$', '\\1')) is version('24', '>=')
 
 - name: Copy new binaries

--- a/tests/ci/release/packaging/dirindex/dirindexgen.py
+++ b/tests/ci/release/packaging/dirindex/dirindexgen.py
@@ -1,8 +1,10 @@
 #!/bin/env python3
 
 import argparse
+import re
 import textwrap
 import boto3
+from natsort import natsorted
 
 
 def folder_list_add(folders, key, value):
@@ -37,6 +39,16 @@ def folderjoin(items, slashes=False):
         if not result.endswith("/"):
             result = result + "/"
     return result
+
+
+def is_bin_repo_arch_folder(folder):
+    """
+    Check if the folder is a bin-repo architecture folder that should use natural sorting.
+    Matches patterns like: bin-repo/arm64, antalya-bin-repo/amd64, fips-bin-repo/arm64, etc.
+    """
+    # Match folders ending with (bin-repo|antalya-bin-repo|fips-bin-repo|hotfix-bin-repo)/(arm64|amd64)
+    pattern = r'(bin-repo|antalya-bin-repo|fips-bin-repo|hotfix-bin-repo)/(arm64|amd64)$'
+    return bool(re.search(pattern, folder))
 
 
 def main():
@@ -98,7 +110,13 @@ def main():
             parent_folder = folderjoin(folder.split("/")[:-1], slashes=True)
             indexdata.append(f'<a href="{parent_folder}">{parent_dir_str}</a>' +
                              f'{" ":{maxlen-len(parent_dir_str)}}   {"-":20}   {"-":20}\n')
-        for sub in subs:
+        # Apply natural sorting (descending) for bin-repo architecture folders
+        # to show newest versions first (e.g., v25.3 before v24.8 before v23.8)
+        if is_bin_repo_arch_folder(folder):
+            sorted_subs = list(reversed(natsorted(subs)))
+        else:
+            sorted_subs = sorted(subs)
+        for sub in sorted_subs:
             sub_path = folderjoin([folder, sub], slashes=True)
             indexdata.append(f'<a href="{sub_path}">{sub}/</a>{" ":{maxlen-len(sub)-1}}' +
                              f'   {"-":20}   {"-":20}\n')


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Automated upload and sanity check for binaries to include symtable.
- Fixes for package installation as signing runner was updated to ubuntu 24.04. 

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)