### PR TITLE
25.3.8-fips Backport of #1533 - Add guard for local data lakes

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5976,6 +5976,9 @@ Normally this setting should be set in user profile (users.xml or queries like `
 
 Note that initially (24.12) there was a server setting (`send_settings_to_client`), but latter it got replaced with this client setting, for better usability.
 )", 0) \
+    DECLARE(Bool, allow_local_data_lakes, false, R"(
+Allow using local data lake engines and table functions (IcebergLocal, DeltaLakeLocal, etc.).
+)", 0) \
     \
     /* ####################################################### */ \
     /* ########### START OF EXPERIMENTAL FEATURES ############ */ \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -69,6 +69,10 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "25.4",
         {
         });
+        addSettingsChanges(settings_changes_history, "25.3.8",
+        {
+            {"allow_local_data_lakes", false, false, "New setting to guard local data lake engines and table functions"},
+        });
         addSettingsChanges(settings_changes_history, "25.3",
         {
             /// Release closed. Please use 25.4

--- a/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/registerStorageObjectStorage.cpp
@@ -18,6 +18,12 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int SUPPORT_IS_DISABLED;
+}
+
+namespace Setting
+{
+    extern const SettingsBool allow_local_data_lakes;
 }
 
 namespace
@@ -235,6 +241,11 @@ void registerStorageIceberg(StorageFactory & factory)
         "IcebergLocal",
         [&](const StorageFactory::Arguments & args)
         {
+            if (!args.getLocalContext()->getSettingsRef()[Setting::allow_local_data_lakes])
+                throw Exception(
+                    ErrorCodes::SUPPORT_IS_DISABLED,
+                    "IcebergLocal is disabled. Set `allow_local_data_lakes` to enable it");
+
             auto configuration = std::make_shared<StorageLocalIcebergConfiguration>();
             return createStorageObjectStorage(args, configuration);
         },

--- a/src/TableFunctions/TableFunctionObjectStorage.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorage.cpp
@@ -31,6 +31,7 @@ namespace DB
 
 namespace Setting
 {
+    extern const SettingsBool allow_local_data_lakes;
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsBool parallel_replicas_for_cluster_engines;
     extern const SettingsString cluster_for_parallel_replicas;
@@ -40,6 +41,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 template <typename Definition, typename Configuration>
@@ -79,6 +81,15 @@ std::vector<size_t> TableFunctionObjectStorage<Definition, Configuration>::skipA
 template <typename Definition, typename Configuration>
 void TableFunctionObjectStorage<Definition, Configuration>::parseArguments(const ASTPtr & ast_function, ContextPtr context)
 {
+    if constexpr (std::is_same_v<Definition, IcebergLocalDefinition>)
+    {
+        if (!context->getSettingsRef()[Setting::allow_local_data_lakes])
+            throw Exception(
+                ErrorCodes::SUPPORT_IS_DISABLED,
+                "Table function '{}' is disabled. Set `allow_local_data_lakes` to enable it",
+                getName());
+    }
+
     /// Clone ast function, because we can modify its arguments like removing headers.
     auto ast_copy = ast_function->clone();
     ASTs & args_func = ast_copy->children;
@@ -109,6 +120,15 @@ template <typename Definition, typename Configuration>
 ColumnsDescription TableFunctionObjectStorage<
     Definition, Configuration>::getActualTableStructure(ContextPtr context, bool is_insert_query) const
 {
+    if constexpr (std::is_same_v<Definition, IcebergLocalDefinition>)
+    {
+        if (!context->getSettingsRef()[Setting::allow_local_data_lakes])
+            throw Exception(
+                ErrorCodes::SUPPORT_IS_DISABLED,
+                "Table function '{}' is disabled. Set `allow_local_data_lakes` to enable it",
+                getName());
+    }
+
     if (configuration->structure == "auto")
     {
         context->checkAccess(getSourceAccessType());
@@ -129,6 +149,15 @@ StoragePtr TableFunctionObjectStorage<Definition, Configuration>::executeImpl(
     ColumnsDescription cached_columns,
     bool is_insert_query) const
 {
+    if constexpr (std::is_same_v<Definition, IcebergLocalDefinition>)
+    {
+        if (!context->getSettingsRef()[Setting::allow_local_data_lakes])
+            throw Exception(
+                ErrorCodes::SUPPORT_IS_DISABLED,
+                "Table function '{}' is disabled. Set `allow_local_data_lakes` to enable it",
+                getName());
+    }
+
     chassert(configuration);
     ColumnsDescription columns;
 
@@ -286,6 +315,10 @@ template class TableFunctionObjectStorage<HDFSDefinition, StorageHDFSConfigurati
 template class TableFunctionObjectStorage<HDFSClusterDefinition, StorageHDFSConfiguration>;
 #endif
 template class TableFunctionObjectStorage<LocalDefinition, StorageLocalConfiguration>;
+
+#if USE_AVRO
+template class TableFunctionObjectStorage<IcebergLocalDefinition, StorageLocalIcebergConfiguration>;
+#endif
 
 #if USE_AVRO && USE_AWS_S3
 template class TableFunctionObjectStorage<IcebergS3ClusterDefinition, StorageS3IcebergConfiguration>;

--- a/tests/integration/test_storage_iceberg/configs/users.d/users.xml
+++ b/tests/integration/test_storage_iceberg/configs/users.d/users.xml
@@ -4,6 +4,12 @@
             <password></password>
             <profile>default</profile>
             <named_collection_control>1</named_collection_control>
+            <allow_local_data_lakes>1</allow_local_data_lakes>
         </default>
     </users>
+    <profiles>
+        <default>
+            <allow_local_data_lakes>1</allow_local_data_lakes>
+        </default>
+    </profiles>
 </clickhouse>


### PR DESCRIPTION


25.3.8 Stable: Add guard for local data lakes

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add setting `allow_local_data_lakes`. Off by default (https://github.com/Altinity/ClickHouse/pull/1533 by @zvonand)

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
