### PR TITLE
FIPS 25.3.8 - Report backport 

### DIFF
--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
+import time
 from pathlib import Path
 from itertools import combinations
 import json
@@ -11,6 +12,7 @@ import pandas as pd
 from jinja2 import Environment, FileSystemLoader
 import requests
 from clickhouse_driver import Client
+from clickhouse_driver.errors import ServerException
 import boto3
 from botocore.exceptions import NoCredentialsError
 
@@ -27,6 +29,30 @@ template_dir = os.path.dirname(__file__)
 template = Environment(loader=FileSystemLoader(template_dir)).get_template(
     "ci_run_report.html.jinja"
 )
+
+
+def _is_clickhouse_memory_limit_error(exc: BaseException) -> bool:
+    if isinstance(exc, ServerException) and getattr(exc, "code", None) == 241:
+        return True
+    msg = str(exc).lower()
+    return "memory limit" in msg or "memory_limit" in msg
+
+
+def query_dataframe_with_retry(
+    client: Client,
+    query: str,
+    *,
+    max_attempts: int = 5,
+    backoff_seconds: float = 3.0,
+) -> pd.DataFrame:
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return client.query_dataframe(query)
+        except Exception as e:
+            if not _is_clickhouse_memory_limit_error(e) or attempt >= max_attempts:
+                raise
+            wait = backoff_seconds * attempt
+            time.sleep(wait)
 
 
 def get_commit_statuses(sha: str) -> pd.DataFrame:
@@ -148,29 +174,63 @@ def get_run_details(run_url: str) -> dict:
     return response.json()
 
 
+def _checks_latest_test_status_cte(commit_sha: str, branch_name: str) -> str:
+    """
+    Shared filtering for gh-data.checks: anchor time excludes stateless teardown checks
+    (Stateless% + test_name not matching ^[0-9]{5}); keep rows with check_start_time
+    >= anchor so main + teardown phases are included.
+    """
+    return f"""WITH checks_with_anchor AS (
+            SELECT
+                check_name,
+                test_name,
+                report_url,
+                check_status,
+                test_status,
+                check_start_time,
+                maxIf(
+                    check_start_time,
+                    NOT (check_name LIKE 'Stateless%' AND NOT match(test_name, '^[0-9]{{5}}'))
+                ) OVER (PARTITION BY check_name) AS latest_check_start_time
+            FROM `gh-data`.checks
+            WHERE commit_sha = '{commit_sha}'
+        ),
+        rows_from_latest_check_run AS (
+            SELECT
+                check_name,
+                test_name,
+                report_url,
+                check_status,
+                test_status,
+                check_start_time
+            FROM checks_with_anchor
+            WHERE check_start_time >= latest_check_start_time
+        ),
+        latest_test_status AS (
+            SELECT
+                argMax(check_status, check_start_time) AS job_status,
+                check_name AS job_name,
+                argMax(test_status, check_start_time) AS status,
+                test_name,
+                report_url AS results_link
+            FROM rows_from_latest_check_run
+            GROUP BY check_name, test_name, report_url
+        )"""
+
+
 def get_checks_fails(client: Client, commit_sha: str, branch_name: str):
     """
     Get tests that did not succeed for the given commit and branch.
     Exclude checks that have status 'error' as they are counted in get_checks_errors.
     """
