### PR TITLE
Antalya 26.1 - enable antalya-related regression suites by default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@
 - [x] <!---ci_exclude_ubsan--> All with UBSAN
 - [x] <!---ci_exclude_coverage--> All with Coverage
 - [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
-- [x] <!---ci_exclude_regression--> All Regression
+- [ ] <!---ci_exclude_regression--> All Regression
 - [ ] <!---no_ci_cache--> Disable CI Cache
 
 #### Regression jobs to run:
@@ -40,10 +40,12 @@
 - [ ] <!---ci_regression_alter--> Alter (1.5h)
 - [ ] <!---ci_regression_benchmark--> Benchmark (30m)
 - [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
-- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
+- [x] <!---ci_regression_iceberg--> Iceberg (2h)
 - [ ] <!---ci_regression_ldap--> LDAP (1h)
-- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
+- [x] <!---ci_regression_parquet--> Parquet (1.5h)
 - [ ] <!---ci_regression_rbac--> RBAC (1.5h)
 - [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
 - [ ] <!---ci_regression_s3--> S3 (2h)
+- [x] <!---ci_regression_s3_export--> S3 Export (2h)
+- [x] <!---ci_regression_swarms--> Swarms (30m)
 - [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SUITE: [aes_encryption, atomic_insert, attach, base_58, clickhouse_keeper_failover,data_types, datetime64_extended_range, disk_level_encryption, dns, engines, example, extended_precision_data_types, functions, jwt_authentication, kafka, kerberos, key_value, lightweight_delete, memory, part_moves_between_shards, selects, session_timezone, settings, swarms, version, window_functions]
+        SUITE: [aes_encryption, atomic_insert, attach, base_58, clickhouse_keeper_failover,data_types, datetime64_extended_range, disk_level_encryption, dns, engines, example, extended_precision_data_types, functions, jwt_authentication, kafka, kerberos, key_value, lightweight_delete, memory, part_moves_between_shards, selects, session_timezone, settings, version, window_functions]
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -435,7 +435,7 @@ jobs:
   S3Export:
     if: |
       fromJson(inputs.workflow_config).JOB_KV_DATA.ci_regression_jobs[0] == null ||
-      contains(fromJson(inputs.workflow_config).JOB_KV_DATA.ci_regression_jobs, 's3')
+      contains(fromJson(inputs.workflow_config).JOB_KV_DATA.ci_regression_jobs, 's3_export')
     strategy:
       fail-fast: false
       matrix:
@@ -459,6 +459,26 @@ jobs:
       regression_args: --storage minio
       extra_args: --only ":/try*" "minio/export tests/export ${{ matrix.PART }}/*"
     secrets: inherit
+
+  Swarms:
+      if: |
+        fromJson(inputs.workflow_config).JOB_KV_DATA.ci_regression_jobs[0] == null ||
+        contains(fromJson(inputs.workflow_config).JOB_KV_DATA.ci_regression_jobs, 'swarms')
+      uses: ./.github/workflows/regression-reusable-suite.yml
+      with:
+        ref: ${{ inputs.commit }}
+        workflow_config: ${{ inputs.workflow_config }}
+        suite_name: swarms
+        suite_executable: regression.py
+        output_format: new-fails
+        flags: --with-analyzer
+        timeout_minutes: ${{ inputs.timeout_minutes }}
+        runner_arch: ${{ inputs.arch }}
+        runner_type: ${{ inputs.runner_type }}
+        build_sha: ${{ inputs.build_sha }}
+        set_commit_status: true
+        job_name: swarms
+      secrets: inherit
 
   TieredStorage:
     if: |


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Reconfigure regression workflow to handle the new settings.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
