### PR TITLE
Antalya 25.8 - Fix CrashWriter to check empty endpoint before sending crash report

### DIFF
--- a/src/Daemon/CrashWriter.cpp
+++ b/src/Daemon/CrashWriter.cpp
@@ -24,8 +24,7 @@ std::unique_ptr<CrashWriter> CrashWriter::instance;
 
 void CrashWriter::initialize(Poco::Util::LayeredConfiguration & config)
 {
-    if (config.getBool("send_crash_reports.enabled", false))
-        instance.reset(new CrashWriter(config));
+    instance.reset(new CrashWriter(config));
 }
 
 bool CrashWriter::initialized()
@@ -67,6 +66,12 @@ void CrashWriter::sendError(Type type, int sig_or_error, std::string_view error_
     if (!instance)
     {
         LOG_INFO(logger, "Not sending crash report");
+        return;
+    }
+
+    if (endpoint.empty())
+    {
+        LOG_DEBUG(logger, "Not sending crash report (crash reporting is disabled)");
         return;
     }
 


### PR DESCRIPTION
This PR improves the fix for #1437 (previously fixed in #1438).

The original fix prevented the exception by not creating the `CrashWriter` instance when disabled, but this resulted in no logging when crashes occurred with reporting disabled.

This PR implements Option B: always create the instance and add an early return in `sendError()` when the endpoint is empty. This prevents the exception while providing informative logs (`<Debug> CrashWriter: Not sending crash report (crash reporting is disabled)`) when crashes happen with reporting disabled.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