-    query = f"""SELECT job_status, job_name, status as test_status, test_name, results_link
-            FROM (
-                SELECT
-                    argMax(check_status, check_start_time) as job_status,
-                    check_name as job_name,
-                    argMax(test_status, check_start_time) as status,
-                    test_name,
-                    report_url as results_link,
-                    task_url
-                FROM `gh-data`.checks
-                WHERE commit_sha='{commit_sha}'
-                GROUP BY check_name, test_name, report_url, task_url
-            )
-            WHERE test_status IN ('FAIL', 'ERROR')
-            AND job_status!='error'
-            ORDER BY job_name, test_name
-            """
-    return client.query_dataframe(query)
+    query = f"""{_checks_latest_test_status_cte(commit_sha, branch_name)}
+        SELECT job_status, job_name, status AS test_status, test_name, results_link
+        FROM latest_test_status
+        WHERE test_status IN ('FAIL', 'ERROR')
+        AND job_status != 'error'
+        ORDER BY job_name, test_name
+        """
+    return query_dataframe_with_retry(client, query)
 
 
 def get_checks_known_fails(
@@ -182,25 +242,15 @@ def get_checks_known_fails(
     if len(known_fails) == 0:
         return pd.DataFrame()
 
-    query = f"""SELECT job_status, job_name, status as test_status, test_name, results_link
-        FROM (
-            SELECT
-                argMax(check_status, check_start_time) as job_status,
-                check_name as job_name,
-                argMax(test_status, check_start_time) as status,
-                test_name,
-                report_url as results_link,
-                task_url
-            FROM `gh-data`.checks
-            WHERE commit_sha='{commit_sha}'
-            GROUP BY check_name, test_name, report_url, task_url
-        )
-        WHERE test_status='BROKEN'
+    query = f"""{_checks_latest_test_status_cte(commit_sha, branch_name)}
+        SELECT job_name, status AS test_status, test_name, results_link
+        FROM latest_test_status
+        WHERE status = 'BROKEN'
         AND test_name IN ({','.join(f"'{test}'" for test in known_fails.keys())})
         ORDER BY job_name, test_name
         """
 
-    df = client.query_dataframe(query)
+    df = query_dataframe_with_retry(client, query)
 
     df.insert(
         len(df.columns) - 1,
@@ -219,23 +269,13 @@ def get_checks_errors(client: Client, commit_sha: str, branch_name: str):
     """
     Get checks that have status 'error' for the given commit and branch.
     """
-    query = f"""SELECT job_status, job_name, status as test_status, test_name, results_link
-            FROM (
-                SELECT
-                    argMax(check_status, check_start_time) as job_status,
-                    check_name as job_name,
-                    argMax(test_status, check_start_time) as status,
-                    test_name,
-                    report_url as results_link,
-                    task_url
-                FROM `gh-data`.checks
-                WHERE commit_sha='{commit_sha}'
-                GROUP BY check_name, test_name, report_url, task_url
-            )
-            WHERE job_status=='error'
-            ORDER BY job_name, test_name
-            """
-    return client.query_dataframe(query)
+    query = f"""{_checks_latest_test_status_cte(commit_sha, branch_name)}
+        SELECT job_status, job_name, status AS test_status, test_name, results_link
+        FROM latest_test_status
+        WHERE job_status = 'error'
+        ORDER BY job_name, test_name
+        """
+    return query_dataframe_with_retry(client, query)
 
 
 def drop_prefix_rows(df, column_to_clean):
@@ -277,7 +317,7 @@ def get_regression_fails(client: Client, job_url: str):
             WHERE job_url LIKE '{job_url}%'
             AND status IN ('Fail', 'Error')
             """
-    df = client.query_dataframe(query)
+    df = query_dataframe_with_retry(client, query)
     df = drop_prefix_rows(df, "test_name")
     df["job_name"] = df["job_name"].str.title()
     return df
@@ -331,7 +371,7 @@ def get_new_fails_this_pr(
             WHERE test_status NOT IN ('FAIL', 'ERROR')
             ORDER BY job_name, test_name
             """
-    base_checks = client.query_dataframe(base_checks_query)
+    base_checks = query_dataframe_with_retry(client, base_checks_query)
 
     # Get regression results from base branch that didn't fail
     base_regression_query = f"""SELECT arch, job_name, status, test_name, results_link
@@ -350,7 +390,7 @@ def get_new_fails_this_pr(
             )
             WHERE status NOT IN ('Fail', 'Error')
             """
-    base_regression = client.query_dataframe(base_regression_query)
+    base_regression = query_dataframe_with_retry(client, base_regression_query)
     if len(base_regression) > 0:
         base_regression["job_name"] = base_regression.apply(
             lambda row: f"{row['arch']} {row['job_name']}".strip(), axis=1

--- a/.github/workflows/grype_scan.yml
+++ b/.github/workflows/grype_scan.yml
@@ -137,7 +137,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 sha: '${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}',
-                state: '${{ steps.parse_grype.outcome }}',
+                state: '${{ steps.parse_grype.outcome == 'success' && 'success' || 'failure' }}',
                 target_url: '${{ steps.upload_results.outputs.https_s3_path }}/results.html',
                 description: 'Grype Scan Completed with ${{ steps.create_summary.outputs.total_high_critical }} high/critical vulnerabilities',
                 context: 'Grype Scan ${{ steps.set_version.outputs.docker_image || inputs.docker_image }}'

--- a/.github/workflows/grype_scan.yml
+++ b/.github/workflows/grype_scan.yml
@@ -77,6 +77,7 @@ jobs:
             ./.github/grype/run_grype_scan.sh $DOCKER_IMAGE
 
         - name: Parse grype results
+          id: parse_grype
           run: |
             python3 -u ./.github/grype/parse_vulnerabilities_grype.py -o nice --no-colors --log raw.log --test-to-end
 
@@ -136,7 +137,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 sha: '${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}',
-                state: '${{ steps.create_summary.outputs.total_high_critical > 0 && 'failure' || 'success' }}',
+                state: '${{ steps.parse_grype.outcome }}',
                 target_url: '${{ steps.upload_results.outputs.https_s3_path }}/results.html',
                 description: 'Grype Scan Completed with ${{ steps.create_summary.outputs.total_high_critical }} high/critical vulnerabilities',
                 context: 'Grype Scan ${{ steps.set_version.outputs.docker_image || inputs.docker_image }}'


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Backport new report queries that properly exclude special checks.
Update grype scan to respect xfails better.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
