### PR TITLE
25.3.8-fips: restrict TLS 1.3 ciphersuites to FIPS-approved algorithms

### DIFF
--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/Context.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/Context.h
@@ -148,6 +148,11 @@ namespace Net
             /// Specifies the supported ciphers in OpenSSL notation.
             /// Defaults to "ALL:!ADH:!LOW:!EXP:!MD5:!3DES:@STRENGTH".
 
+            std::string cipherSuites;
+            /// Specifies the supported TLSv1.3 ciphersuites in OpenSSL notation.
+            /// Defaults to "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256"
+            /// (FIPS-approved ciphersuites only).
+
             std::string dhParamsFile;
             /// Specifies a file containing Diffie-Hellman parameters.
             /// If empty, the default parameters are used.

--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -78,6 +78,7 @@ namespace Net
     ///            <verificationDepth>1..9</verificationDepth>
     ///            <loadDefaultCAFile>true|false</loadDefaultCAFile>
     ///            <cipherList>ALL:!ADH:!LOW:!EXP:!MD5:!3DES:@STRENGTH</cipherList>
+    ///            <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
     ///            <preferServerCiphers>true|false</preferServerCiphers>
     ///            <privateKeyPassphraseHandler>
     ///                <name>KeyFileHandler</name>
@@ -119,7 +120,9 @@ namespace Net
     ///      will fail if a certificate chain larger than this is encountered.
     ///    - loadDefaultCAFile (boolean): Specifies whether the builtin CA certificates from OpenSSL are used.
     ///    - cipherList (string): Specifies the supported ciphers in OpenSSL notation
-    ///      (e.g. "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH").
+    ///      (e.g. "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"). Only applies to TLSv1.2 and below.
+    ///    - cipherSuites (string): Specifies the supported TLSv1.3 ciphersuites in OpenSSL notation
+    ///      (e.g. "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"). If empty, the library default is used.
     ///    - preferServerCiphers (bool): When choosing a cipher, use the server's preferences instead of the
     ///      client preferences. When not called, the SSL server will always follow the clients
     ///      preferences. When called, the SSL/TLS server will choose following its own
@@ -278,6 +281,8 @@ namespace Net
         static const std::string CFG_CIPHER_LIST;
         static const std::string CFG_CYPHER_LIST; // for backwards compatibility
         static const std::string VAL_CIPHER_LIST;
+        static const std::string CFG_CIPHER_SUITES;
+        static const std::string VAL_CIPHER_SUITES;
         static const std::string CFG_PREFER_SERVER_CIPHERS;
         static const std::string CFG_DELEGATE_HANDLER;
         static const std::string VAL_DELEGATE_HANDLER;

--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -121,8 +121,8 @@ namespace Net
     ///    - loadDefaultCAFile (boolean): Specifies whether the builtin CA certificates from OpenSSL are used.
     ///    - cipherList (string): Specifies the supported ciphers in OpenSSL notation
     ///      (e.g. "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"). Only applies to TLSv1.2 and below.
-    ///    - cipherSuites (string): Specifies the supported TLSv1.3 ciphersuites in OpenSSL notation
-    ///      (e.g. "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384"). If empty, the library default is used.
+    ///    - cipherSuites (string): Specifies the supported TLSv1.3 ciphersuites in OpenSSL notation.
+    ///      Defaults to "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256" (FIPS-approved ciphersuites only).
     ///    - preferServerCiphers (bool): When choosing a cipher, use the server's preferences instead of the
     ///      client preferences. When not called, the SSL server will always follow the clients
     ///      preferences. When called, the SSL/TLS server will choose following its own

--- a/base/poco/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
+++ b/base/poco/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h
@@ -78,7 +78,7 @@ namespace Net
     ///            <verificationDepth>1..9</verificationDepth>
     ///            <loadDefaultCAFile>true|false</loadDefaultCAFile>
     ///            <cipherList>ALL:!ADH:!LOW:!EXP:!MD5:!3DES:@STRENGTH</cipherList>
-    ///            <cipherSuites>TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384</cipherSuites>
+    ///            <cipherSuites>TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256</cipherSuites>
     ///            <preferServerCiphers>true|false</preferServerCiphers>
     ///            <privateKeyPassphraseHandler>
     ///                <name>KeyFileHandler</name>

--- a/base/poco/NetSSL_OpenSSL/src/Context.cpp
+++ b/base/poco/NetSSL_OpenSSL/src/Context.cpp
@@ -42,7 +42,8 @@ Context::Params::Params():
 	verificationMode(VERIFY_RELAXED),
 	verificationDepth(9),
 	loadDefaultCAs(false),
-	cipherList("ALL:!ADH:!LOW:!EXP:!MD5:!3DES:@STRENGTH")
+	cipherList("ALL:!ADH:!LOW:!EXP:!MD5:!3DES:@STRENGTH"),
+	cipherSuites("TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256")
 {
 }
 
@@ -322,6 +323,7 @@ void Context::init(const Params& params)
 			SSL_CTX_set_verify(_pSSLContext, params.verificationMode, &SSLManager::verifyClientCallback);
 
 		SSL_CTX_set_cipher_list(_pSSLContext, params.cipherList.c_str());
