### PR TITLE
Antalya 26.1 - Fix report old results

### DIFF
--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
+import time
 from pathlib import Path
 from itertools import combinations
 import json
@@ -14,6 +15,7 @@ import pandas as pd
 from jinja2 import Environment, FileSystemLoader
 import requests
 from clickhouse_driver import Client
+from clickhouse_driver.errors import ServerException
 import boto3
 from botocore.exceptions import NoCredentialsError
 import yaml
@@ -25,6 +27,31 @@ DATABASE_PASSWORD_VAR = "CLICKHOUSE_TEST_STAT_PASSWORD"
 S3_BUCKET = "altinity-build-artifacts"
 GITHUB_REPO = "Altinity/ClickHouse"
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+
+
+def _is_clickhouse_memory_limit_error(exc: BaseException) -> bool:
+    if isinstance(exc, ServerException) and getattr(exc, "code", None) == 241:
+        return True
+    msg = str(exc).lower()
+    return "memory limit" in msg or "memory_limit" in msg
+
+
+def query_dataframe_with_retry(
+    client: Client,
+    query: str,
+    *,
+    max_attempts: int = 5,
+    backoff_seconds: float = 3.0,
+) -> pd.DataFrame:
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return client.query_dataframe(query)
+        except Exception as e:
+            if not _is_clickhouse_memory_limit_error(e) or attempt >= max_attempts:
+                raise
+            wait = backoff_seconds * attempt
+            time.sleep(wait)
+
 
 def get_commit_statuses(sha: str) -> pd.DataFrame:
     """
@@ -198,7 +225,7 @@ def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
         AND job_status != 'error'
         ORDER BY job_name, test_name
         """
-    return client.query_dataframe(query)
+    return query_dataframe_with_retry(client, query)
 
 
 def get_broken_tests_rules(broken_tests_file_path):
