### PR TITLE
25.3.8-fips:  fix kerberos tests on FIPS

### DIFF
--- a/tests/integration/test_kerberos_auth/kerberos_image_config.sh
+++ b/tests/integration/test_kerberos_auth/kerberos_image_config.sh
@@ -29,9 +29,9 @@ create_config() {
  # require the enhanced security JCE policy file to be installed. You should
  # NOT run with this configuration in production or any real environment. You
  # have been warned.
- default_tkt_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
- default_tgs_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
- permitted_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
+ default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des-cbc-md5 des-cbc-crc des3-cbc-sha1
+ default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des-cbc-md5 des-cbc-crc des3-cbc-sha1
+ permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des-cbc-md5 des-cbc-crc des3-cbc-sha1
 
 [realms]
  $REALM = {
@@ -58,8 +58,8 @@ cat>/var/kerberos/krb5kdc/kdc.conf<<EOF
   # require the enhanced security JCE policy file to be installed. You should
   # NOT run with this configuration in production or any real environment. You
   # have been warned.
-  master_key_type = des3-hmac-sha1
-  supported_enctypes = arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
+  master_key_type = aes256-cts-hmac-sha1-96
+  supported_enctypes = aes256-cts-hmac-sha1-96:normal aes128-cts-hmac-sha1-96:normal arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
   default_principal_flags = +preauth
  }
 EOF

--- a/tests/integration/test_kerberos_auth/secrets/krb.conf
+++ b/tests/integration/test_kerberos_auth/secrets/krb.conf
@@ -10,6 +10,9 @@
  ticket_lifetime = 15s
  renew_lifetime = 15s
  forwardable = true
+ default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+ default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+ permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
 
 [realms]
  TEST.CLICKHOUSE.TECH = {

--- a/tests/integration/test_storage_kerberized_kafka/kerberos_image_config.sh
+++ b/tests/integration/test_storage_kerberized_kafka/kerberos_image_config.sh
@@ -29,9 +29,9 @@ create_config() {
  # require the enhanced security JCE policy file to be installed. You should
  # NOT run with this configuration in production or any real environment. You
  # have been warned.
- default_tkt_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
- default_tgs_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
- permitted_enctypes = des-cbc-md5 des-cbc-crc des3-cbc-sha1
+ default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des-cbc-md5 des-cbc-crc des3-cbc-sha1
+ default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des-cbc-md5 des-cbc-crc des3-cbc-sha1
+ permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des-cbc-md5 des-cbc-crc des3-cbc-sha1
 
 [realms]
  $REALM = {
@@ -58,8 +58,8 @@ cat>/var/kerberos/krb5kdc/kdc.conf<<EOF
   # require the enhanced security JCE policy file to be installed. You should
   # NOT run with this configuration in production or any real environment. You
   # have been warned.
-  master_key_type = des3-hmac-sha1
-  supported_enctypes = arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
+  master_key_type = aes256-cts-hmac-sha1-96
+  supported_enctypes = aes256-cts-hmac-sha1-96:normal aes128-cts-hmac-sha1-96:normal arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
   default_principal_flags = +preauth
  }
 EOF

--- a/tests/integration/test_storage_kerberized_kafka/secrets/krb.conf
+++ b/tests/integration/test_storage_kerberized_kafka/secrets/krb.conf
@@ -10,6 +10,9 @@
  ticket_lifetime = 15s
  renew_lifetime = 15s
  forwardable = true
+ default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+ default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
+ permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96
  rdns = false
 
 [realms]


### PR DESCRIPTION
The original test didn't include any of the FIPS-approved encryptions and therefore failed consistently. This patch adds the supported encryptions while keeping the old ones for the compatibility. The older encryptions will not be used for communications with ClickHouse and any attempt would fail anyways.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)