### PR TITLE
25.3 FIPS: Starup checks

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -177,6 +177,14 @@ void Keeper::initialize(Poco::Util::Application & self)
         Poco::Environment::osName(),
         Poco::Environment::osVersion(),
         Poco::Environment::osArchitecture());
+
+#if USE_SSL && defined(FIPS_CLICKHOUSE)
+    if (FIPS_mode())
+    {
+        LOG_INFO(&logger(), "Starting in FIPS mode, KAT test result: {}, Integrity check: {}",
+                BORINGSSL_self_test(), BORINGSSL_integrity_test());
+    }
+#endif
 }
 
 std::string Keeper::getDefaultConfigFileName() const

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -141,6 +141,7 @@
 #    include <Server/SSH/SSHPtyHandlerFactory.h>
 #    include <Common/LibSSHInitializer.h>
 #    include <Common/LibSSHLogger.h>
+#    include <openssl/crypto.h>
 #endif
 
 #if USE_GRPC
@@ -593,6 +594,14 @@ void Server::initialize(Poco::Util::Application & self)
         Poco::Environment::osName(),
         Poco::Environment::osVersion(),
         Poco::Environment::osArchitecture());
+
+#if USE_SSL && defined(FIPS_CLICKHOUSE)
+    if (FIPS_mode())
+    {
+        LOG_INFO(&logger(), "Starting in FIPS mode, KAT test result: {}, Integrity check: {}",
+                BORINGSSL_self_test(), BORINGSSL_integrity_test());
+    }
+#endif
 }
 
 std::string Server::getDefaultCorePath() const


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Extra logging on server startup to make explicit that server started in FIPS mode and appropriate checks passed.

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
