### PR TITLE
25.3.8 fips: try to build FIPS version in CI

### DIFF
--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -45,6 +45,26 @@ docker cp $id:$lib_dir/include $OUTPUT_DIR
 docker rm $id"
 )
 
+# Verification program compiled inside the Docker build to confirm AWS-LC version
+file(WRITE ${AWSLC_BUILD_DIR}/check_version.c
+[=[
+#include <stdio.h>
+#include <string.h>
+const char* awslc_version_string(void);
+int expect(const char * expected, const char * actual) {
+    if (strcmp(expected, actual) == 0)
+        return 0;
+    printf("expected %s but got %s", expected, actual);
+    return 1;
+}
+int main(int argc, char * argv[]) {
+    int result = 0;
+    if (argc > 1)
+        result |= expect((const char*)argv[1], awslc_version_string());
+    return result;
+}
+]=])
+
 # patch a single file in krb5 that relies on file missing from this version of BoringSSL
 # SET(krb5_filb_to_patch ${PROJECT_SOURCE_DIR}/contrib/krb5/src/lib/crypto/openssl/enc_provider/aes.c)
 # message("Patching ${krb5_filb_to_patch} to allow building against older version of BoringSSL")

--- a/contrib/openssl-cmake/Dockerfile
+++ b/contrib/openssl-cmake/Dockerfile
@@ -20,25 +20,10 @@ RUN cd /aws-lc-AWS-LC-FIPS-2.0.0 \
     && make
 
 # Check that version is reported correctly
+COPY check_version.c /tmp/check_version.c
 RUN cd /aws-lc-AWS-LC-FIPS-2.0.0/build \
-    && <<C_CODE gcc -x c - -o ./check_version -L./ssl -l:libssl.a -L./crypto -l:libcrypto.a && ./check_version 'AWS-LC FIPS 2.0.0'
-#include <stdio.h>
-#include <string.h>
-const char* awslc_version_string(void);
-int expect(const char * expected, const char * actual) {
-    if (strcmp(expected, actual) == 0)
-        return 0;
-    printf("expected %s but got %s", expected, actual);
-    return 1;
-}
-int main(int argc, char * argv[]) {
-    int result = 0;
-    if (argc > 1)
-        result |= expect((const char*)argv[1], awslc_version_string());
-    return result;
-};
-C_CODE
-RUN
+    && gcc /tmp/check_version.c -o ./check_version -L./ssl -l:libssl.a -L./crypto -l:libcrypto.a \
+    && ./check_version 'AWS-LC FIPS 2.0.0'
 
 #check is in FIPS mode
 RUN test $(/aws-lc-AWS-LC-FIPS-2.0.0/build/tool/bssl isfips) = 1

--- a/docker/packager/binary-builder/Dockerfile
+++ b/docker/packager/binary-builder/Dockerfile
@@ -1,6 +1,10 @@
 # docker build -t altinityinfra/binary-builder .
 ARG FROM_TAG=latest
 FROM altinityinfra/fasttest:$FROM_TAG
+
+# Refresh the Kitware GPG key inherited from the base image (may have expired)
+RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --batch --dearmor -o /etc/apt/trusted.gpg.d/kitware.gpg
+
 # NOTE(strtgbb) Not sure where LLVM_VERSION is set, so we set it here
 ENV LLVM_VERSION=19
 ENV CC=clang-${LLVM_VERSION}

--- a/docker/packager/binary-builder/Dockerfile
+++ b/docker/packager/binary-builder/Dockerfile
@@ -3,7 +3,8 @@ ARG FROM_TAG=latest
 FROM altinityinfra/fasttest:$FROM_TAG
 
 # Refresh the Kitware GPG key inherited from the base image (may have expired)
-RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --batch --dearmor -o /etc/apt/trusted.gpg.d/kitware.gpg
+RUN rm -f /etc/apt/trusted.gpg.d/kitware.gpg \
+    && curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --batch --dearmor -o /etc/apt/trusted.gpg.d/kitware.gpg
 
 # NOTE(strtgbb) Not sure where LLVM_VERSION is set, so we set it here
 ENV LLVM_VERSION=19
@@ -47,7 +48,9 @@ RUN ARCH=$(uname -m) && \
     rustup target add riscv64gc-unknown-linux-gnu
 
 # A cross-linker for RISC-V 64 (we need it, because LLVM's LLD does not work):
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends software-properties-common \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
     && apt-get update \
     && apt-get install --yes \
         binutils-riscv64-linux-gnu \

--- a/docker/packager/binary-builder/Dockerfile
+++ b/docker/packager/binary-builder/Dockerfile
@@ -55,6 +55,20 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
+# Docker CLI for building AWS-LC FIPS inside a nested container (Docker-in-Docker via socket mount)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
+
 # Download toolchain and SDK for Darwin
 RUN curl -sL -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz
 

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -280,8 +280,13 @@ def parse_env_variables(
         cmake_flags.append("-DCMAKE_INSTALL_PREFIX=/usr")
         cmake_flags.append("-DCMAKE_INSTALL_SYSCONFDIR=/etc")
         cmake_flags.append("-DCMAKE_INSTALL_LOCALSTATEDIR=/var")
+
+        # FIPS mode begin
         cmake_flags.append("-DFIPS_CLICKHOUSE=1")
         cmake_flags.append("-DENABLE_LIBRARIES=0")
+        cmake_flags.append("-DENABLE_NURAFT=1")
+        # FIPS mode end
+
         # Reduce linking and building time by avoid *install/all dependencies
         cmake_flags.append("-DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON")
         if is_release_build(debug_build, package_type, sanitizer, coverage):

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -269,6 +269,8 @@ def parse_env_variables(
         cmake_flags.append("-DCMAKE_INSTALL_PREFIX=/usr")
         cmake_flags.append("-DCMAKE_INSTALL_SYSCONFDIR=/etc")
         cmake_flags.append("-DCMAKE_INSTALL_LOCALSTATEDIR=/var")
+        cmake_flags.append("-DFIPS_CLICKHOUSE=1")
+        cmake_flags.append("-DENABLE_LIBRARIES=0")
         # Reduce linking and building time by avoid *install/all dependencies
         cmake_flags.append("-DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON")
         if is_release_build(debug_build, package_type, sanitizer, coverage):

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -104,9 +104,20 @@ def run_docker_image_with_env(
     if ccache_dir is None:
         ccache_mount = ""
 
+    docker_sock = "/var/run/docker.sock"
+    docker_sock_opts = ""
+    if os.path.exists(docker_sock):
+        docker_sock_opts = f"--volume={docker_sock}:{docker_sock}"
+        try:
+            sock_gid = os.stat(docker_sock).st_gid
+            docker_sock_opts += f" --group-add {sock_gid}"
+        except OSError:
+            pass
+
     cmd = (
         f"docker run --network=host --user={user} --rm {ccache_mount} "
         f"--volume={output_dir}:/output --volume={ch_root}:/build {env_part} "
+        f"{docker_sock_opts} "
         f" {extra_parts} "
         f"--volume={cargo_cache_dir}:/rust/cargo/registry {interactive} {image_name} /build/docker/packager/binary-builder/build.sh"
     )

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -285,6 +285,7 @@ def parse_env_variables(
         cmake_flags.append("-DFIPS_CLICKHOUSE=1")
         cmake_flags.append("-DENABLE_LIBRARIES=0")
         cmake_flags.append("-DENABLE_NURAFT=1")
+        cmake_flags.append("-DENABLE_YAML_CPP=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)