### PR TITLE
Antalya 25.8: follow-up for #1531

### DIFF
--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -97,13 +97,14 @@ TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::createEmpty
 template <typename Definition, typename Configuration, bool is_data_lake>
 void TableFunctionObjectStorage<Definition, Configuration, is_data_lake>::parseArguments(const ASTPtr & ast_function, ContextPtr context)
 {
-    if constexpr (std::is_same_v<Definition, IcebergLocalDefinition> || std::is_same_v<Definition, DeltaLakeLocalDefinition>)
+    if constexpr (std::is_same_v<Definition, IcebergLocalDefinition> || std::is_same_v<Definition, IcebergLocalClusterDefinition>
+                  || std::is_same_v<Definition, DeltaLakeLocalDefinition>)
     {
         if (!context->getSettingsRef()[Setting::allow_local_data_lakes])
             throw Exception(
                 ErrorCodes::SUPPORT_IS_DISABLED,
                 "Table function '{}' is disabled. Set `allow_local_data_lakes` to enable it",
-                Definition::name);
+                getName());
     }
 
     /// Clone ast function, because we can modify its arguments like removing headers.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
