### PR TITLE
25.3.8-fips: fix test_accept_invalid_certificate in FIPS mode

### DIFF
--- a/tests/integration/test_accept_invalid_certificate/test.py
+++ b/tests/integration/test_accept_invalid_certificate/test.py
@@ -88,7 +88,7 @@ def execute_query_native(node, query, config):
 def test_default():
     with pytest.raises(Exception) as err:
         execute_query_native(instance, "SELECT 1", config_default)
-    assert "certificate verify failed" in str(err.value)
+    assert "certificate verify failed" in str(err.value).lower().replace("_", " ")
 
 
 def test_accept():
@@ -109,13 +109,13 @@ def test_connection_accept():
 def test_strict_reject():
     with pytest.raises(Exception) as err:
         execute_query_native(node1, "SELECT 1", "<clickhouse></clickhouse>")
-    assert "certificate verify failed" in str(err.value)
+    assert "certificate verify failed" in str(err.value).lower().replace("_", " ")
 
 
 def test_strict_reject_with_config():
     with pytest.raises(Exception) as err:
         execute_query_native(node1, "SELECT 1", config_accept)
-    assert "alert certificate required" in str(err.value)
+    assert "alert certificate required" in str(err.value).lower().replace("_", " ")
 
 
 def test_strict_connection_reject():
@@ -125,4 +125,4 @@ def test_strict_connection_reject():
             "SELECT 1",
             config_connection_accept.format(ip_address=f"{instance.ip_address}"),
         )
-    assert "certificate verify failed" in str(err.value)
+    assert "certificate verify failed" in str(err.value).lower().replace("_", " ")


### PR DESCRIPTION
The usual OpenSSL error message looks like this:

    error:0A000086:SSL routines::certificate verify failed

And the tests are simply asserting on the line "certificate verify failed" to be in the logs.

AWS-LC, however, has this error in a different format, like this:

    error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED

Therefore, this test replaces the underscores with spaces and makes the string lowercase in order for the test to pass

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)