### PR TITLE
Antalya 26.1 - fixed targeted testing

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,6 +41,7 @@ jobs:
   config_workflow:
     runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
     needs: []
+    if: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
     name: "Config Workflow"
     outputs:
       data: ${{ steps.run.outputs.DATA }}

--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -54,7 +54,12 @@ class Targeting:
     def __init__(self, info: Info, branch: str = ""):
         self.info = info
         self.branch = branch or getattr(info, 'base_branch', '')
-        self.cidb = CIDBCluster()
+        # NOTE (strtgbb): Read credentials from env directly to avoid
+        # a mutation bug in CIDBCluster's secret resolution path.
+        url = os.environ.get(Settings.SECRET_CI_DB_URL, "")
+        user = os.environ.get(Settings.SECRET_CI_DB_USER, "")
+        pwd = os.environ.get(Settings.SECRET_CI_DB_PASSWORD, "")
+        self.cidb = CIDBCluster(url=url, user=user, pwd=pwd)
         if "stateless" in info.job_name.lower():
             self.job_type = self.STATELESS_JOB_TYPE
         elif "integration" in info.job_name.lower():

--- a/ci/jobs/scripts/functional_tests/export_coverage.py
+++ b/ci/jobs/scripts/functional_tests/export_coverage.py
@@ -63,10 +63,11 @@ class CoverageExporter:
             if not self.to_file:
                 query = (
                     f"INSERT INTO FUNCTION remoteSecure('{self.dest.url.removeprefix('https://').split(':')[0]}', '{Settings.CI_DB_DB_NAME}.checks_coverage_inverted', '{self.dest.user}', '{self.dest.pwd}') "
+                    "(branch, symbol, check_start_time, check_name, test_name) "
                     "SELECT DISTINCT "
+                    f"'{self.branch}' AS branch, "
                     "arrayJoin(symbol) AS symbol, "
                     f"'{self.check_start_time}' AS check_start_time, "
-                    f"'{self.branch}' AS branch, "
                     f"'{self.job_name}' AS check_name, "
                     "test_name "
                     f"FROM system.{table}"

--- a/ci/jobs/scripts/functional_tests/export_coverage.py
+++ b/ci/jobs/scripts/functional_tests/export_coverage.py
@@ -62,7 +62,7 @@ class CoverageExporter:
 
             if not self.to_file:
                 query = (
-                    f"INSERT INTO FUNCTION remoteSecure('{self.dest.url.removeprefix('https://')}', '{Settings.CI_DB_DB_NAME}.checks_coverage_inverted', '{self.dest.user}', '{self.dest.pwd}') "
+                    f"INSERT INTO FUNCTION remoteSecure('{self.dest.url.removeprefix('https://').split(':')[0]}', '{Settings.CI_DB_DB_NAME}.checks_coverage_inverted', '{self.dest.user}', '{self.dest.pwd}') "
                     "SELECT DISTINCT "
                     "arrayJoin(symbol) AS symbol, "
                     f"'{self.check_start_time}' AS check_start_time, "

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -37,6 +37,7 @@ workflow = Workflow.Config(
     name="PR",
     event=Workflow.Event.PULL_REQUEST,
     base_branches=[BASE_BRANCH, "releases/*", "antalya-*"],
+    if_condition="github.repository == github.event.pull_request.head.repo.full_name",
     jobs=[
         # JobConfigs.style_check, # NOTE (strtgbb): we don't run style check
         # JobConfigs.docs_job, # NOTE (strtgbb): we don't build docs


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)