### PR TITLE
25.3-FIPS: Contribs - Fixed building AMQP contrib

### DIFF
--- a/contrib/amqpcpp-cmake/CMakeLists.txt
+++ b/contrib/amqpcpp-cmake/CMakeLists.txt
@@ -45,4 +45,10 @@ add_library(_amqp-cpp ${SRCS})
 
 target_include_directories (_amqp-cpp SYSTEM BEFORE PUBLIC "${LIBRARY_DIR}/include" "${LIBRARY_DIR}")
 target_link_libraries (_amqp-cpp PUBLIC OpenSSL::Crypto OpenSSL::SSL ch_contrib::uv)
+
+# errno.h should've been explicitly included in sslerrorprinter.cpp, hack to fix it:
+target_compile_options (_amqp-cpp
+    PRIVATE -includeerrno.h
+)
+
 add_library (ch_contrib::amqp_cpp ALIAS _amqp-cpp)

--- a/contrib/openssl-cmake/include/evp_API_shim.h
+++ b/contrib/openssl-cmake/include/evp_API_shim.h
@@ -64,4 +64,9 @@ inline void EVP_CIPHER_free(EVP_CIPHER *cipher)
     (void)(cipher);
 }
 
+// Required for contrib/minizip-ng/mz_crypt_openssl.c mz_crypt_init()
+// since there are no dynamically loaded engines, disabling the flag is Ok:
+// all engines are initialized anyway
+# define OPENSSL_INIT_ENGINE_ALL_BUILTIN 0
+
 #endif

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -283,9 +283,13 @@ def parse_env_variables(
 
         # FIPS mode begin
         cmake_flags.append("-DFIPS_CLICKHOUSE=1")
+        # TODO(vnemkov): this is transitional measures, make sure to either enable all libraries or disable some selectively before releasing
         cmake_flags.append("-DENABLE_LIBRARIES=0")
         cmake_flags.append("-DENABLE_NURAFT=1")
         cmake_flags.append("-DENABLE_YAML_CPP=1")
+        cmake_flags.append("-DENABLE_AMQPCPP=1")
+        cmake_flags.append("-DENABLE_MINIZIP=1")
+        cmake_flags.append("-DENABLE_CASSANDRA=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)