### PR TITLE
25.3.8-fips: enable more libraries

### DIFF
--- a/contrib/libgsasl-cmake/CMakeLists.txt
+++ b/contrib/libgsasl-cmake/CMakeLists.txt
@@ -108,6 +108,7 @@ target_include_directories(_gsasl PUBLIC ${SRC_DIR}/digest-md5)
 target_include_directories(_gsasl PUBLIC "${ClickHouse_SOURCE_DIR}/contrib/libgsasl-cmake/linux_x86_64/include")
 
 target_compile_definitions(_gsasl PRIVATE HAVE_CONFIG_H=1)
+target_compile_definitions(_gsasl PRIVATE _GNU_SOURCE=1)
 
 if (TARGET ch_contrib::krb5)
     target_link_libraries(_gsasl PUBLIC ch_contrib::krb5)

--- a/contrib/librdkafka-cmake/CMakeLists.txt
+++ b/contrib/librdkafka-cmake/CMakeLists.txt
@@ -149,6 +149,7 @@ add_library(_rdkafka ${SRCS})
 add_library(ch_contrib::rdkafka ALIAS _rdkafka)
 target_compile_options(_rdkafka PRIVATE -fno-sanitize=undefined)
 target_compile_definitions(_rdkafka PRIVATE -DCJSON_HIDE_SYMBOLS)
