### PR TITLE
Minor: fixed up some comments and removed commented out code

### DIFF
--- a/contrib/openssl-cmake/CMakeLists.txt
+++ b/contrib/openssl-cmake/CMakeLists.txt
@@ -65,18 +65,11 @@ int main(int argc, char * argv[]) {
 }
 ]=])
 
-# patch a single file in krb5 that relies on file missing from this version of BoringSSL
-# SET(krb5_filb_to_patch ${PROJECT_SOURCE_DIR}/contrib/krb5/src/lib/crypto/openssl/enc_provider/aes.c)
-# message("Patching ${krb5_filb_to_patch} to allow building against older version of BoringSSL")
-# file(READ ${krb5_filb_to_patch} FILE_CONTENTS)
-# string(REPLACE "#include <openssl/modes.h>" "//#include <openssl/modes.h>" FILE_CONTENTS "${FILE_CONTENTS}")
-# file(WRITE ${krb5_filb_to_patch} "${FILE_CONTENTS}")
-
 message("Creating directory for AWS-LC binaries and includes in ${AWSLC_BINARIES_DIR}")
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${AWSLC_BINARIES_DIR}/include")
 
 add_custom_target(build-awslc
-#    COMMENT "Build AWS-LC in FIPS mode with docker (using go1.22 build suite)"
+    COMMENT "Build AWS-LC in FIPS mode with docker"
     DEPENDS ${AWSLC_BINARIES_DIR}/libssl.a ${AWSLC_BINARIES_DIR}/libcrypto.a
 )
 
@@ -90,7 +83,7 @@ add_custom_command(
     OUTPUT
         "${AWSLC_BUILD_DIR}/output/libssl.a"
         "${AWSLC_BUILD_DIR}/output/libcrypto.a"
-    COMMENT "Building AWS-LC in FIPS mode using Docker"
+    COMMENT "Building AWS-LC in FIPS mode using docker"
     COMMAND bash -c "chmod +x ${AWSLC_BUILD_DIR}/build_awclc_fips.sh"
     COMMAND bash -c "${AWSLC_BUILD_DIR}/build_awclc_fips.sh ${AWSLC_BINARIES_DIR} ${DOCKERFILE_PATH}"
     WORKING_DIRECTORY ${AWSLC_BUILD_DIR}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)