### PR TITLE
25.3 FIPS - fixes for contribs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,7 +142,8 @@
 	url = https://github.com/ClickHouse/sentry-native
 [submodule "contrib/krb5"]
 	path = contrib/krb5
-	url = https://github.com/ClickHouse/krb5
+	url = https://github.com/Altinity/krb5
+	branch = altinity_awslc_200_fips
 [submodule "contrib/cyrus-sasl"]
 	path = contrib/cyrus-sasl
 	url = https://github.com/ClickHouse/cyrus-sasl

--- a/contrib/krb5-cmake/CMakeLists.txt
+++ b/contrib/krb5-cmake/CMakeLists.txt
@@ -713,9 +713,7 @@ target_compile_definitions(_krb5 PRIVATE
     LIBDIR="/usr/local/lib"
 )
 
-# stdio.h should've been explicitly included in disp_status.c, hack to fix it:
 target_compile_options(_krb5
-    # PRIVATE -includestdio.h
     PRIVATE -D_GNU_SOURCE=1
     PRIVATE -DUSE_BORINGSSL=1
 )

--- a/contrib/krb5-cmake/CMakeLists.txt
+++ b/contrib/krb5-cmake/CMakeLists.txt
@@ -713,6 +713,14 @@ target_compile_definitions(_krb5 PRIVATE
     LIBDIR="/usr/local/lib"
 )
 
+# stdio.h should've been explicitly included in disp_status.c, hack to fix it:
+target_compile_options(_krb5
+    # PRIVATE -includestdio.h
+    PRIVATE -D_GNU_SOURCE=1
+    PRIVATE -DUSE_BORINGSSL=1
+)
+
 target_link_libraries(_krb5 PRIVATE OpenSSL::Crypto OpenSSL::SSL)
+
 
 add_library(ch_contrib::krb5 ALIAS _krb5)

--- a/contrib/libssh-cmake/CMakeLists.txt
+++ b/contrib/libssh-cmake/CMakeLists.txt
@@ -86,6 +86,10 @@ configure_file(${LIB_SOURCE_DIR}/include/libssh/libssh_version.h.cmake ${LIB_BIN
 add_library(_ssh ${libssh_SRCS})
 add_library(ch_contrib::ssh ALIAS _ssh)
 
+target_compile_options(_ssh
+    PRIVATE -DUSE_BORINGSSL=1
+)
+
 target_link_libraries(_ssh PRIVATE OpenSSL::Crypto)
 
 target_include_directories(_ssh PUBLIC "${LIB_SOURCE_DIR}/include" "${LIB_BINARY_DIR}/include")

--- a/contrib/libssh-cmake/linux/x86-64/config.h
+++ b/contrib/libssh-cmake/linux/x86-64/config.h
@@ -118,7 +118,7 @@
 #define HAVE_OPENSSL_CRYPTO_THREADID_SET_CALLBACK 1
 
 /* Define to 1 if you have the `CRYPTO_ctr128_encrypt' function. */
-#define HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT 1
+#undef HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT
 
 /* Define to 1 if you have the `EVP_CIPHER_CTX_new' function. */
 #define HAVE_OPENSSL_EVP_CIPHER_CTX_NEW 1

--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -91,6 +91,8 @@ add_custom_command(
     USES_TERMINAL # To stream output
     DEPENDS
         ${AWSLC_BUILD_DIR}/build_awclc_fips.sh
+        ${AWSLC_BUILD_DIR}/check_version.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile
 )
 
 add_library(crypto UNKNOWN IMPORTED GLOBAL)

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -301,6 +301,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_CASSANDRA=1")
         cmake_flags.append("-DENABLE_KRB5=1")
         cmake_flags.append("-DENABLE_CYRUS_SASL=1")
+        cmake_flags.append("-DENABLE_SSH=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -299,6 +299,8 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_AMQPCPP=1")
         cmake_flags.append("-DENABLE_MINIZIP=1")
         cmake_flags.append("-DENABLE_CASSANDRA=1")
+        cmake_flags.append("-DENABLE_KRB5=1")
+        cmake_flags.append("-DENABLE_CYRUS_SASL=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -451,6 +451,7 @@ dbms_target_link_libraries (
         ch_contrib::lz4
         Poco::JSON
     PUBLIC
+        boost::iostreams
         boost::system
         clickhouse_compression
         clickhouse_common_io


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)