### PR TITLE
25.8.16 Stable: Update regression commit hash and mark known flaky tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4179,7 +4179,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester
-      commit: 4a2660c75904708cd2b35a7d8ed1d5f075db6218
+      commit: 82f98d70609e2ca20da00a10ae2fc9060a1a6769
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -4191,7 +4191,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester-aarch64
-      commit: 4a2660c75904708cd2b35a7d8ed1d5f075db6218
+      commit: 82f98d70609e2ca20da00a10ae2fc9060a1a6769
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4179,7 +4179,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester
-      commit: 82f98d70609e2ca20da00a10ae2fc9060a1a6769
+      commit: 979bb27171f92724bcd8f086989ba623f2e03fdc
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -4191,7 +4191,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester-aarch64
-      commit: 82f98d70609e2ca20da00a10ae2fc9060a1a6769
+      commit: 979bb27171f92724bcd8f086989ba623f2e03fdc
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4044,7 +4044,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester
-      commit: 4a2660c75904708cd2b35a7d8ed1d5f075db6218
+      commit: 82f98d70609e2ca20da00a10ae2fc9060a1a6769
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -4056,7 +4056,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester-aarch64
-      commit: 4a2660c75904708cd2b35a7d8ed1d5f075db6218
+      commit: 82f98d70609e2ca20da00a10ae2fc9060a1a6769
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4044,7 +4044,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester
-      commit: 82f98d70609e2ca20da00a10ae2fc9060a1a6769
+      commit: 979bb27171f92724bcd8f086989ba623f2e03fdc
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300
@@ -4056,7 +4056,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester-aarch64
-      commit: 82f98d70609e2ca20da00a10ae2fc9060a1a6769
+      commit: 979bb27171f92724bcd8f086989ba623f2e03fdc
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 300

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -35,7 +35,7 @@ class AltinityWorkflowTemplates:
           echo "Workflow Run Report: [View Report]($REPORT_LINK)" >> $GITHUB_STEP_SUMMARY
 """
     # Additional jobs
-    REGRESSION_HASH = "4a2660c75904708cd2b35a7d8ed1d5f075db6218"
+    REGRESSION_HASH = "82f98d70609e2ca20da00a10ae2fc9060a1a6769"
     ALTINITY_JOBS = {
         "GrypeScan": r"""
   GrypeScanServer:

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -35,7 +35,7 @@ class AltinityWorkflowTemplates:
           echo "Workflow Run Report: [View Report]($REPORT_LINK)" >> $GITHUB_STEP_SUMMARY
 """
     # Additional jobs
-    REGRESSION_HASH = "82f98d70609e2ca20da00a10ae2fc9060a1a6769"
+    REGRESSION_HASH = "979bb27171f92724bcd8f086989ba623f2e03fdc"
     ALTINITY_JOBS = {
         "GrypeScan": r"""
   GrypeScanServer:

--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -175,6 +175,12 @@
   reason: 'FIXME: Unstable in current version. Fixed in recent upstream.'
 - name: test_dirty_pages_force_purge/test.py::test_dirty_pages_force_purge
   reason: 'KNOWN: https://github.com/Altinity/ClickHouse/issues/1369'
+- name: test_async_load_databases/test.py::test_materialized_views_cascaded_multiple
+  reason: 'KNOWN: Flaky upstream test. Fixed in upstream PR #88573 but not backported to 25.8.'
+  message: "AssertionError"
+- name: test_async_load_databases/test.py::test_materialized_views_replicated
+  reason: 'KNOWN: Flaky upstream test. Fixed in upstream PR #88573 but not backported to 25.8.'
+  message: 'DATABASE_ALREADY_EXISTS'
 
 # Regex rules should be ordered from most specific to least specific.
 # regex: true applies to name, message, and not_message fields, but not to reason or check_types fields.


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)