### PR TITLE
25.3.8-fips: fixes for verification issues

### DIFF
--- a/contrib/openssl-cmake/include/evp_API_shim.h
+++ b/contrib/openssl-cmake/include/evp_API_shim.h
@@ -125,7 +125,6 @@ static inline int BIO_do_handshake(BIO *b) {
         return 0;
     if (!SSL_get_rbio(ssl) && BIO_next(b)) {
         BIO_up_ref(BIO_next(b));
-        BIO_up_ref(BIO_next(b));
         SSL_set_bio(ssl, BIO_next(b), BIO_next(b));
     }
     BIO_clear_retry_flags(b);

--- a/src/Compression/CompressionCodecEncrypted.cpp
+++ b/src/Compression/CompressionCodecEncrypted.cpp
@@ -683,7 +683,12 @@ namespace DB
 /// Register codecs for all algorithms
 void registerCodecEncrypted(CompressionCodecFactory & factory)
 {
+#if defined(FIPS_CLICKHOUSE) && FIPS_CLICKHOUSE
     registerEncryptionCodec(factory, AES_128_GCM);
     registerEncryptionCodec(factory, AES_256_GCM);
+#else
+    registerEncryptionCodec(factory, AES_128_GCM_SIV);
+    registerEncryptionCodec(factory, AES_256_GCM_SIV);
+#endif
 }
 }

--- a/src/Compression/fuzzers/encrypted_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/encrypted_decompress_fuzzer.cpp
@@ -309,8 +309,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
 
         auto config = generator.getResult();
 #if defined(FIPS_CLICKHOUSE) && FIPS_CLICKHOUSE
-        auto codec_128 = getCompressionCodecEncrypted(DB::AES_128_GCM_SIV);
-        auto codec_256 = getCompressionCodecEncrypted(DB::AES_256_GCM_SIV);
+        auto codec_128 = getCompressionCodecEncrypted(DB::AES_128_GCM);
+        auto codec_256 = getCompressionCodecEncrypted(DB::AES_256_GCM);
 #else
         auto codec_128 = getCompressionCodecEncrypted(DB::AES_128_GCM_SIV);
         auto codec_256 = getCompressionCodecEncrypted(DB::AES_256_GCM_SIV);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
