### PR TITLE
Antalya-26.1 - Update CVE sorting

### DIFF
--- a/.github/actions/create_workflow_report/ci_run_report.html.jinja
+++ b/.github/actions/create_workflow_report/ci_run_report.html.jinja
@@ -226,6 +226,8 @@
           element.className = element.className.replace(regex_dir, '') + dir
         }
         function getValue(element) {
+          var childWithSort = element.querySelector('[data-sort]')
+          if (childWithSort) return childWithSort.getAttribute('data-sort')
           return (
             (alt_sort && element.getAttribute('data-sort-alt')) ||
             element.getAttribute('data-sort') || element.innerText

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -26,6 +26,9 @@ S3_BUCKET = "altinity-build-artifacts"
 GITHUB_REPO = "Altinity/ClickHouse"
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
 
+CVE_SEVERITY_ORDER = {"critical": 1, "high": 2, "medium": 3, "low": 4, "negligible": 5}
+
+
 def get_commit_statuses(sha: str) -> pd.DataFrame:
     """
     Fetch commit statuses for a given SHA and return as a pandas DataFrame.
@@ -536,11 +539,9 @@ def get_cves(pr_number, commit_sha, branch):
         return pd.DataFrame()
 
     df = pd.DataFrame(rows).drop_duplicates()
-    df = df.sort_values(
+    df = df.sort_values(by="docker_image").sort_values(
         by="severity",
-        key=lambda col: col.str.lower().map(
-            {"critical": 1, "high": 2, "medium": 3, "low": 4, "negligible": 5}
-        ),
+        key=lambda col: col.str.lower().map(CVE_SEVERITY_ORDER),
     )
     return df
 
@@ -588,6 +589,9 @@ def format_results_as_html_table(results) -> str:
             "Message": lambda m: m.replace("\n", " "),
             "Identifier": lambda i: url_to_html_link(
                 "https://nvd.nist.gov/vuln/detail/" + i
+            ),
+            "Severity": lambda s: (
+                f'<span data-sort="{CVE_SEVERITY_ORDER.get(str(s).lower(), 6)}">{s}</span>'
             ),
         },
         escape=False,

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -501,7 +501,9 @@ def get_cves(pr_number, commit_sha, branch):
                 Bucket=S3_BUCKET, Prefix=s3_prefix, Delimiter="/"
             )
             grype_result_dirs.extend(
-                content["Prefix"] for content in response.get("CommonPrefixes", [])
+                content["Prefix"]
+                for content in response.get("CommonPrefixes", [])
+                if isinstance(content, dict) and content.get("Prefix")
             )
         except Exception as e:
             print(f"Error listing S3 objects at {s3_prefix}: {e}")
@@ -776,10 +778,15 @@ def create_workflow_report(
         "pr_new_fails": [],
         "checks_errors": get_checks_errors(db_client, commit_sha, branch_name),
         "regression_fails": get_regression_fails(db_client, actions_run_url),
-        "docker_images_cves": (
-            [] if not check_cves else get_cves(pr_number, commit_sha, branch_name)
-        ),
+        "docker_images_cves": [],
     }
+
+    try:
+        fail_results["docker_images_cves"] = (
+            [] if not check_cves else get_cves(pr_number, commit_sha, branch_name)
+        )
+    except Exception as e:
+        print(f"Error in get_cves: {e}")
 
     # get_cves returns ... in the case where no Grype result files were found.
     # This might occur when run in preview mode.

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -541,10 +541,13 @@ def get_cves(pr_number, commit_sha, branch):
         return pd.DataFrame()
 
     df = pd.DataFrame(rows).drop_duplicates()
-    df = df.sort_values(by="docker_image").sort_values(
-        by="severity",
-        key=lambda col: col.str.lower().map(CVE_SEVERITY_ORDER),
-    )
+
+    def _cve_sort_key(col):
+        if col.name == "severity":
+            return col.str.lower().map(CVE_SEVERITY_ORDER)
+        return col
+
+    df = df.sort_values(by=["severity", "docker_image"], key=_cve_sort_key)
     return df
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
