### PR TITLE
Antalya 25.8 - Simplify server image, update broken tests and fix regression job.name

### DIFF
--- a/.github/workflows/regression-reusable-suite.yml
+++ b/.github/workflows/regression-reusable-suite.yml
@@ -74,6 +74,7 @@ jobs:
       SUITE_EXECUTABLE: ${{ inputs.suite_executable }}
       STORAGE: ${{ inputs.storage_path }}
       PART: ${{ inputs.part }}
+      REPORT_JOB_NAME: ${{ format('{0}{1}', inputs.job_name != '' && inputs.job_name || inputs.suite_name, inputs.part != '' && format('_{0}', inputs.part) || '') }}
       # AWS credentials
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -98,7 +99,7 @@ jobs:
         --local
         --collect-service-logs
         --output ${{ inputs.output_format }}
-        --attr project="${GITHUB_REPOSITORY}" project.id="${GITHUB_REPOSITORY_ID}" user.name="${GITHUB_ACTOR}" version="${{ fromJson(inputs.workflow_config).custom_data.version.string }}" package="$clickhouse_path" repository="https://github.com/Altinity/clickhouse-regression" commit.hash="$(git rev-parse HEAD)" job.name=$GITHUB_JOB job.retry=$GITHUB_RUN_ATTEMPT job.url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" arch="$(uname -i)"
+        --attr project="${GITHUB_REPOSITORY}" project.id="${GITHUB_REPOSITORY_ID}" user.name="${GITHUB_ACTOR}" version="${{ fromJson(inputs.workflow_config).custom_data.version.string }}" package="$clickhouse_path" repository="https://github.com/Altinity/clickhouse-regression" commit.hash="$(git rev-parse HEAD)" job.name="$REPORT_JOB_NAME" job.retry=$GITHUB_RUN_ATTEMPT job.url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" arch="$(uname -i)"
         --cicd
         --log raw.log
         ${{ inputs.flags != 'none' && inputs.flags || ''}}

--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -35,11 +35,8 @@ RUN arch=${TARGETARCH:-amd64} \
         arm64) ln -sf /lib/ld-2.35.so /lib/ld-linux-aarch64.so.1 ;; \
     esac
 
-# lts / testing / prestable / etc
-ARG REPO_CHANNEL="stable"
-ARG REPOSITORY="https://packages.clickhouse.com/tgz/${REPO_CHANNEL}"
-ARG VERSION="25.7.4.11"
-ARG PACKAGES="clickhouse-keeper"
+# NOTE (strtgbb): Removed install methods other than direct URL install to tidy the Dockerfile
+
 ARG DIRECT_DOWNLOAD_URLS=""
 
 # user/group precreated explicitly with fixed uid/gid on purpose.
@@ -63,12 +60,7 @@ RUN arch=${TARGETARCH:-amd64} \
             && wget -c -q "$url" \
         ; done \
     else \
-        for package in ${PACKAGES}; do \
-            cd /tmp \
-            && echo "Get ${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
-            && wget -c -q "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
-            && wget -c -q "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz.sha512" \
-        ; done \
+        exit 1; \
     fi \
     && cat *.tgz.sha512 | sha512sum -c \
     && for file in *.tgz; do \

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -32,11 +32,10 @@ RUN arch=${TARGETARCH:-amd64} \
         arm64) ln -sf /lib/ld-2.35.so /lib/ld-linux-aarch64.so.1 ;; \
     esac
 
-# lts / testing / prestable / etc
-ARG REPO_CHANNEL="stable"
-ARG REPOSITORY="https://packages.clickhouse.com/tgz/${REPO_CHANNEL}"
-ARG VERSION="25.7.4.11"
-ARG PACKAGES="clickhouse-client clickhouse-server clickhouse-common-static"
+
+
+# NOTE (strtgbb): Removed install methods other than direct URL install to tidy the Dockerfile
+
 ARG DIRECT_DOWNLOAD_URLS=""
 
 # user/group precreated explicitly with fixed uid/gid on purpose.