+		SSL_CTX_set_ciphersuites(_pSSLContext, params.cipherSuites.c_str());
 		SSL_CTX_set_verify_depth(_pSSLContext, params.verificationDepth);
 		SSL_CTX_set_mode(_pSSLContext, SSL_MODE_AUTO_RETRY);
 		SSL_CTX_set_session_cache_mode(_pSSLContext, SSL_SESS_CACHE_OFF);

--- a/base/poco/NetSSL_OpenSSL/src/SSLManager.cpp
+++ b/base/poco/NetSSL_OpenSSL/src/SSLManager.cpp
@@ -42,6 +42,8 @@ const bool        SSLManager::VAL_ENABLE_DEFAULT_CA(true);
 const std::string SSLManager::CFG_CIPHER_LIST("cipherList");
 const std::string SSLManager::CFG_CYPHER_LIST("cypherList");
 const std::string SSLManager::VAL_CIPHER_LIST("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
+const std::string SSLManager::CFG_CIPHER_SUITES("cipherSuites");
+const std::string SSLManager::VAL_CIPHER_SUITES("TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256");
 const std::string SSLManager::CFG_PREFER_SERVER_CIPHERS("preferServerCiphers");
 const std::string SSLManager::CFG_DELEGATE_HANDLER("privateKeyPassphraseHandler.name");
 const std::string SSLManager::VAL_DELEGATE_HANDLER("KeyConsoleHandler");
@@ -275,6 +277,7 @@ void SSLManager::initDefaultContext(bool server)
 	params.loadDefaultCAs = config.getBool(prefix + CFG_ENABLE_DEFAULT_CA, VAL_ENABLE_DEFAULT_CA);
 	params.cipherList = config.getString(prefix + CFG_CIPHER_LIST, VAL_CIPHER_LIST);
 	params.cipherList = config.getString(prefix + CFG_CYPHER_LIST, params.cipherList); // for backwards compatibility
+	params.cipherSuites = config.getString(prefix + CFG_CIPHER_SUITES, VAL_CIPHER_SUITES);
 	bool requireTLSv1 = config.getBool(prefix + CFG_REQUIRE_TLSV1, false);
 	bool requireTLSv1_1 = config.getBool(prefix + CFG_REQUIRE_TLSV1_1, false);
 	bool requireTLSv1_2 = config.getBool(prefix + CFG_REQUIRE_TLSV1_2, false);

--- a/src/Server/PostgreSQLHandler.cpp
+++ b/src/Server/PostgreSQLHandler.cpp
@@ -90,6 +90,7 @@ PostgreSQLHandler::PostgreSQLHandler(
         params.cipherList = config.getString(prefix + Poco::Net::SSLManager::CFG_CIPHER_LIST, Poco::Net::SSLManager::VAL_CIPHER_LIST);
         params.cipherList
             = config.getString(prefix + Poco::Net::SSLManager::CFG_CYPHER_LIST, params.cipherList); // for backwards compatibility
+        params.cipherSuites = config.getString(prefix + Poco::Net::SSLManager::CFG_CIPHER_SUITES, Poco::Net::SSLManager::VAL_CIPHER_SUITES);
 
         bool require_tlsv1 = config.getBool(prefix + Poco::Net::SSLManager::CFG_REQUIRE_TLSV1, false);
         bool require_tlsv1_1 = config.getBool(prefix + Poco::Net::SSLManager::CFG_REQUIRE_TLSV1_1, false);

--- a/src/Server/TLSHandler.cpp
+++ b/src/Server/TLSHandler.cpp
@@ -51,6 +51,7 @@ DB::TLSHandler::TLSHandler(
         params.loadDefaultCAs = config.getBool(prefix + SSLManager::CFG_ENABLE_DEFAULT_CA, SSLManager::VAL_ENABLE_DEFAULT_CA);
         params.cipherList = config.getString(prefix + SSLManager::CFG_CIPHER_LIST, SSLManager::VAL_CIPHER_LIST);
         params.cipherList = config.getString(prefix + SSLManager::CFG_CYPHER_LIST, params.cipherList); // for backwards compatibility
+        params.cipherSuites = config.getString(prefix + SSLManager::CFG_CIPHER_SUITES, SSLManager::VAL_CIPHER_SUITES);
 
         bool require_tlsv1 = config.getBool(prefix + SSLManager::CFG_REQUIRE_TLSV1, false);
         bool require_tlsv1_1 = config.getBool(prefix + SSLManager::CFG_REQUIRE_TLSV1_1, false);


### PR DESCRIPTION
SSL_CTX_set_cipher_list() only controls TLS 1.2 and below. TLS 1.3 ciphersuites are a separate namespace controlled by SSL_CTX_set_ciphersuites(), which was never called. This meant all TLS 1.3 ciphersuites were allowed by default, including non-FIPS-approved ones like TLS_CHACHA20_POLY1305_SHA256.

Add a new "cipherSuites" parameter (mirroring the existing "cipherList") that calls SSL_CTX_set_ciphersuites(). The default is set to "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256", which are the only two FIPS-approved TLS 1.3 ciphersuites. This can be overridden via the <cipherSuites> XML config element under openSSL.server/client.

The parameter is plumbed through all three SSL context creation paths: SSLManager (general), TLSHandler (native TCP), and PostgreSQLHandler (PostgreSQL wire protocol).

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
restrict TLS 1.3 ciphersuites to FIPS-approved algorithms


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
