### PR TITLE
Antalya 26.1: bump openssl to 3.5.6

### DIFF
--- a/contrib/openssl-cmake/common/include/openssl/cmp.h
+++ b/contrib/openssl-cmake/common/include/openssl/cmp.h
@@ -194,6 +194,8 @@ typedef ASN1_BIT_STRING OSSL_CMP_PKIFAILUREINFO;
  *       -- CertReqMsg
  *   }
  */
+#  define OSSL_CMP_PKISTATUS_rejected_by_client     -5
+#  define OSSL_CMP_PKISTATUS_checking_response      -4
 #  define OSSL_CMP_PKISTATUS_request                -3
 #  define OSSL_CMP_PKISTATUS_trans                  -2
 #  define OSSL_CMP_PKISTATUS_unspecified            -1

--- a/contrib/openssl-cmake/common/include/openssl/opensslv.h
+++ b/contrib/openssl-cmake/common/include/openssl/opensslv.h
@@ -29,7 +29,7 @@ extern "C" {
  */
 # define OPENSSL_VERSION_MAJOR  3
 # define OPENSSL_VERSION_MINOR  5
-# define OPENSSL_VERSION_PATCH  0
+# define OPENSSL_VERSION_PATCH  6
 
 /*
  * Additional version information
@@ -74,21 +74,21 @@ extern "C" {
  * longer variant with OPENSSL_VERSION_PRE_RELEASE_STR and
  * OPENSSL_VERSION_BUILD_METADATA_STR appended.
  */
-# define OPENSSL_VERSION_STR "3.5.0"
-# define OPENSSL_FULL_VERSION_STR "3.5.0"
+# define OPENSSL_VERSION_STR "3.5.6"
+# define OPENSSL_FULL_VERSION_STR "3.5.6"
 
 /*
  * SECTION 3: ADDITIONAL METADATA
  *
  * These strings are defined separately to allow them to be parsable.
  */
-# define OPENSSL_RELEASE_DATE "8 Apr 2025"
+# define OPENSSL_RELEASE_DATE "7 Apr 2026"
 
 /*
  * SECTION 4: BACKWARD COMPATIBILITY
  */
 
-# define OPENSSL_VERSION_TEXT "OpenSSL 3.5.0 8 Apr 2025"
+# define OPENSSL_VERSION_TEXT "OpenSSL 3.5.6 7 Apr 2026"
 
 /* Synthesize OPENSSL_VERSION_NUMBER with the layout 0xMNN00PPSL */
 # ifdef OPENSSL_VERSION_PRE_RELEASE

--- a/tests/integration/test_dictionaries_ddl/test.py
+++ b/tests/integration/test_dictionaries_ddl/test.py
@@ -590,7 +590,11 @@ def test_secure(started_cluster):
     )
     with pytest.raises(QueryRuntimeException) as excinfo:
         node1.query("SELECT dictGet('test.clickhouse_secure', 'value', toUInt64(1))")
-    assert "Unexpected packet from server localhost:9440" in str(excinfo.value)
+    error = str(excinfo.value)
+    assert (
+        "Unexpected packet from server localhost:9440" in error
+        or "Connection reset by peer" in error
+    )
 
     # Secure is set to 0 in named collection
     node1.query("DROP DICTIONARY IF EXISTS test.clickhouse_secure")
@@ -611,7 +615,11 @@ def test_secure(started_cluster):
     )
     with pytest.raises(QueryRuntimeException) as excinfo:
         node1.query("SELECT dictGet('test.clickhouse_secure', 'value', toUInt64(1))")
-    assert "Unexpected packet from server localhost:9440" in str(excinfo.value)
+    error = str(excinfo.value)
+    assert (
+        "Unexpected packet from server localhost:9440" in error
+        or "Connection reset by peer" in error
+    )
 
     # Secure is set to 0 in named collection and in 1 in DDL
     node1.query("DROP DICTIONARY IF EXISTS test.clickhouse_secure")


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Use openssl 3.5.6 (https://github.com/ClickHouse/ClickHouse/pull/102606 by @thevar1able)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
