### PR TITLE
25.3.8-fips: xfail CVE-2026-2673 (grype): marked as Low severity by OpenSSL

### DIFF
--- a/.github/grype/parse_vulnerabilities_grype.py
+++ b/.github/grype/parse_vulnerabilities_grype.py
@@ -3,12 +3,15 @@ import json
 
 from testflows.core import *
 
-xfails = {}
+xfails = {
+    "/docker vulnerabilities/CVE-2026-2673@nvd﹕cpe,High": [
+        (Fail, "Marked as Low severity by OpenSSL: https://openssl-library.org/news/secadv/20260313.txt")
+    ],
+}
 
-
-@Name("docker vulnerabilities")
-@XFails(xfails)
 @TestModule
+@XFails(xfails)
+@Name("docker vulnerabilities")
 def docker_vulnerabilities(self):
     with Given("I gather grype scan results"):
         with open("./result.json", "r") as f:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
