### PR TITLE
Improve artifact finding for tag runs

### DIFF
--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -62,6 +62,10 @@ class EventType:
 def get_pr_for_commit(sha, ref):
     if not ref:
         return None
+    # Tag pushes (refs/tags/...) are not expected to have a corresponding PR head ref.
+    # Avoid noisy warnings and unnecessary GH API calls in this case.
+    if isinstance(ref, str) and ref.startswith("refs/tags/"):
+        return None
     try_get_pr_url = (
         f"https://api.github.com/repos/{GITHUB_REPOSITORY}/commits/{sha}/pulls"
     )
@@ -246,7 +250,8 @@ class PRInfo:
                 except ValueError:
                     logging.error("Failed to convert %s to integer", merged_pr)
             self.sha = github_event["after"]
-            pull_request = get_pr_for_commit(self.sha, github_event["ref"])
+            event_ref = github_event.get("ref", "")
+            pull_request = get_pr_for_commit(self.sha, event_ref)
 
             if pull_request is None or pull_request["state"] == "closed":
                 # it's merged PR to master, or there is no PR (build against specific commit or tag)
@@ -256,7 +261,12 @@ class PRInfo:
                 self.labels = set()
                 self.base_ref = ref
                 self.base_name = self.repo_full_name
-                self.head_ref = ref
+                # For tags, keep self.ref as "refs/tags/...", but use the tag name as head_ref.
+                # This makes build report naming/selection deterministic and consistent across helpers.
+                if isinstance(event_ref, str) and event_ref.startswith("refs/tags/"):
+                    self.head_ref = event_ref[10:]
+                else:
+                    self.head_ref = ref
                 self.head_name = self.repo_full_name
                 before_sha = github_event["before"]
                 # in case of just a tag on exsiting commit, "before_sha" is 0000000000000000000000000000000000000000


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
