### PR TITLE
Antalya 26.1 Backport of #94335 - Fix reading columns with dot-separated names from Iceberg

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/SchemaConverter.h
+++ b/src/Processors/Formats/Impl/Parquet/SchemaConverter.h
@@ -137,8 +137,10 @@ private:
         DataTypePtr & out_inferred_type, std::optional<GeoColumnMetadata> geo_metadata) const;
 
     /// Returns element.name or a corresponding name from ColumnMapper.
-    /// For tuple elements, that's just the element name like `x`, not the whole path like `t.x`.
-    std::string_view useColumnMapperIfNeeded(const parq::SchemaElement & element) const;
+    /// For nested tuple elements, returns just the element name like `x`, not the whole path like `t.x`.
+    /// For top-level columns (when current_path is empty), returns the full mapped name to support
+    /// column names with dots (e.g. `integer.col` in Iceberg).
+    std::string_view useColumnMapperIfNeeded(const parq::SchemaElement & element, const String & current_path) const;
 };
 
 }

--- a/tests/integration/test_storage_iceberg_with_spark/test_column_names_with_dots.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_column_names_with_dots.py
@@ -1,0 +1,218 @@
+import pytest
+
+from pyspark.sql.types import (
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from helpers.iceberg_utils import (
+    default_upload_directory,
+    write_iceberg_from_df,
+    create_iceberg_table,
+    get_creation_expression,
+    get_uuid_str,
+)
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_column_names_with_dots(started_cluster_iceberg_with_spark, storage_type):
+    """
+    Test that Iceberg tables with dot-separated column names are read correctly.
+    This tests the fix for field ID-based column name mapping in Parquet V3 reader.
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = "test_column_names_with_dots_" + storage_type + "_" + get_uuid_str()
+
+    # Create DataFrame with column names containing dots
+    data = [
+        (1, "value1", "multi_dot_value1"),
+        (2, "value2", "multi_dot_value2"),
+        (3, "value3", "multi_dot_value3"),
+    ]
+    schema = StructType([
+        StructField("id", IntegerType()),
+        StructField("name.column", StringType()),
+        StructField("double.column.dot", StringType()),
+    ])
+    df = spark.createDataFrame(data=data, schema=schema)
+
+    write_iceberg_from_df(spark, df, TABLE_NAME, mode="overwrite", format_version="2")
+
+    default_upload_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    # Test via table function
+    table_function_expr = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_with_spark, table_function=True
+    )
+
+    # Verify single-dot column name
+    result = instance.query(
+        f"SELECT `name.column` FROM {table_function_expr} ORDER BY id"
+    ).strip()
+    assert result == "value1\nvalue2\nvalue3", f"Expected values, got: {result}"
+
+    # Verify multi-dot column name
+    result = instance.query(
+        f"SELECT `double.column.dot` FROM {table_function_expr} ORDER BY id"
+    ).strip()
+    assert result == "multi_dot_value1\nmulti_dot_value2\nmulti_dot_value3", f"Expected values, got: {result}"
+
+    # Verify all columns together
+    result = instance.query(
+        f"SELECT id, `name.column`, `double.column.dot` FROM {table_function_expr} ORDER BY id"
+    ).strip()
+    expected = "1\tvalue1\tmulti_dot_value1\n2\tvalue2\tmulti_dot_value2\n3\tvalue3\tmulti_dot_value3"
+    assert result == expected, f"Expected:\n{expected}\nGot:\n{result}"
+
+    # Test via table engine
+    create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark)
+
+    result = instance.query(
+        f"SELECT `name.column`, `double.column.dot` FROM {TABLE_NAME} ORDER BY id"
+    ).strip()
+    expected = "value1\tmulti_dot_value1\nvalue2\tmulti_dot_value2\nvalue3\tmulti_dot_value3"
+    assert result == expected, f"Expected:\n{expected}\nGot:\n{result}"
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_nested_struct_with_dotted_field(started_cluster_iceberg_with_spark, storage_type):
+    """
+    Test that nested struct fields with dot-separated names are read correctly.
+    This tests the fix for prefix stripping in useColumnMapperIfNeeded.
+    E.g., for my_struct.weird.field we should return "weird.field", not just "field".
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = "test_nested_struct_with_dotted_field_" + storage_type + "_" + get_uuid_str()
+
+    # Create DataFrame with nested struct containing a dotted field
+    data = [
+        (1, (100, "nested_dot_value1")),
+        (2, (200, "nested_dot_value2")),
+        (3, (300, "nested_dot_value3")),
+    ]
+    schema = StructType(
+        [
+            StructField("id", IntegerType()),
+            StructField(
+                "my_struct",
+                StructType(
+                    [
+                        StructField("normal_field", IntegerType()),
+                        StructField("weird.field", StringType()),
+                    ]
+                )
+            )
+        ]
+    )
+    df = spark.createDataFrame(data=data, schema=schema)
+
+    write_iceberg_from_df(spark, df, TABLE_NAME, mode="overwrite", format_version="2")
+
+    default_upload_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    # Test via table function
+    table_function_expr = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_with_spark, table_function=True
+    )
+
+    # Verify nested struct with dotted field via table function
+    result = instance.query(
+        f"SELECT my_struct.normal_field, `my_struct.weird.field` FROM {table_function_expr} ORDER BY id"
+    ).strip()
+    expected = "100\tnested_dot_value1\n200\tnested_dot_value2\n300\tnested_dot_value3"
+    assert result == expected, f"Expected:\n{expected}\nGot:\n{result}"
+
+    # Test via table engine
+    create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark)
+
+    result = instance.query(
+        f"SELECT my_struct.normal_field, `my_struct.weird.field` FROM {TABLE_NAME} ORDER BY id"
+    ).strip()
+    expected = "100\tnested_dot_value1\n200\tnested_dot_value2\n300\tnested_dot_value3"
+    assert result == expected, f"Expected:\n{expected}\nGot\n{result}"
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_deeply_nested_struct_with_dotted_names(started_cluster_iceberg_with_spark, storage_type):
+    """
+    Test deeply nested structs where EVERY level has dots in the name.
+    Structure: my.struct -> some_dot.separated_parent -> weird.field
+    Full path: my.struct.some_dot.separated_parent.weird.field
+
+    This verifies that prefix stripping works correctly at all nesting depths.
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = "test_deeply_nested_struct_with_dotted_names_" + storage_type + "_" + get_uuid_str()
+
+    # Create DataFrame with deeply nested struct containing dotted names
+    data = [
+        (1, (("deep_value1",),)),
+        (2, (("deep_value2",),)),
+        (3, (("deep_value3",),)),
+    ]
+    schema = StructType(
+        [
+            StructField("id", IntegerType()),
+            StructField(
+                "my.struct",
+                StructType(
+                    [
+                        StructField(
+                            "some_dot.separated_parent",
+                            StructType(
+                                [
+                                    StructField("weird.field", StringType()),
+                                ]
+                            ),
+                        ),
+                    ]
+                ),
+            ),
+        ]
+    )
+    df = spark.createDataFrame(data=data, schema=schema)
+
+    write_iceberg_from_df(spark, df, TABLE_NAME, mode="overwrite", format_version="2")
+
+    default_upload_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    # Test via table function
+    table_function_expr = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_with_spark, table_function=True
+    )
+
+    # Query the deeply nested dotted field
+    result = instance.query(
+        f"SELECT `my.struct.some_dot.separated_parent.weird.field` FROM {table_function_expr} ORDER BY id"
+    ).strip()
+    expected = "deep_value1\ndeep_value2\ndeep_value3"
+    assert result == expected, f"Expected:\n{expected}\nGot:\n{result}"
+
+    # Test via table engine
+    create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark)
+
+    result = instance.query(
+        f"SELECT `my.struct.some_dot.separated_parent.weird.field` FROM {TABLE_NAME} ORDER BY id"
+    ).strip()
+    expected = "deep_value1\ndeep_value2\ndeep_value3"
+    assert result == expected, f"Expected:\n{expected}\nGot:\n{result}"


### PR DESCRIPTION
Fix reading columns with dot-separated names from Iceberg

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes an issue when Iceberg columns with dot in names returned NULL as values (https://github.com/ClickHouse/ClickHouse/pull/94335 by @mkmkme)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)