@@ -59,11 +58,7 @@ RUN arch=${TARGETARCH:-amd64} \
             && wget -c -q "$url" \
         ; done \
     else \
-        for package in ${PACKAGES}; do \
-            echo "Get ${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
-            && wget -c -q "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
-            && wget -c -q "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz.sha512" \
-        ; done \
+        exit 1; \
     fi \
     && cat *.tgz.sha512 | sed 's:/output/:/tmp/:' | sha512sum -c \
     && for file in *.tgz; do \

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -30,23 +30,12 @@ RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list 
     && busybox --install -s \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 
-ARG REPO_CHANNEL="stable"
-ARG REPOSITORY="deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb ${REPO_CHANNEL} main"
-ARG VERSION="25.7.4.11"
-ARG PACKAGES="clickhouse-client clickhouse-server clickhouse-common-static"
-
 #docker-official-library:off
 # The part between `docker-official-library` tags is related to our builds
 
-# set non-empty deb_location_url url to create a docker image
-# from debs created by CI build, for example:
-# docker build . --network host --build-arg version="21.4.1.6282" --build-arg deb_location_url="https://..." -t ...
-ARG deb_location_url=""
-ARG DIRECT_DOWNLOAD_URLS=""
+# NOTE (strtgbb): Removed install methods other than direct URL install to tidy the Dockerfile
 
-# set non-empty single_binary_location_url to create docker image
-# from a single binary url (useful for non-standard builds - with sanitizers, for arm64).
-ARG single_binary_location_url=""
+ARG DIRECT_DOWNLOAD_URLS=""
 
 ARG TARGETARCH
 
