### PR TITLE
Antalya 26.1 - Fix pushing docker server

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4482,7 +4482,7 @@ jobs:
     secrets: inherit
     with:
       docker_image: altinityinfra/clickhouse-server
-      version: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+      version: ${{ fromJson(needs.config_workflow.outputs.data).JOB_KV_DATA.version.string }}
       tag-suffix: ${{ matrix.suffix }}
   GrypeScanKeeper:
       needs: [config_workflow, docker_keeper_image]
@@ -4491,7 +4491,7 @@ jobs:
       secrets: inherit
       with:
         docker_image: altinityinfra/clickhouse-keeper
-        version: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+        version: ${{ fromJson(needs.config_workflow.outputs.data).JOB_KV_DATA.version.string }}
 
   RegressionTestsRelease:
     needs: [config_workflow, build_amd_binary]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4672,7 +4672,7 @@ jobs:
     secrets: inherit
     with:
       docker_image: altinityinfra/clickhouse-server
-      version: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+      version: ${{ fromJson(needs.config_workflow.outputs.data).JOB_KV_DATA.version.string }}
       tag-suffix: ${{ matrix.suffix }}
   GrypeScanKeeper:
       needs: [config_workflow, docker_keeper_image]
@@ -4681,7 +4681,7 @@ jobs:
       secrets: inherit
       with:
         docker_image: altinityinfra/clickhouse-keeper
-        version: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+        version: ${{ fromJson(needs.config_workflow.outputs.data).JOB_KV_DATA.version.string }}
 
   RegressionTestsRelease:
     needs: [config_workflow, build_amd_binary]

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -1207,7 +1207,7 @@ jobs:
     secrets: inherit
     with:
       docker_image: altinityinfra/clickhouse-server
-      version: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+      version: ${{ fromJson(needs.config_workflow.outputs.data).JOB_KV_DATA.version.string }}
       tag-suffix: ${{ matrix.suffix }}
   GrypeScanKeeper:
       needs: [config_workflow, docker_keeper_image]
@@ -1216,7 +1216,7 @@ jobs:
       secrets: inherit
       with:
         docker_image: altinityinfra/clickhouse-keeper
-        version: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+        version: ${{ fromJson(needs.config_workflow.outputs.data).JOB_KV_DATA.version.string }}
 
   SignRelease:
     needs: [config_workflow, build_amd_release]

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1045,7 +1045,7 @@ class JobConfigs:
     docker_keeper = Job.Config(
         name=JobNames.DOCKER_KEEPER,
         runs_on=RunnerLabels.STYLE_CHECK_AMD,
-        command="python3 ./ci/jobs/docker_server.py --tag-type head --allow-build-reuse",
+        command="python3 ./ci/jobs/docker_server.py --tag-type head --allow-build-reuse --push",
         digest_config=Job.CacheDigestConfig(
             include_paths=[
                 "./ci/jobs/docker_server.py",

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -310,6 +310,7 @@ def main():
     version_dict = None
     if not info.is_local_run:
         version_dict = info.get_kv_data("version")
+        print(f"Version dict from kv data: {version_dict}")
     if not version_dict:
         version_dict = CHVersion.get_current_version_as_dict()
         if not info.is_local_run:
@@ -319,6 +320,7 @@ def main():
             info.add_workflow_report_message(
                 "WARNING: ClickHouse version has not been found in workflow kv storage"
             )
+        print(f"Version dict from repo: {version_dict}")
     assert version_dict
 
     if not info.is_local_run:

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -350,7 +350,7 @@ def main():
         push = True
 
     image = DockerImageData(image_repo, image_path)
-    tags = [f'{info.pr_number}-{version_dict["describe"]}']
+    tags = [f'{info.pr_number}-{version_dict["string"]}']
     repo_urls = {}
     direct_urls: Dict[str, List[str]] = {}
 

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -395,7 +395,7 @@ def main():
                     repo_urls,
                     os_,
                     tag,
-                    version_dict["describe"],
+                    version_dict["string"],
                     direct_urls,
                     run_url=info.run_url,
                     sha=info.sha,

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -58,10 +58,10 @@ def docker_login(relogin: bool = True) -> None:
         "docker system info | grep --quiet -E 'Username|Registry'"
     ):
         Shell.check(
-            "docker login --username 'robotclickhouse' --password-stdin",
+            "docker login --username 'altinityinfra' --password-stdin",
             strict=True,
             stdin_str=Secret.Config(
-                "dockerhub_robot_password", type=Secret.Type.AWS_SSM_PARAMETER
+                "DOCKER_PASSWORD", type=Secret.Type.GH_SECRET
             ).get_value(),
             encoding="utf-8",
         )
@@ -348,7 +348,7 @@ def main():
         push = True
 
     image = DockerImageData(image_repo, image_path)
-    tags = [f'{info.pr_number}-{version_dict["string"]}']
+    tags = [f'{info.pr_number}-{version_dict["describe"]}']
     repo_urls = {}
     direct_urls: Dict[str, List[str]] = {}
 

--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -65,6 +65,10 @@ SET(VERSION_STRING {string})
     @classmethod
     def get_current_version_as_dict(cls):
         version = cls.get_release_version_as_dict()
+
+        # NOTE (strtgbb): Just return, no need for the below logic
+        return version
+
         info = Info()
         try:
             # Check if the commit is directly on the first-parent chain

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -49,7 +49,7 @@ class AltinityWorkflowTemplates:
     secrets: inherit
     with:
       docker_image: altinityinfra/clickhouse-server
-      version: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+      version: ${{ fromJson(needs.config_workflow.outputs.data).JOB_KV_DATA.version.string }}
       tag-suffix: ${{ matrix.suffix }}
   GrypeScanKeeper:
       needs: [config_workflow, docker_keeper_image]
@@ -58,7 +58,7 @@ class AltinityWorkflowTemplates:
       secrets: inherit
       with:
         docker_image: altinityinfra/clickhouse-keeper
-        version: ${{ fromJson(needs.config_workflow.outputs.data).custom_data.version.string }}
+        version: ${{ fromJson(needs.config_workflow.outputs.data).JOB_KV_DATA.version.string }}
 """,
         "Regression": r"""
   RegressionTestsRelease:


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Docker server job was unable to locate credentials.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)