@@ -270,7 +297,7 @@ def get_checks_known_fails(
         ORDER BY job_name, test_name
         """
 
-    df = client.query_dataframe(query)
+    df = query_dataframe_with_retry(client, query)
 
     if df.shape[0] == 0:
         return df
@@ -299,7 +326,7 @@ def get_checks_errors(client: Client, commit_sha: str, branch_name: str):
         WHERE job_status = 'error'
         ORDER BY job_name, test_name
         """
-    return client.query_dataframe(query)
+    return query_dataframe_with_retry(client, query)
 
 
 def drop_prefix_rows(df, column_to_clean):
@@ -341,7 +368,7 @@ def get_regression_fails(client: Client, job_url: str):
             WHERE job_url LIKE '{job_url}%'
             AND status IN ('Fail', 'Error')
             """
-    df = client.query_dataframe(query)
+    df = query_dataframe_with_retry(client, query)
     df = drop_prefix_rows(df, "test_name")
     df["job_name"] = df["job_name"].str.title()
     return df
@@ -396,7 +423,7 @@ def get_new_fails_this_pr(
             WHERE test_status NOT IN ('FAIL', 'ERROR')
             ORDER BY job_name, test_name
             """
-    base_checks = client.query_dataframe(base_checks_query)
+    base_checks = query_dataframe_with_retry(client, base_checks_query)
 
     # Get regression results from base branch that didn't fail
     base_regression_query = f"""SELECT arch, job_name, status, test_name, results_link
@@ -415,7 +442,7 @@ def get_new_fails_this_pr(
             )
             WHERE status NOT IN ('Fail', 'Error')
             """
-    base_regression = client.query_dataframe(base_regression_query)
+    base_regression = query_dataframe_with_retry(client, base_regression_query)
     if len(base_regression) > 0:
         base_regression["job_name"] = base_regression.apply(
             lambda row: f"{row['arch']} {row['job_name']}".strip(), axis=1

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -147,23 +147,51 @@ def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
     Get tests that did not succeed for the given commit and branch.
     Exclude checks that have status 'error' as they are counted in get_checks_errors.
     """
-    query = f"""SELECT job_status, job_name, status as test_status, test_name, results_link
-            FROM (
-                SELECT
-                    argMax(check_status, check_start_time) as job_status,
-                    check_name as job_name,
-                    argMax(test_status, check_start_time) as status,
-                    test_name,
-                    report_url as results_link,
-                    task_url
-                FROM `gh-data`.checks
-                WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
-                GROUP BY check_name, test_name, report_url, task_url
-            )
-            WHERE test_status IN ('FAIL', 'ERROR')
-            AND job_status!='error'
-            ORDER BY job_name, test_name
-            """
+    query = f"""WITH checks_for_commit AS (
+            SELECT
+                check_name,
+                test_name,
+                report_url,
+                check_status,
+                test_status,
+                check_start_time
+            FROM `gh-data`.checks
+            WHERE commit_sha = '{commit_sha}' AND head_ref = '{branch_name}'
+        ),
+        latest_start_time_for_checks AS (
+            SELECT
+                *,
+                max(check_start_time) OVER (PARTITION BY check_name) AS latest_check_start_time
+            FROM checks_for_commit
+            WHERE NOT (check_name LIKE 'Stateless%' AND NOT match(test_name, '^[0-9]{{5}}')) -- Exclude stateless teardown checks
+        ),
+        rows_from_latest_check_run AS (
+            SELECT
+                check_name,
+                test_name,
+                report_url,
+                check_status,
+                test_status,
+                check_start_time
+            FROM latest_start_time_for_checks
+            WHERE check_start_time >= latest_check_start_time
+        ),
+        latest_test_status AS (
+            SELECT
+                argMax(check_status, check_start_time) AS job_status,
+                check_name AS job_name,
+                argMax(test_status, check_start_time) AS status,
+                test_name,
+                report_url AS results_link
+            FROM rows_from_latest_check_run
+            GROUP BY check_name, test_name, report_url
+        )
+        SELECT job_status, job_name, status AS test_status, test_name, results_link
+        FROM latest_test_status
+        WHERE test_status IN ('FAIL', 'ERROR')
+        AND job_status != 'error'
+        ORDER BY job_name, test_name
+        """
     return client.query_dataframe(query)
 
 

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -356,6 +356,7 @@ def get_new_fails_this_pr(
     """
     Get tests that failed in the PR but passed in the base branch.
     Compares both checks and regression test results.
+    Always includes targeted checks (``targeted`` in job_name).
     """
     base_sha = pr_info.get("base", {}).get("sha")
     if not base_sha:
@@ -433,7 +434,9 @@ def get_new_fails_this_pr(
 
     # Filter PR results to only include new fails
     mask = all_pr_fails.apply(
-        lambda row: (row["job_name"], row["test_name"]) in new_fails, axis=1
+        lambda row: (row["job_name"], row["test_name"]) in new_fails
+        or "targeted" in row["job_name"],
+        axis=1,
     )
     new_fails_df = all_pr_fails[mask]
 

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -142,28 +142,26 @@ def get_run_details(run_id: str) -> dict:
     return response.json()
 
 
-def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
+def _checks_latest_test_status_cte(commit_sha: str, branch_name: str) -> str:
     """
-    Get tests that did not succeed for the given commit and branch.
-    Exclude checks that have status 'error' as they are counted in get_checks_errors.
+    Shared filtering for gh-data.checks: anchor time excludes stateless teardown checks
+    (Stateless% + test_name not matching ^[0-9]{5}); keep rows with check_start_time
+    >= anchor so main + teardown phases are included.
     """
-    query = f"""WITH checks_for_commit AS (
+    return f"""WITH checks_with_anchor AS (
             SELECT
                 check_name,
                 test_name,
                 report_url,
                 check_status,
                 test_status,
-                check_start_time
+                check_start_time,
+                maxIf(
+                    check_start_time,
+                    NOT (check_name LIKE 'Stateless%' AND NOT match(test_name, '^[0-9]{{5}}'))
+                ) OVER (PARTITION BY check_name) AS latest_check_start_time
             FROM `gh-data`.checks
             WHERE commit_sha = '{commit_sha}' AND head_ref = '{branch_name}'
-        ),
-        latest_start_time_for_checks AS (
-            SELECT
-                *,
-                max(check_start_time) OVER (PARTITION BY check_name) AS latest_check_start_time
-            FROM checks_for_commit
-            WHERE NOT (check_name LIKE 'Stateless%' AND NOT match(test_name, '^[0-9]{{5}}')) -- Exclude stateless teardown checks
         ),
         rows_from_latest_check_run AS (
             SELECT
@@ -173,7 +171,7 @@ def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
                 check_status,
                 test_status,
                 check_start_time
-            FROM latest_start_time_for_checks
+            FROM checks_with_anchor
             WHERE check_start_time >= latest_check_start_time
         ),
         latest_test_status AS (
@@ -185,7 +183,15 @@ def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
                 report_url AS results_link
             FROM rows_from_latest_check_run
             GROUP BY check_name, test_name, report_url
-        )
+        )"""
+
+
+def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
+    """
+    Get tests that did not succeed for the given commit and branch.
+    Exclude checks that have status 'error' as they are counted in get_checks_errors.
+    """
+    query = f"""{_checks_latest_test_status_cte(commit_sha, branch_name)}
         SELECT job_status, job_name, status AS test_status, test_name, results_link
         FROM latest_test_status
         WHERE test_status IN ('FAIL', 'ERROR')
@@ -257,19 +263,10 @@ def get_checks_known_fails(
     if len(known_fails) == 0:
         return pd.DataFrame()
 
-    query = f"""SELECT job_name, status as test_status, test_name, results_link
-        FROM (
-            SELECT
-                check_name as job_name,
-                argMax(test_status, check_start_time) as status,
-                test_name,
-                report_url as results_link,
-                task_url
-            FROM `gh-data`.checks
-            WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
-            GROUP BY check_name, test_name, report_url, task_url
-        )
-        WHERE test_status='BROKEN'
+    query = f"""{_checks_latest_test_status_cte(commit_sha, branch_name)}
+        SELECT job_name, status AS test_status, test_name, results_link
+        FROM latest_test_status
+        WHERE status = 'BROKEN'
         ORDER BY job_name, test_name
         """
 
@@ -296,22 +293,12 @@ def get_checks_errors(client: Client, commit_sha: str, branch_name: str):
     """
     Get checks that have status 'error' for the given commit and branch.
     """
-    query = f"""SELECT job_status, job_name, status as test_status, test_name, results_link
-            FROM (
-                SELECT
-                    argMax(check_status, check_start_time) as job_status,
-                    check_name as job_name,
-                    argMax(test_status, check_start_time) as status,
-                    test_name,
-                    report_url as results_link,
-                    task_url
-                FROM `gh-data`.checks
-                WHERE commit_sha='{commit_sha}' AND head_ref='{branch_name}'
-                GROUP BY check_name, test_name, report_url, task_url
-            )
-            WHERE job_status=='error'
-            ORDER BY job_name, test_name
-            """
+    query = f"""{_checks_latest_test_status_cte(commit_sha, branch_name)}
+        SELECT job_status, job_name, status AS test_status, test_name, results_link
+        FROM latest_test_status
+        WHERE job_status = 'error'
+        ORDER BY job_name, test_name
+        """
     return client.query_dataframe(query)
 
 

--- a/.github/actions/create_workflow_report/test_report_queries.py
+++ b/.github/actions/create_workflow_report/test_report_queries.py
@@ -62,6 +62,17 @@ def check_result_matches_expect(df: pd.DataFrame, expect: list[str]) -> None:
             ),
         ),
         (
+            "stateless_fail_in_teardown_no_reruns",
+            "0cd90a87ab7b2ad83d24df87d96af5d3de7858c2",
+            "feature/antalya-26.1/json_part2",
+            (
+                "00411_long_accurate_number_comparison_int4",
+                "03572_export_merge_tree_part_limits_and_table_functions",
+                "Exception in test runner",
+                "Some queries hung",
+            ),
+        ),
+        (
             "stateless_and_integration_passed_after_reruns",
             "49bb3f7beb5e6e424a1e94c749478fd23a8e6196",
             "antalya-25.8",

--- a/.github/actions/create_workflow_report/test_report_queries.py
+++ b/.github/actions/create_workflow_report/test_report_queries.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Test cases for report queries: ``commit_sha``, ``head_ref``, and ``expect``.
+
+``expect`` is the exact set of ``test_name`` values the query must return (order
+ignored). Use an empty ``expect`` tuple when it must return no failures.
+
+Requires ``testflows`` and ``clickhouse_driver``. Run:
+
+  pip install testflows
+  python .github/actions/create_workflow_report/test_report_queries.py
+
+Set ``CHECKS_DATABASE_HOST``, ``CLICKHOUSE_TEST_STAT_LOGIN``,
+``CLICKHOUSE_TEST_STAT_PASSWORD``.
+"""
+
+import os
+
+import pandas as pd
+from clickhouse_driver import Client
+from testflows.core import *
+
+from create_workflow_report import get_checks_fails
+
+
+def check_result_matches_expect(df: pd.DataFrame, expect: list[str]) -> None:
+    """Result ``test_name`` values must match ``expect`` exactly (as a set)."""
+    if "test_name" not in df.columns and not df.empty:
+        fail(f"DataFrame has no test_name column: {df.columns.tolist()}")
+    actual = set(df["test_name"].tolist()) if not df.empty else set()
+    required = set(expect)
+    if actual != required:
+        fail(f"test_name mismatch: got {sorted(actual)}; required {sorted(required)}")
+
+
+@TestOutline(Scenario)
+@Examples(
+    "case_id commit_sha head_ref expect",
+    [
+        (
+            "tests_passing_no_reruns",
+            "088fb0351680a67f6f34b4ad56ca12030012c919",
+            "qa/update-broken-tests",
+            (),
+        ),
+        (
+            "stress_startup_failed_no_reruns",
+            "33fd024890a401d30d85b3fad656f9deba916cbc",
+            "antalya-25.8",
+            (
+                "Cannot start clickhouse-server",
+                "Server failed to start (see application_errors.txt and clickhouse-server.clean.log)",
+            ),
+        ),
+        (
+            "stateless_and_integration_failed_no_reruns",
+            "4edabbad8665e1c727bbd7c891e0cbcd81aefd56",
+            "antalya-25.8",
+            (
+                "test_dns_cache/test.py::test_user_access_ip_change[node5]",
+                "01042_check_query_and_last_granule_size",
+            ),
+        ),
+        (
+            "stateless_and_integration_passed_after_reruns",
+            "49bb3f7beb5e6e424a1e94c749478fd23a8e6196",
+            "antalya-25.8",
+            (),
+        ),
+        (
+            "stress_passed_after_reruns",
+            "51762a72207f3d4bcee51a0a78912a8b2cbb1bb5",
+            "antalya-25.8",
+            (),
+        ),
+    ],
+)
+def test_checks_fails_query(self, case_id, commit_sha, head_ref, expect):
+    """Test checks fails query for one commit."""
+    with Given("DB Client is configured"):
+        host = os.getenv("CHECKS_DATABASE_HOST")
+        user = os.getenv("CLICKHOUSE_TEST_STAT_LOGIN")
+        password = os.getenv("CLICKHOUSE_TEST_STAT_PASSWORD")
+        if not all([host, user, password]):
+            skip(
+                "Set CHECKS_DATABASE_HOST, CLICKHOUSE_TEST_STAT_LOGIN, "
+                "CLICKHOUSE_TEST_STAT_PASSWORD"
+            )
+        client = Client(
+            host=host,
+            user=user,
+            password=password,
+            port=9440,
+            secure="y",
+            verify=False,
+            settings={"use_numpy": True},
+        )
+
+    with When(
+        f"I call get_checks_fails for commit_sha={commit_sha!r} head_ref={head_ref!r}"
+    ):
+        df = get_checks_fails(client, commit_sha, head_ref)
+
+    with Then("result test_name set equals expect"):
+        check_result_matches_expect(df, list(expect))
+
+
+@Name("test report queries")
+@TestModule
+def test_report_queries(self):
+    Scenario(run=test_checks_fails_query, flags=TE)
+
+
+if main():
+    test_report_queries()


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Test for main report query.
Improved main report query.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