@@ -62,64 +51,7 @@ RUN if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
         && rm -rf /tmp/* ; \
     fi
 
-# install from a web location with deb packages
-RUN arch="${TARGETARCH:-amd64}" \
-    && if [ -n "${deb_location_url}" ]; then \
-        echo "installing from custom url with deb packages: ${deb_location_url}" \
-        && rm -rf /tmp/clickhouse_debs \
-        && mkdir -p /tmp/clickhouse_debs \
-        && for package in ${PACKAGES}; do \
-            { wget --progress=bar:force:noscroll "${deb_location_url}/${package}_${VERSION}_${arch}.deb" -P /tmp/clickhouse_debs || \
-                wget --progress=bar:force:noscroll "${deb_location_url}/${package}_${VERSION}_all.deb" -P /tmp/clickhouse_debs ; } \
-            || exit 1 \
-        ; done \
-        && dpkg -i /tmp/clickhouse_debs/*.deb \
-        && rm -rf /tmp/* ; \
-    fi
-
-# install from a single binary
-RUN if [ -n "${single_binary_location_url}" ]; then \
-        echo "installing from single binary url: ${single_binary_location_url}" \
-        && rm -rf /tmp/clickhouse_binary \
-        && mkdir -p /tmp/clickhouse_binary \
-        && wget --progress=bar:force:noscroll "${single_binary_location_url}" -O /tmp/clickhouse_binary/clickhouse \
-        && chmod +x /tmp/clickhouse_binary/clickhouse \
-        && /tmp/clickhouse_binary/clickhouse install --user "clickhouse" --group "clickhouse" \
-        && rm -rf /tmp/* ; \
-    fi
-
-# The rest is the same in the official docker and in our build system
-#docker-official-library:on
-
-# A fallback to installation from ClickHouse repository
-# It works unless the clickhouse binary already exists
-RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
-    ; apt-get update \
-    && apt-get install --yes --no-install-recommends \
-        dirmngr \
-        gnupg2 \
-    && mkdir -p /etc/apt/sources.list.d \
-    && GNUPGHOME=$(mktemp -d) \
-    && GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
-        --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
-        --keyserver hkp://keyserver.ubuntu.com:80 \
-        --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 \
-    && rm -rf "$GNUPGHOME" \
-    && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
-    && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \
-    && echo "installing from repository: ${REPOSITORY}" \
-    && apt-get update \
-    && for package in ${PACKAGES}; do \
-        packages="${packages} ${package}=${VERSION}" \
-    ; done \
-    && apt-get install --yes --no-install-recommends ${packages} || exit 1 \
-    && rm -rf \
-        /var/lib/apt/lists/* \
-        /var/cache/debconf \
-        /tmp/* \
-    && apt-get autoremove --purge -yq dirmngr gnupg2 \
-    && chmod ugo+Xrw -R /etc/clickhouse-server /etc/clickhouse-client
-# The last chmod is here to make the next one is No-op in docker official library Dockerfile
+# NOTE (strtgbb): Removed install methods other than direct URL install to tidy the Dockerfile
 
 # post install
 # we need to allow "others" access to clickhouse folder, because docker container

--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -43,7 +43,7 @@
   - tsan
   - msan
 - name: 03321_clickhouse_local_initialization_not_too_slow_even_under_sanitizers
-  reason: INVESTIGATE - Unstable on msan
+  reason: INVESTIGATE - Unstable on msan, tsan
   message: result differs with reference
   check_types:
   - msan
@@ -79,6 +79,10 @@
 - name: 00024_random_counters
   reason: INVESTIGATE - random timeout
   message: Timeout! Processes left in process group
+- name: 03211_nested_json_merges
+  reason: KNOWN - Unstable upstream
+- name: 03644_object_storage_correlated_subqueries
+  reason: KNOWN - Unstable in upstream 25.8.
 - name: test_storage_s3_queue/test_5.py::test_migration[1-s3queue_]
   reason: KNOWN - Sometimes fails due to test order
   message: 'Failed: Timeout >900.0s'
@@ -187,9 +191,17 @@
   reason: 'KNOWN: Occasional timeout'
   message: docker_compose_iceberg_hms_catalog.yml', '--verbose', 'up', '-d']' timed out after 300 seconds
 - name: test_keeper_memory_soft_limit/test.py::test_soft_limit_create
-  reason: 'INVESTIGATE: Out of Memory or startup instability'
+  reason: 'FIXME: Unstable in current version. Fixed in recent upstream.'
 - name: test_s3_cache_locality/test.py::test_cache_locality[0]
   reason: 'INVESTIGATE: Timeout or AssertionError'
+- name: test_dirty_pages_force_purge/test.py::test_dirty_pages_force_purge
+  reason: 'KNOWN: https://github.com/Altinity/ClickHouse/issues/1369'
+- name: test_async_load_databases/test.py::test_materialized_views_cascaded_multiple
+  reason: 'KNOWN: Flaky upstream test. Fixed in upstream PR #88573 but not backported to 25.8.'
+  message: AssertionError
+- name: test_async_load_databases/test.py::test_materialized_views_replicated
+  reason: 'KNOWN: Flaky upstream test. Fixed in upstream PR #88573 but not backported to 25.8.'
+  message: 'DATABASE_ALREADY_EXISTS'
 
 # Regex rules should be ordered from most specific to least specific.
 # regex: true applies to name, message, and not_message fields, but not to reason or check_types fields.

--- a/tests/ci/docker_server.py
+++ b/tests/ci/docker_server.py
@@ -184,8 +184,8 @@ def buildx_args(
     args = [
         f"--platform=linux/{arch}",
         f"--label=build-url={GITHUB_RUN_URL}",
-        f"--label=com.clickhouse.build.githash={git.sha}",
-        f"--label=com.clickhouse.build.version={version}",
+        f"--label=com.altinity.build.githash={git.sha}",
+        f"--label=com.altinity.build.version={version}",
     ]
     if direct_urls:
         args.append(f"--build-arg=DIRECT_DOWNLOAD_URLS='{' '.join(direct_urls)}'")


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changes
- set regression job.name properly in new reusable suite
- copy known broken tests from stable 25.8
- remove references to upstream packages from server/keeper dockerfile

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)