### PR TITLE
25.3.8-fips: try to build AWS-LC FIPS on aarch64

### DIFF
--- a/contrib/libssh-cmake/linux/aarch64/config.h
+++ b/contrib/libssh-cmake/linux/aarch64/config.h
@@ -118,7 +118,7 @@
 #define HAVE_OPENSSL_CRYPTO_THREADID_SET_CALLBACK 1
 
 /* Define to 1 if you have the `CRYPTO_ctr128_encrypt' function. */
-#define HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT 1
+#undef HAVE_OPENSSL_CRYPTO_CTR128_ENCRYPT
 
 /* Define to 1 if you have the `EVP_CIPHER_CTX_new' function. */
 #define HAVE_OPENSSL_EVP_CIPHER_CTX_NEW 1

--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -80,19 +80,25 @@ add_custom_target(build-awslc
     DEPENDS ${AWSLC_BINARIES_DIR}/libssl.a ${AWSLC_BINARIES_DIR}/libcrypto.a
 )
 
+if(ARCH_AARCH64)
+    set(DOCKERFILE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile.aarch64)
+else()
+    set(DOCKERFILE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile)
+endif()
+
 add_custom_command(
     OUTPUT
         "${AWSLC_BUILD_DIR}/output/libssl.a"
         "${AWSLC_BUILD_DIR}/output/libcrypto.a"
     COMMENT "Building AWS-LC in FIPS mode using Docker"
     COMMAND bash -c "chmod +x ${AWSLC_BUILD_DIR}/build_awclc_fips.sh"
-    COMMAND bash -c "${AWSLC_BUILD_DIR}/build_awclc_fips.sh ${AWSLC_BINARIES_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile"
+    COMMAND bash -c "${AWSLC_BUILD_DIR}/build_awclc_fips.sh ${AWSLC_BINARIES_DIR} ${DOCKERFILE_PATH}"
     WORKING_DIRECTORY ${AWSLC_BUILD_DIR}
     USES_TERMINAL # To stream output
     DEPENDS
         ${AWSLC_BUILD_DIR}/build_awclc_fips.sh
         ${AWSLC_BUILD_DIR}/check_version.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/Dockerfile
+        ${DOCKERFILE_PATH}
 )
 
 add_library(crypto UNKNOWN IMPORTED GLOBAL)

--- a/contrib/openssl-cmake/Dockerfile.aarch64
+++ b/contrib/openssl-cmake/Dockerfile.aarch64
@@ -1,0 +1,32 @@
+FROM --platform=linux/aarch64 ubuntu:22.04
+
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        cmake \
+        golang \
+        unzip
+
+ADD --checksum=sha256:6241ec2f13a5f80224ee9cd8592ed66a97d426481066feaa4efc6f24e60bbc96 \
+    https://github.com/aws/aws-lc/archive/refs/tags/AWS-LC-FIPS-2.0.0.zip .
+
+RUN unzip -q AWS-LC-FIPS-2.0.0.zip -d .
+
+RUN cd /aws-lc-AWS-LC-FIPS-2.0.0 \
+    && mkdir -p ./build \
+    && cd ./build \
+    && cmake -DFIPS=1 -DGO_EXECUTABLE=`which go` .. \
+    && make
+
+# Check that version is reported correctly
+COPY check_version.c /tmp/check_version.c
+RUN cd /aws-lc-AWS-LC-FIPS-2.0.0/build \
+    && gcc /tmp/check_version.c -o ./check_version -L./ssl -l:libssl.a -L./crypto -l:libcrypto.a \
+    && ./check_version 'AWS-LC FIPS 2.0.0'
+
+#check is in FIPS mode
+RUN test $(/aws-lc-AWS-LC-FIPS-2.0.0/build/tool/bssl isfips) = 1
+
+# execute all test
+RUN find /aws-lc-AWS-LC-FIPS-2.0.0/build -iname '*test*' -type f -executable -print -exec {} \;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)