### PR TITLE
24.8.14 Backport of #98960 - Fix skip index not used for ALIAS columns when query plan expression merging is disabled

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyConditionAndLimit.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrimaryKeyConditionAndLimit.cpp
@@ -22,22 +22,40 @@ void optimizePrimaryKeyConditionAndLimit(const Stack & stack)
     if (storage_prewhere_info)
         source_step_with_filter->addFilter(storage_prewhere_info->prewhere_actions.clone(), storage_prewhere_info->prewhere_column_name);
 
+    /// Collect ExpressionStep DAGs encountered while walking up the plan.
+    /// When a filter references columns produced by expressions (e.g., ALIAS
+    /// columns computed in "Compute alias columns" step, or renamed in
+    /// "Change column names to column identifiers" step), we compose the
+    /// filter through these expression DAGs so that column references are
+    /// resolved to physical columns. This is essential for correct index
+    /// analysis when plan optimizations like mergeExpressions have not
+    /// merged these steps into the filter.
+    std::vector<const ActionsDAG *> expression_dags;
+
     for (auto iter = stack.rbegin() + 1; iter != stack.rend(); ++iter)
     {
         if (auto * filter_step = typeid_cast<FilterStep *>(iter->node->step.get()))
         {
-            source_step_with_filter->addFilter(filter_step->getExpression().clone(), filter_step->getFilterColumnName());
+            auto filter_dag = filter_step->getExpression().clone();
+            auto filter_column_name = filter_step->getFilterColumnName();
+
+            /// Compose filter through accumulated expression DAGs
+            /// (in bottom-to-top order). This resolves column identifiers
+            /// to their underlying expressions, enabling correct index
+            /// matching for ALIAS columns and renamed columns.
+            for (auto it = expression_dags.rbegin(); it != expression_dags.rend(); ++it)
+                filter_dag = ActionsDAG::merge((*it)->clone(), std::move(filter_dag));
+
+            source_step_with_filter->addFilter(std::move(filter_dag), filter_column_name);
         }
         else if (auto * limit_step = typeid_cast<LimitStep *>(iter->node->step.get()))
         {
             source_step_with_filter->setLimit(limit_step->getLimitForSorting());
             break;
         }
-        else if (typeid_cast<ExpressionStep *>(iter->node->step.get()))
+        else if (auto * expression_step = typeid_cast<ExpressionStep *>(iter->node->step.get()))
         {
-            /// Note: actually, plan optimizations merge Filter and Expression steps.
-            /// Ideally, chain should look like (Expression -> ...) -> (Filter -> ...) -> ReadFromStorage,
-            /// So this is likely not needed.
+            expression_dags.push_back(&expression_step->getExpression());
             continue;
         }
         else

--- a/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.reference
+++ b/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.reference
@@ -1,0 +1,85 @@
+merge_expressions=0
+Expression (Project names)
+  Expression (Projection)
+    Filter (WHERE)
+      Expression (Change column names to column identifiers)
+        Expression (Compute alias columns)
+          ReadFromMergeTree (default.test_alias_skip_idx)
+          Indexes:
+            PrimaryKey
+              Keys:
+                c
+              Condition: (plus(c, 1) in [101, +Inf))
+              Parts: 1/2
+              Granules: 1/2
+              Search Algorithm: generic exclusion search
+            Skip
+              Name: idx_a
+              Description: minmax GRANULARITY 1
+              Condition: (plus(c, 1) in [101, +Inf))
+              Parts: 1/1
+              Granules: 1/1
+            Ranges: 1
+enable_optimizations=0
+Expression (Project names)
+  Expression (Projection)
+    Filter (WHERE)
+      Expression (Change column names to column identifiers)
+        Expression (Compute alias columns)
+          ReadFromMergeTree (default.test_alias_skip_idx)
+          Indexes:
+            PrimaryKey
+              Keys:
+                c
+              Condition: (plus(c, 1) in [101, +Inf))
+              Parts: 1/2
+              Granules: 1/2
+              Search Algorithm: generic exclusion search
+            Skip
+              Name: idx_a
+              Description: minmax GRANULARITY 1
+              Condition: (plus(c, 1) in [101, +Inf))
+              Parts: 1/1
+              Granules: 1/1
+            Ranges: 1
+nested_alias
+Expression (Project names)
+  Expression (Projection)
+    Filter (WHERE)
+      Expression (Change column names to column identifiers)
+        Expression (Compute alias columns)
+          ReadFromMergeTree (default.test_nested_alias_idx)
+          Indexes:
+            PrimaryKey
+              Keys:
+                c
+              Condition: (plus(plus(c, 1), 1) in [101, +Inf))
+              Parts: 1/2
+              Granules: 1/2
+              Search Algorithm: generic exclusion search
+            Skip
+              Name: idx_a2
+              Description: minmax GRANULARITY 1
+              Condition: (plus(plus(c, 1), 1) in [101, +Inf))
+              Parts: 1/1
+              Granules: 1/1
+            Ranges: 1
+default_settings
+Expression ((Project names + Projection))
+  Filter ((WHERE + (Change column names to column identifiers + Compute alias columns)))
+    ReadFromMergeTree (default.test_alias_skip_idx)
+    Indexes:
+      PrimaryKey
+        Keys:
+          c
+        Condition: (plus(c, 1) in [101, +Inf))
+        Parts: 1/2
+        Granules: 1/2
+        Search Algorithm: generic exclusion search
+      Skip
+        Name: idx_a
+        Description: minmax GRANULARITY 1
+        Condition: (plus(c, 1) in [101, +Inf))
+        Parts: 1/1
+        Granules: 1/1
+      Ranges: 1

--- a/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.reference
+++ b/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.reference
@@ -7,19 +7,16 @@ Expression (Project names)
           ReadFromMergeTree (default.test_alias_skip_idx)
           Indexes:
             PrimaryKey
-              Keys:
+              Keys: 
                 c
               Condition: (plus(c, 1) in [101, +Inf))
               Parts: 1/2
               Granules: 1/2
-              Search Algorithm: generic exclusion search
             Skip
               Name: idx_a
               Description: minmax GRANULARITY 1
-              Condition: (plus(c, 1) in [101, +Inf))
               Parts: 1/1
               Granules: 1/1
-            Ranges: 1
 enable_optimizations=0
 Expression (Project names)
   Expression (Projection)
@@ -29,19 +26,16 @@ Expression (Project names)
           ReadFromMergeTree (default.test_alias_skip_idx)
           Indexes:
             PrimaryKey
-              Keys:
+              Keys: 
                 c
               Condition: (plus(c, 1) in [101, +Inf))
               Parts: 1/2
               Granules: 1/2
-              Search Algorithm: generic exclusion search
             Skip
               Name: idx_a
               Description: minmax GRANULARITY 1
-              Condition: (plus(c, 1) in [101, +Inf))
               Parts: 1/1
               Granules: 1/1
-            Ranges: 1
 nested_alias
 Expression (Project names)
   Expression (Projection)
@@ -51,35 +45,29 @@ Expression (Project names)
           ReadFromMergeTree (default.test_nested_alias_idx)
           Indexes:
             PrimaryKey
-              Keys:
+              Keys: 
                 c
               Condition: (plus(plus(c, 1), 1) in [101, +Inf))
               Parts: 1/2
               Granules: 1/2
-              Search Algorithm: generic exclusion search
             Skip
               Name: idx_a2
               Description: minmax GRANULARITY 1
-              Condition: (plus(plus(c, 1), 1) in [101, +Inf))
               Parts: 1/1
               Granules: 1/1
-            Ranges: 1
 default_settings
 Expression ((Project names + Projection))
   Filter ((WHERE + (Change column names to column identifiers + Compute alias columns)))
     ReadFromMergeTree (default.test_alias_skip_idx)
     Indexes:
       PrimaryKey
-        Keys:
+        Keys: 
           c
         Condition: (plus(c, 1) in [101, +Inf))
         Parts: 1/2
         Granules: 1/2
-        Search Algorithm: generic exclusion search
       Skip
         Name: idx_a
         Description: minmax GRANULARITY 1
-        Condition: (plus(c, 1) in [101, +Inf))
         Parts: 1/1
         Granules: 1/1
-      Ranges: 1

--- a/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.sql
+++ b/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.sql
@@ -1,0 +1,60 @@
+-- Tags: no-parallel-replicas
+-- Test that skip indexes on ALIAS columns work even when query plan
+-- expression merging is disabled, which prevents tryMergeExpressions
+-- from composing filter and expression steps.
+-- Regression test for issue #98822.
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS test_alias_skip_idx;
+
+CREATE TABLE test_alias_skip_idx
+(
+    c UInt32,
+    a ALIAS c + 1,
+    INDEX idx_a (a) TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY c
+SETTINGS index_granularity = 8192, add_minmax_index_for_numeric_columns = 0;
+
+INSERT INTO test_alias_skip_idx SELECT number FROM numbers(10);
+INSERT INTO test_alias_skip_idx SELECT number + 200 FROM numbers(10);
+
+-- Test 1: Skip index used with merge_expressions disabled
+SELECT 'merge_expressions=0';
+EXPLAIN indexes = 1 SELECT * FROM test_alias_skip_idx WHERE a > 100
+SETTINGS query_plan_merge_expressions = 0;
+
+-- Test 2: Skip index used with all optimizations disabled
+SELECT 'enable_optimizations=0';
+EXPLAIN indexes = 1 SELECT * FROM test_alias_skip_idx WHERE a > 100
+SETTINGS query_plan_enable_optimizations = 0;
+
+-- Test 3: Nested ALIAS columns
+DROP TABLE IF EXISTS test_nested_alias_idx;
+
+CREATE TABLE test_nested_alias_idx
+(
+    c UInt32,
+    a1 ALIAS c + 1,
+    a2 ALIAS a1 + 1,
+    INDEX idx_a2 (a2) TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY c
+SETTINGS index_granularity = 8192, add_minmax_index_for_numeric_columns = 0;
+
+INSERT INTO test_nested_alias_idx SELECT number FROM numbers(10);
+INSERT INTO test_nested_alias_idx SELECT number + 200 FROM numbers(10);
+
+SELECT 'nested_alias';
+EXPLAIN indexes = 1 SELECT * FROM test_nested_alias_idx WHERE a2 > 100
+SETTINGS query_plan_merge_expressions = 0;
+
+-- Test 4: Default settings still work (regression guard)
+SELECT 'default_settings';
+EXPLAIN indexes = 1 SELECT * FROM test_alias_skip_idx WHERE a > 100;
+
+DROP TABLE test_alias_skip_idx;
+DROP TABLE test_nested_alias_idx;

--- a/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.sql
+++ b/tests/queries/0_stateless/03822_alias_column_skip_index_no_merge.sql
@@ -16,7 +16,7 @@ CREATE TABLE test_alias_skip_idx
 )
 ENGINE = MergeTree
 ORDER BY c
-SETTINGS index_granularity = 8192, add_minmax_index_for_numeric_columns = 0;
+SETTINGS index_granularity = 8192;
 
 INSERT INTO test_alias_skip_idx SELECT number FROM numbers(10);
 INSERT INTO test_alias_skip_idx SELECT number + 200 FROM numbers(10);
@@ -43,7 +43,7 @@ CREATE TABLE test_nested_alias_idx
 )
 ENGINE = MergeTree
 ORDER BY c
-SETTINGS index_granularity = 8192, add_minmax_index_for_numeric_columns = 0;
+SETTINGS index_granularity = 8192;
 
 INSERT INTO test_nested_alias_idx SELECT number FROM numbers(10);
 INSERT INTO test_nested_alias_idx SELECT number + 200 FROM numbers(10);


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix skip indexes (and primary key conditions) not being applied for ALIAS columns when query plan expression merging is disabled (query_plan_merge_expressions = 0 or query_plan_enable_optimizations = 0). (https://github.com/ClickHouse/ClickHouse/pull/98960 by @fastio)

### Documentation entry for user-facing changes
When query plan expression merging is disabled, ExpressionStep nodes like "Compute alias columns" and "Change column names to column identifiers" remain separate
from filter steps. The optimizePrimaryKeyConditionAndLimit optimization previously ignored these expression steps, causing filters on ALIAS columns to reference
unresolved column identifiers that the storage layer could not match against indexes.

This fix composes filter DAGs through accumulated expression DAGs (in bottom-to-top order) so that ALIAS column references are resolved to their underlying physical
column expressions, enabling correct primary key and skip index analysis regardless of whether expression merging is active.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
