### PR TITLE
Fix local replicated_partition_exports table might miss entries

### DIFF
--- a/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.cpp
+++ b/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.cpp
@@ -535,14 +535,19 @@ void ExportPartitionManifestUpdatingTask::poll()
 
         ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperRequests);
         ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperGetWatch);
-        std::string status;
-        if (!zk->tryGetWatch(fs::path(entry_path) / "status", status, nullptr, status_watch_callback))
+        std::string status_string;
+        if (!zk->tryGetWatch(fs::path(entry_path) / "status", status_string, nullptr, status_watch_callback))
         {
             LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing status", key);
             continue;
         }
 
-        bool is_pending = status == "PENDING";
+        const auto status = magic_enum::enum_cast<ExportReplicatedMergeTreePartitionTaskEntry::Status>(status_string);
+        if (!status)
+        {
+            LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Invalid status {} for task {}, skipping", status_string, key);
+            continue;
+        }
 
         /// if we have the cleanup lock, try to cleanup
         /// if we successfully cleaned it up, early exit
@@ -556,16 +561,11 @@ void ExportPartitionManifestUpdatingTask::poll()
                 key,
                 metadata,
                 now,
-                is_pending, entries_by_key);
+                *status == ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING,
+                entries_by_key);
 
             if (cleanup_successful)
                 continue;
-        }
-
-        if (!is_pending)
-        {
-            LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: status is not PENDING", key);
-            continue;
         }
 
         if (has_local_entry_and_is_up_to_date)
@@ -574,7 +574,7 @@ void ExportPartitionManifestUpdatingTask::poll()
             continue;
         }
 
-        addTask(metadata, key, entries_by_key);
+        addTask(metadata, *status, key, entries_by_key);
     }
 
     /// Remove entries that were deleted by someone else
@@ -587,22 +587,30 @@ void ExportPartitionManifestUpdatingTask::poll()
 
 void ExportPartitionManifestUpdatingTask::addTask(
     const ExportReplicatedMergeTreePartitionManifest & metadata,
+    ExportReplicatedMergeTreePartitionTaskEntry::Status status,
     const std::string & key,
     auto & entries_by_key
 )
 {
     std::vector<DataPartPtr> part_references;
 
-    for (const auto & part_name : metadata.parts)
+    /// If the status is PENDING, we grab references to the data parts to prevent them from being deleted from the disk
+    /// Otherwise, the operation has already been completed and there is no need to keep the data parts alive
+    /// You might also ask: why bother adding tasks that have already been completed (i.e, status != PENDING)?
+    /// The reason is the `replicated_partition_exports` table in the local only mode might miss entries if they are not added here.
+    if (status == ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING)
     {
-        if (const auto part = storage.getPartIfExists(part_name, {MergeTreeDataPartState::Active, MergeTreeDataPartState::Outdated}))
+        for (const auto & part_name : metadata.parts)
         {
-            part_references.push_back(part);
+            if (const auto part = storage.getPartIfExists(part_name, {MergeTreeDataPartState::Active, MergeTreeDataPartState::Outdated}))
+            {
+                part_references.push_back(part);
+            }
         }
     }
 
     /// Insert or update entry. The multi_index container automatically maintains both indexes.
-    auto entry = ExportReplicatedMergeTreePartitionTaskEntry {metadata, ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING, std::move(part_references)};
+    auto entry = ExportReplicatedMergeTreePartitionTaskEntry {metadata, status, std::move(part_references)};
     auto it = entries_by_key.find(key);
     if (it != entries_by_key.end())
         entries_by_key.replace(it, entry);

--- a/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.h
+++ b/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_set>
 #include <Storages/System/StorageSystemReplicatedPartitionExports.h>
+#include <Storages/ExportReplicatedMergeTreePartitionTaskEntry.h>
 namespace DB
 {
 
@@ -31,6 +32,7 @@ private:
 
     void addTask(
         const ExportReplicatedMergeTreePartitionManifest & metadata,
+        ExportReplicatedMergeTreePartitionTaskEntry::Status status,
         const std::string & key,
         auto & entries_by_key
     );


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
The `system.replicated_partition_exports` table has two modes: remote and local. This is controlled by `export_merge_tree_partition_system_table_prefer_remote_information`. The idea is to avoid querying zookeeper whenever possible. The local mode relies purely on the in-memory list of tasks. This PR fixes a possibly rare issue when a task is created and set to a non pending state (e.g, killed or completed) before a given replica can fetch it. In that case, the entry would never exist locally and would not show up.

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
