### PR TITLE
25.3 Update version to 10042

### DIFF
--- a/cmake/autogenerated_versions.txt
+++ b/cmake/autogenerated_versions.txt
@@ -8,9 +8,9 @@ SET(VERSION_MINOR 3)
 SET(VERSION_PATCH 8)
 SET(VERSION_GITHASH 36637934778b7d39b37f378d258359dd6ffdd110)
 #10000 for altinitystable candidates
-#20000 for altinityedge candidates
-SET(VERSION_TWEAK 10000)
+#20000 for altinityantalya candidates
+SET(VERSION_TWEAK 10042)
 SET(VERSION_FLAVOUR altinitytest)
-SET(VERSION_DESCRIBE v25.3.8.10000.altinitytest)
-SET(VERSION_STRING 25.3.8.10000.altinitytest)
+SET(VERSION_DESCRIBE v25.3.8.10042.altinitytest)
+SET(VERSION_STRING 25.3.8.10042.altinitytest)
 # end of autochange

--- a/tests/ci/test_version.py
+++ b/tests/ci/test_version.py
@@ -22,9 +22,10 @@ class TestFunctions(unittest.TestCase):
             ("v31.1.1.2-testing", vh.get_version_from_string("31.1.1.2")),
             ("refs/tags/v31.1.1.2-testing", vh.get_version_from_string("31.1.1.2")),
         )
-        for test_case in cases:
-            version = vh.version_arg(test_case[0])
-            self.assertEqual(test_case[1], version)
+        for i, test_case in enumerate(cases):
+            with self.subTest(test_case, i=i):
+                version = vh.version_arg(test_case[0])
+                self.assertEqual(test_case[1], version)
         error_cases = (
             "0.0.0",
             "1.1.1.a",
@@ -48,40 +49,29 @@ class TestFunctions(unittest.TestCase):
             expected: CHV
 
         cases = (
-            # TestCase(
-            #     "v24.6.1.1-new",
-            #     15,
-            #     "v24.4.1.2088-stable",
-            #     415,
-            #     CHV(24, 5, 1, 54487, None, 415),
-            # ),
-            # TestCase(
-            #     "v24.6.1.1-testing",
-            #     15,
-            #     "v24.4.1.2088-stable",
-            #     415,
-            #     CHV(24, 5, 1, 54487, None, 15),
-            # ),
-            # TestCase(
-            #     "v24.6.1.1-stable",
-            #     15,
-            #     "v24.4.1.2088-stable",
-            #     415,
-            #     CHV(24, 5, 1, 54487, None, 15),
-            # ),
-            # TestCase(
-            #     "v24.5.1.1-stable",
-            #     15,
-            #     "v24.4.1.2088-stable",
-            #     415,
-            #     CHV(24, 5, 1, 54487, None, 15),
-            # ),
+            # Tagged run: upstream-style tag on current commit, tweak must match cmake (15)
             TestCase(
-                "v24.5.1.100-stable",
+                "v24.5.1.15-stable",
                 0,
                 "v24.4.1.2088-stable",
                 415,
-                CHV(24, 5, 1, 54487, None, 100),
+                CHV(24, 5, 1, 54487, None, 15),
+            ),
+            # Tagged run: Altinity-style tag on current commit, tweak must match cmake (15)
+            TestCase(
+                "v24.5.1.15.altinitystable",
+                0,
+                "v24.4.1.2088-stable",
+                415,
+                CHV(24, 5, 1, 54487, None, 15),
+            ),
+            # PR run: not on a tagged commit, cmake version used as-is (tweak=15 from cmake file)
+            TestCase(
+                "v24.5.1.100-stable",
+                10,
+                "v24.4.1.2088-stable",
+                415,
+                CHV(24, 5, 1, 54487, None, 15),
             ),
         )
         git = Git(True)

--- a/tests/ci/version_helper.py
+++ b/tests/ci/version_helper.py
@@ -4,7 +4,12 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentType
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
 
-from pr_info import PRInfo  # grype scan needs to know the PR number
+try:
+    # grype scan needs to know the PR number
+    # But non-grype jobs might be missing dependencies
+    from pr_info import PRInfo
+except ImportError:
+    PRInfo = None
 
 from git_helper import TWEAK, Git, get_tags, git_runner, removeprefix, VersionType
 
@@ -311,7 +316,7 @@ def get_version_from_repo(
         flavour=versions.get("flavour", None)
     )
 
-    # if this commit is tagged, use tag's version instead of something stored in cmake
+    # If this commit is tagged, use tag's version instead of something stored in cmake
     if git is not None and git.latest_tag:
         version_from_tag = get_version_from_tag(git.latest_tag)
         logging.debug(f'Git latest tag: {git.latest_tag} ({git.commits_since_latest} commits ago)\n'
@@ -324,17 +329,13 @@ def get_version_from_repo(
             # Version must match (except tweak, flavour, description, etc.) to avoid accidental mess.
             if not (version_from_tag.major == cmake_version.major \
                     and version_from_tag.minor == cmake_version.minor \
-                    and version_from_tag.patch == cmake_version.patch):
-                raise RuntimeError(f"Version generated from tag ({version_from_tag}) should have same major, minor, and patch values as version generated from cmake ({cmake_version})")
+                    and version_from_tag.patch == cmake_version.patch \
+                    and version_from_tag.tweak == cmake_version.tweak):
+                raise RuntimeError(f"Version generated from tag ({version_from_tag}) should have same major, minor, patch, and tweak values as version generated from cmake ({cmake_version})")
 
             # Don't need to reset version completely, mostly because revision part is not set in tag, but must be preserved
-            logging.debug(f"Resetting TWEAK and FLAVOUR of version from cmake {cmake_version} to values from tag: {version_from_tag.tweak}.{version_from_tag._flavour}")
+            logging.debug(f"Resetting FLAVOUR of version from cmake {cmake_version} to values from tag: {version_from_tag._flavour}")
             cmake_version._flavour = version_from_tag._flavour
-            cmake_version.tweak = version_from_tag.tweak
-        else:
-            # We've had some number of commits since the latest (upstream) tag.
-            logging.debug(f"Bumping the TWEAK of version from cmake {cmake_version} by {git.commits_since_upstream}")
-            cmake_version.tweak = cmake_version.tweak + git.commits_since_upstream
 
     return cmake_version
 
@@ -433,9 +434,14 @@ def get_supported_versions(
 def update_cmake_version(
     version: ClickHouseVersion,
     versions_path: Union[Path, str] = FILE_WITH_VERSION_PATH,
+    preserve_sha: bool = False,
 ) -> None:
+    version_dict = version.as_dict()
+    if preserve_sha:
+        githash = read_versions(versions_path)["githash"]
+        version_dict["githash"] = githash
     get_abs_path(versions_path).write_text(
-        VERSIONS_TEMPLATE.format_map(version.as_dict()), encoding="utf-8"
+        VERSIONS_TEMPLATE.format_map(version_dict), encoding="utf-8"
     )
 
 
@@ -535,10 +541,11 @@ def main():
         update_cmake_version(version)
 
     # grype scan needs to know the PR number
-    pr_info = PRInfo()
-    print(f"PR_NUMBER={pr_info.number}")
-    if args.export:
-        print(f"export PR_NUMBER")
+    if PRInfo:
+        pr_info = PRInfo()
+        print(f"PR_NUMBER={pr_info.number}")
+        if args.export:
+            print(f"export PR_NUMBER")
 
     for k, v in version.as_dict().items():
         name = f"CLICKHOUSE_VERSION_{k.upper()}"


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Update the tweak to 10042

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
