### PR TITLE
Antalya 26.1: Fix remote initiator host name

### DIFF
--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -34,6 +34,7 @@
 #include <Analyzer/JoinNode.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/Utils.h>
+#include <Poco/URI.h>
 
 #include <algorithm>
 #include <memory>
@@ -405,7 +406,8 @@ IStorageCluster::RemoteCallVariables IStorageCluster::convertToRemote(
     /// After getClusterImpl each shard must have exactly 1 replica
     if (shard_addresses.size() != 1)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of shard {} in cluster {} is not equal 1", shard_num, cluster_name_from_settings);
-    auto host_name = shard_addresses[0].toString();
+    std::string host_name;
+    Poco::URI::decode(shard_addresses[0].toString(), host_name);
 
     LOG_INFO(log, "Choose remote initiator '{}'", host_name);
 

--- a/tests/integration/test_s3_cluster/configs/cluster.xml
+++ b/tests/integration/test_s3_cluster/configs/cluster.xml
@@ -20,6 +20,20 @@
         </shard>
     </cluster_simple>
 
+    <!-- Cluster without s0_0_0-->
+    <cluster_remote>
+        <shard>
+            <replica>
+                <host>s0_0_1</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>s0_1_0</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </cluster_remote>
+
     <!-- A part of the cluster above, represents only one shard-->
     <first_shard>
         <shard>
@@ -48,6 +62,44 @@
             </replica>
         </shard>
     </cluster_non_existent_port>
+
+    <cluster_with_dots>
+        <shard>
+            <replica>
+                <host>c2.s0_0_0</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>c2.s0_0_1</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </cluster_with_dots>
+
+    <cluster_all>
+        <shard>
+            <replica>
+                <host>s0_0_0</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>s0_0_1</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>s0_1_0</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>c2.s0_0_0</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>c2.s0_0_1</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </cluster_all>
 
     </remote_servers>
     <macros>

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -114,6 +114,22 @@ def started_cluster():
             with_zookeeper=True,
             stay_alive=True,
         )
+        cluster.add_instance(
+            "c2.s0_0_0",
+            main_configs=["configs/cluster.xml", "configs/named_collections.xml"],
+            user_configs=["configs/users.xml"],
+            macros={"replica": "replica1", "shard": "shard1"},
+            with_zookeeper=True,
+            stay_alive=True,
+        )
+        cluster.add_instance(
+            "c2.s0_0_1",
+            main_configs=["configs/cluster.xml", "configs/named_collections.xml"],
+            user_configs=["configs/users.xml"],
+            macros={"replica": "replica2", "shard": "shard1"},
+            with_zookeeper=True,
+            stay_alive=True,
+        )
 
         logging.info("Starting cluster...")
         cluster.start()
@@ -1197,3 +1213,61 @@ def test_joins(started_cluster):
     )
     res = list(map(str.split, result8.splitlines()))
     assert len(res) == 25
+
+
+def test_object_storage_remote_initiator(started_cluster):
+    node = started_cluster.instances["s0_0_0"]
+
+    query_id = uuid.uuid4().hex
+    result = node.query(
+        f"""
+        SELECT * from s3Cluster(
+            'cluster_remote',
+            'http://minio1:9001/root/data/{{clickhouse,database}}/*', 'minio', '{minio_secret_key}', 'CSV',
+            'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
+        SETTINGS object_storage_remote_initiator=1
+        """,
+        query_id = query_id,
+    )
+
+    assert result is not None
+
+    node.query("SYSTEM FLUSH LOGS ON CLUSTER 'cluster_all'")
+    queries = node.query(
+        f"""
+        SELECT count()
+            FROM clusterAllReplicas('cluster_all', system.query_log)
+            WHERE type='QueryFinish' AND initial_query_id='{query_id}'
+            FORMAT TSV
+        """
+    ).splitlines()
+
+    # initial node + describe table + remote initiator + 2 subqueries on replicas
+    assert queries == ["5"]
+
+    query_id = uuid.uuid4().hex
+    result = node.query(
+        f"""
+        SELECT * from s3Cluster(
+            'cluster_with_dots',
+            'http://minio1:9001/root/data/{{clickhouse,database}}/*', 'minio', '{minio_secret_key}', 'CSV',
+            'name String, value UInt32, polygon Array(Array(Tuple(Float64, Float64)))') ORDER BY (name, value, polygon)
+        SETTINGS object_storage_remote_initiator=1
+        """,
+        query_id = query_id,
+    )
+
+    assert result is not None
+
+    node.query("SYSTEM FLUSH LOGS ON CLUSTER 'cluster_all'")
+    queries = node.query(
+        f"""
+        SELECT count()
+            FROM clusterAllReplicas('cluster_all', system.query_log)
+            WHERE type='QueryFinish' AND initial_query_id='{query_id}'
+            FORMAT TSV
+        """
+    ).splitlines()
+
+    # initial node + describe table + remote initiator + 2 subqueries on replicas
+    assert queries == ["5"]


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Solved #1549
Fix remote initiator host name


### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