+target_compile_definitions(_rdkafka PRIVATE -D_GNU_SOURCE=1)
 
 # target_include_directories(_rdkafka SYSTEM PUBLIC include)
 target_include_directories(_rdkafka SYSTEM PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include") # for "librdkafka/rdkafka.h"

--- a/contrib/nats-io-cmake/CMakeLists.txt
+++ b/contrib/nats-io-cmake/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SRCS
 
 add_library(_nats_io ${SRCS} ${PS_SOURCES})
 add_library(ch_contrib::nats_io ALIAS _nats_io)
+target_compile_definitions(_nats_io PRIVATE -D_GNU_SOURCE=1)
 
 target_include_directories(_nats_io SYSTEM PUBLIC ${NATS_IO_SOURCE_DIR})
 target_include_directories(_nats_io SYSTEM PUBLIC ${NATS_IO_SOURCE_DIR}/adapters)

--- a/contrib/openssl-cmake/include/evp_API_shim.h
+++ b/contrib/openssl-cmake/include/evp_API_shim.h
@@ -1,7 +1,15 @@
 #ifndef AWS_LC_2_0_0_API_SHIM_FOR_OPENSSL_3_INCLUDED
 #define AWS_LC_2_0_0_API_SHIM_FOR_OPENSSL_3_INCLUDED
 
+// This header is being force-included before any other headers in files
+// depending on ssl target, and can pull in some headers itself.
+// librdkafka uses IOV_MAX which is defined in limits.h and pulled by
+// openssl/evp.h which is included by this file. Hence, we need to define _GNU_SOURCE
+// before including any other headers.
+#define _GNU_SOURCE
+
 #include <openssl/evp.h>
+#include <openssl/hmac.h> // HMAC is used by librdkafka
 // #include <openssl/types.h>
 #include <assert.h>
 
@@ -14,7 +22,7 @@
     To simplify porting and minimize code changes at other places,
     those missing functions/defines/constants will be defined here
     if there are trivial way to do it.
- 
+
     ALSO, this header can be included from both C++ and C code,
     so make sure that there are no non-compatible C++ features.
  */
@@ -36,7 +44,7 @@
 /* There are two types of cipher fetching in OpenSSL 3+:
     implicit (`EVP_get_cipherbyname`) and explicit (`EVP_CIPHER_fetch`).
 
-    Those types are necessary for OpenSSL's strategy of loading 
+    Those types are necessary for OpenSSL's strategy of loading
     some of the ciphers from plugins - shared (dynamic) libraries,
     which are called providers in OpenSSL's lingo.
 
@@ -68,5 +76,17 @@ inline void EVP_CIPHER_free(EVP_CIPHER *cipher)
 // since there are no dynamically loaded engines, disabling the flag is Ok:
 // all engines are initialized anyway
 # define OPENSSL_INIT_ENGINE_ALL_BUILTIN 0
+
+// librdkafka uses RAND_priv_bytes, which is not defined in AWS-LC.
+// However, RAND_bytes _is_ defined and is semantically equivalent.
+#define RAND_priv_bytes RAND_bytes
+
+// SSL_CTX_use_cert_and_key is used by librdkafka. We could define it as an
+// inline function, but that would require to include openssl/ssl.h, which is
+// worse for the build time.
+#define SSL_CTX_use_cert_and_key(ctx, cert, pkey, chain, override) \
+    (SSL_CTX_use_certificate((ctx), (cert)) == 1 \
+     && SSL_CTX_use_PrivateKey((ctx), (pkey)) == 1 \
+     && (!(chain) || SSL_CTX_set1_chain((ctx), (chain)) == 1))
 
 #endif

--- a/contrib/openssl-cmake/include/evp_API_shim.h
+++ b/contrib/openssl-cmake/include/evp_API_shim.h
@@ -1,13 +1,6 @@
 #ifndef AWS_LC_2_0_0_API_SHIM_FOR_OPENSSL_3_INCLUDED
 #define AWS_LC_2_0_0_API_SHIM_FOR_OPENSSL_3_INCLUDED
 
-// This header is being force-included before any other headers in files
-// depending on ssl target, and can pull in some headers itself.
-// librdkafka uses IOV_MAX which is defined in limits.h and pulled by
-// openssl/evp.h which is included by this file. Hence, we need to define _GNU_SOURCE
-// before including any other headers.
-#define _GNU_SOURCE
-
 #include <openssl/evp.h>
 #include <openssl/hmac.h> // HMAC is used by librdkafka
 #include <openssl/ssl.h>

--- a/contrib/openssl-cmake/include/evp_API_shim.h
+++ b/contrib/openssl-cmake/include/evp_API_shim.h
@@ -10,6 +10,7 @@
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h> // HMAC is used by librdkafka
+#include <openssl/ssl.h>
 // #include <openssl/types.h>
 #include <assert.h>
 
@@ -81,12 +82,54 @@ inline void EVP_CIPHER_free(EVP_CIPHER *cipher)
 // However, RAND_bytes _is_ defined and is semantically equivalent.
 #define RAND_priv_bytes RAND_bytes
 
-// SSL_CTX_use_cert_and_key is used by librdkafka. We could define it as an
-// inline function, but that would require to include openssl/ssl.h, which is
-// worse for the build time.
-#define SSL_CTX_use_cert_and_key(ctx, cert, pkey, chain, override) \
-    (SSL_CTX_use_certificate((ctx), (cert)) == 1 \
-     && SSL_CTX_use_PrivateKey((ctx), (pkey)) == 1 \
-     && (!(chain) || SSL_CTX_set1_chain((ctx), (chain)) == 1))
+// SSL_CTX_use_cert_and_key is used by librdkafka but not provided by AWS-LC.
+// Replicates OpenSSL's behaviour: sets certificate, private key, and optionally
+// the certificate chain on the SSL_CTX.
+static inline int SSL_CTX_use_cert_and_key(SSL_CTX *ctx, X509 *cert,
+                                           EVP_PKEY *pkey, STACK_OF(X509) *chain,
+                                           int override)
+{
+    (void)override;
+    if (SSL_CTX_use_certificate(ctx, cert) != 1)
+        return 0;
+    if (SSL_CTX_use_PrivateKey(ctx, pkey) != 1)
+        return 0;
+    if (chain && SSL_CTX_set1_chain(ctx, chain) != 1)
+        return 0;
+    return 1;
+}
+
+// BIO_get_ssl and BIO_do_handshake are convenience macros in OpenSSL
+// that expand to BIO_ctrl calls that are used by mongodb driver.
+// AWS-LC has the underlying BIO_ctrl and the control constants but not the macros.
+#define BIO_get_ssl(b, sslp) \
+    BIO_ctrl(b, BIO_C_GET_SSL, 0, (char *)(sslp))
+#define BIO_do_handshake(b) \
+    BIO_ctrl(b, BIO_C_DO_STATE_MACHINE, 0, NULL)
+
+// BIO_new_ssl is an OpenSSL convenience function that creates a new BIO
+// wrapping a fresh SSL connection. AWS-LC provides all the building blocks
+// (BIO_f_ssl, SSL_new, BIO_set_ssl) but not this wrapper.
+// Used by mongodb driver.
+static inline BIO *BIO_new_ssl(SSL_CTX *ctx, int client)
+{
+    BIO *bio = BIO_new(BIO_f_ssl());
+    if (!bio)
+        return NULL;
+
+    SSL *ssl = SSL_new(ctx);
+    if (!ssl) {
+        BIO_free(bio);
+        return NULL;
+    }
+
+    if (client)
+        SSL_set_connect_state(ssl);
+    else
+        SSL_set_accept_state(ssl);
+
+    BIO_set_ssl(bio, ssl, BIO_CLOSE);
+    return bio;
+}
 
 #endif

--- a/contrib/postgres-cmake/CMakeLists.txt
+++ b/contrib/postgres-cmake/CMakeLists.txt
@@ -24,12 +24,8 @@ set(SRCS
     "${LIBPQ_SOURCE_DIR}/pqexpbuffer.c"
 
     "${POSTGRES_SOURCE_DIR}/src/common/scram-common.c"
-    "${POSTGRES_SOURCE_DIR}/src/common/sha2.c"
-    "${POSTGRES_SOURCE_DIR}/src/common/sha1.c"
-    "${POSTGRES_SOURCE_DIR}/src/common/md5.c"
     "${POSTGRES_SOURCE_DIR}/src/common/md5_common.c"
     "${POSTGRES_SOURCE_DIR}/src/common/hmac_openssl.c"
-    "${POSTGRES_SOURCE_DIR}/src/common/cryptohash.c"
     "${POSTGRES_SOURCE_DIR}/src/common/saslprep.c"
     "${POSTGRES_SOURCE_DIR}/src/common/unicode_norm.c"
     "${POSTGRES_SOURCE_DIR}/src/common/ip.c"
@@ -57,6 +53,19 @@ set(SRCS
     "${POSTGRES_SOURCE_DIR}/src/port/pg_bitutils.c"
     "${POSTGRES_SOURCE_DIR}/src/port/path.c"
 )
+
+# If FIPS_CLICKHOUSE is enabled, we use the "OpenSSL" (AWS-LC) version of the
+# SHA256_Transform and SHA512_Transform functions instead of the internal ones.
+if(FIPS_CLICKHOUSE)
+    list(APPEND SRCS "${POSTGRES_SOURCE_DIR}/src/common/cryptohash_openssl.c")
+else()
+    list(APPEND SRCS
+        "${POSTGRES_SOURCE_DIR}/src/common/sha2.c"
+        "${POSTGRES_SOURCE_DIR}/src/common/sha1.c"
+        "${POSTGRES_SOURCE_DIR}/src/common/md5.c"
+        "${POSTGRES_SOURCE_DIR}/src/common/cryptohash.c"
+    )
+endif()
 
 if(NOT OS_DARWIN)
     set(SRCS ${SRCS}

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -301,6 +301,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_CASSANDRA=1")
         cmake_flags.append("-DENABLE_KAFKA=1")
         cmake_flags.append("-DENABLE_LIBPQXX=1")
+        cmake_flags.append("-DENABLE_MYSQL=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -299,6 +299,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_AMQPCPP=1")
         cmake_flags.append("-DENABLE_MINIZIP=1")
         cmake_flags.append("-DENABLE_CASSANDRA=1")
+        cmake_flags.append("-DENABLE_KAFKA=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -307,6 +307,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_ISAL_LIBRARY=1")
         cmake_flags.append("-DENABLE_QPL=1")
         cmake_flags.append("-DENABLE_NATS=1")
+        cmake_flags.append("-DENABLE_LDAP=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -308,6 +308,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_QPL=1")
         cmake_flags.append("-DENABLE_NATS=1")
         cmake_flags.append("-DENABLE_LDAP=1")
+        cmake_flags.append("-DUSE_MONGODB=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -303,6 +303,9 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_LIBPQXX=1")
         cmake_flags.append("-DENABLE_MYSQL=1")
         cmake_flags.append("-DENABLE_DATASKETCHES=1")
+        cmake_flags.append("-DENABLE_QATLIB=1")
+        cmake_flags.append("-DENABLE_ISAL_LIBRARY=1")
+        cmake_flags.append("-DENABLE_QPL=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -306,6 +306,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_QATLIB=1")
         cmake_flags.append("-DENABLE_ISAL_LIBRARY=1")
         cmake_flags.append("-DENABLE_QPL=1")
+        cmake_flags.append("-DENABLE_NATS=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -302,6 +302,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_KAFKA=1")
         cmake_flags.append("-DENABLE_LIBPQXX=1")
         cmake_flags.append("-DENABLE_MYSQL=1")
+        cmake_flags.append("-DENABLE_DATASKETCHES=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies

--- a/docker/packager/packager
+++ b/docker/packager/packager
@@ -300,6 +300,7 @@ def parse_env_variables(
         cmake_flags.append("-DENABLE_MINIZIP=1")
         cmake_flags.append("-DENABLE_CASSANDRA=1")
         cmake_flags.append("-DENABLE_KAFKA=1")
+        cmake_flags.append("-DENABLE_LIBPQXX=1")
         # FIPS mode end
 
         # Reduce linking and building time by avoid *install/all dependencies


### PR DESCRIPTION
Subset of changes from #1444 to merge before enabling all the libraries.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)