### PR TITLE
Fix Protobuf shared cache issue

### DIFF
--- a/src/Formats/ProtobufSchemas.cpp
+++ b/src/Formats/ProtobufSchemas.cpp
@@ -62,25 +62,21 @@ public:
 
         assert(file_descriptor);
 
-        if (with_envelope == WithEnvelope::No)
+        if (with_envelope == WithEnvelope::Yes)
         {
-            const auto * message_descriptor = file_descriptor->FindMessageTypeByName(message_name);
-            if (!message_descriptor)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Could not find a message named '{}' in the schema file '{}'",
-                    message_name, schema_path);
-
-            return message_descriptor;
+            const auto * envelope_descriptor = file_descriptor->FindMessageTypeByName("Envelope");
+            if (envelope_descriptor)
+            {
+                const auto * message_descriptor = envelope_descriptor->FindNestedTypeByName(message_name);
+                if (message_descriptor)
+                    return message_descriptor;
+            }
         }
 
-        const auto * envelope_descriptor = file_descriptor->FindMessageTypeByName("Envelope");
-        if (!envelope_descriptor)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Could not find a message named 'Envelope' in the schema file '{}'", schema_path);
-
-        const auto * message_descriptor = envelope_descriptor->FindNestedTypeByName(
-            message_name); // silly protobuf API disallows a restricting the field type to messages
+        const auto * message_descriptor = file_descriptor->FindMessageTypeByName(message_name);
         if (!message_descriptor)
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS, "Could not find a message named '{}' in the schema file '{}'", message_name, schema_path);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Could not find a message named '{}' in the schema file '{}'",
+                message_name, schema_path);
 
         return message_descriptor;
     }
@@ -129,11 +125,12 @@ ProtobufSchemas::getMessageTypeForFormatSchema(const FormatSchemaInfo & info, Wi
     }
 
     std::lock_guard lock(mutex);
-    auto it = importers.find(info.schemaDirectory());
+    auto key = ImporterKey{info.schemaDirectory(), with_envelope};
+    auto it = importers.find(key);
     if (it == importers.end())
         it = importers
                  .emplace(
-                     info.schemaDirectory(),
+                     key,
                      std::make_shared<ImporterWithSourceTree>(info.schemaDirectory(), google_protos_path, with_envelope))
                  .first;
     auto * importer = it->second.get();

--- a/src/Formats/ProtobufSchemas.h
+++ b/src/Formats/ProtobufSchemas.h
@@ -81,7 +81,17 @@ public:
     getMessageTypeForFormatSchema(const FormatSchemaInfo & info, WithEnvelope with_envelope, const String & google_protos_path);
 
 private:
-    std::unordered_map<String, std::shared_ptr<ImporterWithSourceTree>> importers;
+    using ImporterKey = std::pair<String, WithEnvelope>;
+    struct ImporterKeyHash
+    {
+        size_t operator()(const ImporterKey & key) const
+        {
+            auto h1 = std::hash<String>{}(key.first);
+            auto h2 = std::hash<uint8_t>{}(static_cast<uint8_t>(key.second));
+            return h1 ^ (h2 << 1);
+        }
+    };
+    std::unordered_map<ImporterKey, std::shared_ptr<ImporterWithSourceTree>, ImporterKeyHash> importers;
     std::mutex mutex;
 };
 


### PR DESCRIPTION
This PR fixes a caching issue with protobuf format in which the `WithEnvelope` is not considered. This leads to misleading broken format parsing when first using `FORMAT Protobuf` in which both `Protobuf` and `ProtobufList` format are able to use the provided message type, however when the cache is reset, `ProtobufList` attempts to force the `Envelope` format which can lead to errors when not available. The `Envelope` specific format is not truly required - any `Envelope` will work and pointing to the original format is all thats required for the schema.

The secondary fix, allowing fallback from envelope may be undesirable, if so I can remove.

Further information in SUP-28848

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed protobuf cache entry and added fallback to message type if `Envelope` not found

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
