### PR TITLE
25.3.8-fips: enabling libraries (mkmkme)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -217,7 +217,7 @@
 	url = https://github.com/ClickHouse/hive-metastore
 [submodule "contrib/azure"]
 	path = contrib/azure
-	url = https://github.com/ClickHouse/azure-sdk-for-cpp
+	url = https://github.com/mkmkme/azure-sdk-for-cpp
 [submodule "contrib/minizip-ng"]
 	path = contrib/minizip-ng
 	url = https://github.com/zlib-ng/minizip-ng

--- a/.gitmodules
+++ b/.gitmodules
@@ -217,7 +217,7 @@
 	url = https://github.com/ClickHouse/hive-metastore
 [submodule "contrib/azure"]
 	path = contrib/azure
-	url = https://github.com/mkmkme/azure-sdk-for-cpp
+	url = https://github.com/Altinity/azure-sdk-for-cpp
 [submodule "contrib/minizip-ng"]
 	path = contrib/minizip-ng
 	url = https://github.com/zlib-ng/minizip-ng

--- a/contrib/curl-cmake/curl_config.h
+++ b/contrib/curl-cmake/curl_config.h
@@ -55,6 +55,13 @@
 #define USE_THREADS_POSIX
 #define USE_ARES
 
+/**
+ * evp_API_shim.h includes <openssl/evp.h> which transitively includes <stdbool.h>.
+ * This defines `bool` as `_Bool`, but this does not define `HAVE_BOOL_T`.
+ * Let's define it manually.
+ */
+#define HAVE_BOOL_T
+
 #ifdef __illumos__
 #define HAVE_POSIX_STRERROR_R 1
 #define HAVE_STRERROR_R 1

--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -123,6 +123,11 @@ target_compile_options(ssl INTERFACE
   -DOPENSSL_IS_BORINGSSL=1
 )
 
+# This is taken from the later in the file when FIPS_CLICKHOUSE is not defined.
+# Without it, the build fails due to using API deprecated in C++23
+target_compile_options(global-group INTERFACE "-Wno-deprecated-declarations")
+target_compile_options(global-group INTERFACE "-Wno-poison-system-directories")
+
 else() # FIPS_CLICKHOUSE
 
 

--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -102,7 +102,7 @@ set_target_properties(crypto PROPERTIES
 )
 
 add_library(ssl UNKNOWN IMPORTED GLOBAL)
-add_dependencies(ssl _crypto)
+add_dependencies(ssl crypto)
 set_target_properties(ssl PROPERTIES
     IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
     IMPORTED_LOCATION "${AWSLC_BINARIES_DIR}/libssl.a"

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -286,6 +286,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_LIBRARIES=0")
         cmake_flags.append("-DENABLE_NURAFT=1")
         cmake_flags.append("-DENABLE_YAML_CPP=1")
+        cmake_flags.append("-DENABLE_AWS_S3=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -288,6 +288,9 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_YAML_CPP=1")
         cmake_flags.append("-DENABLE_S2_GEOMETRY=1")
         cmake_flags.append("-DENABLE_AWS_S3=1")
+        cmake_flags.append("-DENABLE_THRIFT=1")
+        cmake_flags.append("-DENABLE_PARQUET=1")
+        cmake_flags.append("-DENABLE_BROTLI=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -286,6 +286,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_LIBRARIES=0")
         cmake_flags.append("-DENABLE_NURAFT=1")
         cmake_flags.append("-DENABLE_YAML_CPP=1")
+        cmake_flags.append("-DENABLE_S2_GEOMETRY=1")
         cmake_flags.append("-DENABLE_AWS_S3=1")
         # FIPS mode end
 

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -292,6 +292,8 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_THRIFT=1")
         cmake_flags.append("-DENABLE_PARQUET=1")
         cmake_flags.append("-DENABLE_BROTLI=1")
+        cmake_flags.append("-DENABLE_CURL=1")
+        cmake_flags.append("-DENABLE_AZURE_BLOB_STORAGE=1")
         cmake_flags.append("-DENABLE_AMQPCPP=1")
         cmake_flags.append("-DENABLE_MINIZIP=1")
         cmake_flags.append("-DENABLE_CASSANDRA=1")

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -294,6 +294,8 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_BROTLI=1")
         cmake_flags.append("-DENABLE_CURL=1")
         cmake_flags.append("-DENABLE_AZURE_BLOB_STORAGE=1")
+        cmake_flags.append("-DENABLE_GRPC=1")
+        cmake_flags.append("-DENABLE_GOOGLE_CLOUD_CPP=1")
         cmake_flags.append("-DENABLE_AMQPCPP=1")
         cmake_flags.append("-DENABLE_MINIZIP=1")
         cmake_flags.append("-DENABLE_CASSANDRA=1")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)