### PR TITLE
Antalya 25.8: Fix use after free in rescheduleTasksFromReplica

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
@@ -48,6 +48,9 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getNextTask(size_t numb
     {
         std::lock_guard lock(mutex);
         auto processed_file_list_ptr = replica_to_files_to_be_processed.find(number_of_current_replica);
+        // rescheduleTasksFromReplica can be called only when error catched in RemoteQueryExecutor::processPacket
+        // so getnextTash can't bealled after that
+        // Check only for logical eeror in code
         if (processed_file_list_ptr == replica_to_files_to_be_processed.end())
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
@@ -69,15 +72,15 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getNextTask(size_t numb
     {
         std::lock_guard lock(mutex);
         auto processed_file_list_ptr = replica_to_files_to_be_processed.find(number_of_current_replica);
+
         if (processed_file_list_ptr == replica_to_files_to_be_processed.end())
-        { // It is possible that replica was lost after check in the begining of the method
-            auto file_identifier = getFileIdentifier(file);
-            auto file_replica_idx = getReplicaForFile(file_identifier);
-            unprocessed_files.emplace(file_identifier, std::make_pair(file, file_replica_idx));
-            connection_to_files[file_replica_idx].push_back(file);
-        }
-        else
-            processed_file_list_ptr->second.push_back(file);
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Replica number {} was marked as lost, can't set task for it anymore",
+                number_of_current_replica
+            );
+
+        processed_file_list_ptr->second.push_back(file);
     }
 
     return file;

--- a/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
@@ -71,7 +71,7 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getNextTask(size_t numb
         auto processed_file_list_ptr = replica_to_files_to_be_processed.find(number_of_current_replica);
         if (processed_file_list_ptr == replica_to_files_to_be_processed.end())
         { // It is possible that replica was lost after check in the begining of the method
-            auto file_identifier = file->getAbsolutePath().value_or(file->getPath());
+            auto file_identifier = getFileIdentifier(file);
             auto file_replica_idx = getReplicaForFile(file_identifier);
             unprocessed_files.emplace(file_identifier, std::make_pair(file, file_replica_idx));
             connection_to_files[file_replica_idx].push_back(file);
@@ -136,7 +136,7 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getPreQueuedFile(size_t
         auto next_file = files.back();
         files.pop_back();
 
-        auto file_identifier = send_over_whole_archive ? next_file->getPathOrPathToArchiveIfArchive() : next_file->getIdentifier();
+        auto file_identifier = getFileIdentifier(next_file);
         auto it = unprocessed_files.find(file_identifier);
         if (it == unprocessed_files.end())
             continue;
@@ -194,18 +194,7 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getMatchingFileFromIter
             }
         }
 
-        String file_identifier;
-        if (send_over_whole_archive && object_info->isArchive())
-        {
-            file_identifier = object_info->getPathOrPathToArchiveIfArchive();
-            LOG_TEST(log, "Will send over the whole archive {} to replicas. "
-                     "This will be suboptimal, consider turning on "
-                     "cluster_function_process_archive_on_multiple_nodes setting", file_identifier);
-        }
-        else
-        {
-            file_identifier = object_info->getIdentifier();
-        }
+        String file_identifier = getFileIdentifier(object_info, true);
 
         size_t file_replica_idx;
 
@@ -269,7 +258,7 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getAnyUnprocessedFile(s
                 auto next_file = it->second.first;
                 unprocessed_files.erase(it);
 
-                auto file_path = send_over_whole_archive ? next_file->getPathOrPathToArchiveIfArchive() : next_file->getAbsolutePath().value_or(next_file->getPath());
+                auto file_path = getFileIdentifier(next_file);
                 LOG_TRACE(
                     log,
                     "Iterator exhausted. Assigning unprocessed file {} to replica {} from matched replica {}",
@@ -333,10 +322,27 @@ void StorageObjectStorageStableTaskDistributor::rescheduleTasksFromReplica(size_
     replica_to_files_to_be_processed.erase(number_of_current_replica);
     for (const auto & file : files)
     {
-        auto file_replica_idx = getReplicaForFile(file->getAbsolutePath().value_or(file->getPath()));
-        unprocessed_files.emplace(file->getAbsolutePath().value_or(file->getPath()), std::make_pair(file, file_replica_idx));
+        auto file_identifier = getFileIdentifier(file);
+        auto file_replica_idx = getReplicaForFile(file_identifier);
+        unprocessed_files.emplace(file_identifier, std::make_pair(file, file_replica_idx));
         connection_to_files[file_replica_idx].push_back(file);
     }
+}
+
+String StorageObjectStorageStableTaskDistributor::getFileIdentifier(ObjectInfoPtr file_object, bool write_to_log) const
+{
+    if (send_over_whole_archive && file_object->isArchive())
+    {
+        auto file_identifier = file_object->getPathOrPathToArchiveIfArchive();
+        if (write_to_log)
+        {
+            LOG_TEST(log, "Will send over the whole archive {} to replicas. "
+                        "This will be suboptimal, consider turning on "
+                        "cluster_function_process_archive_on_multiple_nodes setting", file_identifier);
+        }
+        return file_identifier;
+    }
+    return file_object->getIdentifier();
 }
 
 }

--- a/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
@@ -45,13 +45,16 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getNextTask(size_t numb
 
     saveLastNodeActivity(number_of_current_replica);
 
-    auto processed_file_list_ptr = replica_to_files_to_be_processed.find(number_of_current_replica);
-    if (processed_file_list_ptr == replica_to_files_to_be_processed.end())
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR,
-            "Replica number {} was marked as lost, can't set task for it anymore",
-            number_of_current_replica
-        );
+    {
+        std::lock_guard lock(mutex);
+        auto processed_file_list_ptr = replica_to_files_to_be_processed.find(number_of_current_replica);
+        if (processed_file_list_ptr == replica_to_files_to_be_processed.end())
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Replica number {} was marked as lost, can't set task for it anymore",
+                number_of_current_replica
+            );
+    }
 
     // 1. Check pre-queued files first
     auto file = getPreQueuedFile(number_of_current_replica);
@@ -63,7 +66,19 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getNextTask(size_t numb
         file = getAnyUnprocessedFile(number_of_current_replica);
 
     if (file)
-        processed_file_list_ptr->second.push_back(file);
+    {
+        std::lock_guard lock(mutex);
+        auto processed_file_list_ptr = replica_to_files_to_be_processed.find(number_of_current_replica);
+        if (processed_file_list_ptr == replica_to_files_to_be_processed.end())
+        { // It is possible that replica was lost after check in the begining of the method
+            auto file_identifier = file->getAbsolutePath().value_or(file->getPath());
+            auto file_replica_idx = getReplicaForFile(file_identifier);
+            unprocessed_files.emplace(file_identifier, std::make_pair(file, file_replica_idx));
+            connection_to_files[file_replica_idx].push_back(file);
+        }
+        else
+            processed_file_list_ptr->second.push_back(file);
+    }
 
     return file;
 }
@@ -192,7 +207,13 @@ ObjectInfoPtr StorageObjectStorageStableTaskDistributor::getMatchingFileFromIter
             file_identifier = object_info->getIdentifier();
         }
 
-        size_t file_replica_idx = getReplicaForFile(file_identifier);
+        size_t file_replica_idx;
+
+        {
+            std::lock_guard lock(mutex);
+            file_replica_idx = getReplicaForFile(file_identifier);
+        }
+
         if (file_replica_idx == number_of_current_replica)
         {
             LOG_TRACE(

--- a/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
@@ -329,8 +329,9 @@ void StorageObjectStorageStableTaskDistributor::rescheduleTasksFromReplica(size_
             "All replicas were marked as lost"
         );
 
+    auto files = std::move(processed_file_list_ptr->second);
     replica_to_files_to_be_processed.erase(number_of_current_replica);
-    for (const auto & file : processed_file_list_ptr->second)
+    for (const auto & file : files)
     {
         auto file_replica_idx = getReplicaForFile(file->getAbsolutePath().value_or(file->getPath()));
         unprocessed_files.emplace(file->getAbsolutePath().value_or(file->getPath()), std::make_pair(file, file_replica_idx));

--- a/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.h
@@ -40,6 +40,8 @@ private:
 
     void saveLastNodeActivity(size_t number_of_current_replica);
 
+    String getFileIdentifier(ObjectInfoPtr file_object, bool write_to_log = false) const;
+
     const std::shared_ptr<IObjectIterator> iterator;
     const bool send_over_whole_archive;
 

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -1195,7 +1195,7 @@ def test_joins(started_cluster):
     assert len(res) == 25
 
 
-def _test_graceful_shutdown(started_cluster):
+def test_graceful_shutdown(started_cluster):
     node = started_cluster.instances["s0_0_0"]
     node_to_shutdown = started_cluster.instances["s0_1_0"]
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix incorrect potential initiator crash in cluster request when cluster node is unavailable.
Fix file identifier for distributed tasks in cluster request.


### Documentation entry for user-facing changes
Solved #1554 
Fix incorrect using iterator to removed element.

Backport of #1493
Fix file identifier for distributed tasks
(logic was backported in #1237)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
