### PR TITLE
Fix version parsing for Antalya branch

### DIFF
--- a/src/Common/ClickHouseVersion.cpp
+++ b/src/Common/ClickHouseVersion.cpp
@@ -25,6 +25,11 @@ ClickHouseVersion::ClickHouseVersion(std::string_view version)
 
     for (const auto & split_element : split)
     {
+        if (split_element == "altinityantalya")
+        {
+            is_antalya = true;
+            continue;
+        }
         size_t component;
         ReadBufferFromString buf(split_element);
         if (!tryReadIntText(component, buf) || !buf.eof())
@@ -35,7 +40,10 @@ ClickHouseVersion::ClickHouseVersion(std::string_view version)
 
 String ClickHouseVersion::toString() const
 {
-    return fmt::format("{}", fmt::join(components, "."));
+    auto res = fmt::format("{}", fmt::join(components, "."));
+    if (is_antalya)
+        res += ".altinityantalya";
+    return res;
 }
 
 }

--- a/src/Common/ClickHouseVersion.cpp
+++ b/src/Common/ClickHouseVersion.cpp
@@ -27,6 +27,9 @@ ClickHouseVersion::ClickHouseVersion(std::string_view version)
     {
         if (split_element == "altinityantalya")
         {
+            /// version like '26.3.1.20001.altinityantalya'
+            if (components.size() != 4 || split.size() != 5)
+                throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version here: {}", version};
             is_antalya = true;
             continue;
         }

--- a/src/Common/ClickHouseVersion.h
+++ b/src/Common/ClickHouseVersion.h
@@ -18,6 +18,7 @@ public:
 
 private:
     std::vector<size_t> components;
+    bool is_antalya = false;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix version parsing for Antalya branch

### Documentation entry for user-facing changes
ClickHouse 26.3 has class `ClickHouseVersion` for parsing version string. Upstream version expects only digits and dots, when Antalya branch has postfix `.antalya`. Without PR ClickHouse throws exception `Cannot parse ClickHouse version`


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
