### PR TITLE
Skip remote suite on export tests that block minio

### DIFF
--- a/tests/integration/test_export_merge_tree_part_to_object_storage/test.py
+++ b/tests/integration/test_export_merge_tree_part_to_object_storage/test.py
@@ -9,6 +9,18 @@ import uuid
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 
+
+def skip_if_remote_database_disk_enabled(cluster):
+    """Skip test if any instance in the cluster has remote database disk enabled.
+
+    Tests that block MinIO cannot run when remote database disk is enabled,
+    as the database metadata is stored on MinIO and blocking it would break the database.
+    """
+    for instance in cluster.instances.values():
+        if instance.with_remote_database_disk:
+            pytest.skip("Test cannot run with remote database disk enabled (db disk), as it blocks MinIO which stores database metadata")
+
+
 @pytest.fixture(scope="module")
 def cluster():
     try:
@@ -37,6 +49,7 @@ def create_tables_and_insert_data(node, mt_table, s3_table):
 
 
 def test_drop_column_during_export_snapshot(cluster):
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["node1"]
 
     mt_table = "mutations_snapshot_mt_table"
@@ -88,6 +101,7 @@ def test_drop_column_during_export_snapshot(cluster):
 
 
 def test_add_column_during_export(cluster):
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["node1"]
 
     mt_table = "add_column_during_export_mt_table"
@@ -193,6 +207,7 @@ def test_pending_mutations_skip_before_export(cluster):
 
 def test_data_mutations_after_export_started(cluster):
     """Test that mutations applied after export starts don't affect the exported data."""
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["node1"]
 
     mt_table = "mutations_after_export_mt_table"

--- a/tests/integration/test_export_replicated_mt_partition_to_object_storage/test.py
+++ b/tests/integration/test_export_replicated_mt_partition_to_object_storage/test.py
@@ -69,6 +69,17 @@ def wait_for_export_to_start(
     raise TimeoutError(f"Export did not start within {timeout}s. ")
 
 
+def skip_if_remote_database_disk_enabled(cluster):
+    """Skip test if any instance in the cluster has remote database disk enabled.
+
+    Tests that block MinIO cannot run when remote database disk is enabled,
+    as the database metadata is stored on MinIO and blocking it would break the database.
+    """
+    for instance in cluster.instances.values():
+        if instance.with_remote_database_disk:
+            pytest.skip("Test cannot run with remote database disk enabled (db disk), as it blocks MinIO which stores database metadata")
+
+
 @pytest.fixture(scope="module")
 def cluster():
     try:
@@ -123,6 +134,7 @@ def create_tables_and_insert_data(node, mt_table, s3_table, replica_name):
 
 
 def test_restart_nodes_during_export(cluster):
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["replica1"]
     node2 = cluster.instances["replica2"]
     watcher_node = cluster.instances["watcher_node"]
@@ -213,6 +225,7 @@ def test_restart_nodes_during_export(cluster):
 
 
 def test_kill_export(cluster):
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["replica1"]
     node2 = cluster.instances["replica2"]
     watcher_node = cluster.instances["watcher_node"]
@@ -297,6 +310,7 @@ def test_kill_export(cluster):
 
 
 def test_drop_source_table_during_export(cluster):
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["replica1"]
     # node2 = cluster.instances["replica2"]
     watcher_node = cluster.instances["watcher_node"]
@@ -390,6 +404,7 @@ def test_concurrent_exports_to_different_targets(cluster):
 
 
 def test_failure_is_logged_in_system_table(cluster):
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["replica1"]
 
     mt_table = "failure_is_logged_in_system_table_mt_table"
@@ -459,6 +474,7 @@ def test_failure_is_logged_in_system_table(cluster):
 
 
 def test_inject_short_living_failures(cluster):
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["replica1"]
 
     mt_table = "inject_short_living_failures_mt_table"
@@ -881,6 +897,7 @@ def test_pending_patch_parts_skip_before_export_partition(cluster):
 
 def test_mutations_after_export_partition_started(cluster):
     """Test that mutations applied after export partition starts don't affect the exported data."""
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["replica1"]
 
     mt_table = "mutations_after_export_partition_mt_table"
@@ -930,6 +947,7 @@ def test_mutations_after_export_partition_started(cluster):
 
 def test_patch_parts_after_export_partition_started(cluster):
     """Test that patch parts created after export partition starts don't affect the exported data."""
+    skip_if_remote_database_disk_enabled(cluster)
     node = cluster.instances["replica1"]
 
     mt_table = "patches_after_export_partition_mt_table"


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes export part/ partition tests failing under `db disk` integration test suites because those tests require MinIO traffict to be blocked and `db disk` relies on remote metadata stored in MinIO/s3 for plain merge tree tables, causing a deadlock and the suite to time out.

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)