### PR TITLE
[releasy] Antalya 26.1: Add support for EC JWT validation 

### DIFF
--- a/docs/en/operations/external-authenticators/tokens.md
+++ b/docs/en/operations/external-authenticators/tokens.md
@@ -1,0 +1,278 @@
+---
+slug: /en/operations/external-authenticators/oauth
+title: "Token-based authentication"
+---
+import SelfManaged from '@site/docs/en/_snippets/_self_managed_only_no_roadmap.md';
+
+<SelfManaged />
+
+ClickHouse users can be authenticated using tokens. This works in two ways:
+
+- An existing user (defined in `users.xml` or in local access control paths) can be authenticated with a token if this user can be `IDENTIFIED WITH jwt`. 
+- Use the information from the token or from an external Identity Provider (IdP) as a source of user definitions and allow locally undefined users to be authenticated with a valid token.
+
+Although not all tokens are JWTs, under the hood both ways are treated as the same authentication method to maintain better compatibility.
+
+# Token Processors
+
+## Configuration
+
+Token-based authentication is enabled by default. To disable it, set `enable_token_auth` to `0` in `config.xml`:
+
+```xml
+<enable_token_auth>0</enable_token_auth>
+```
+
+When disabled, token processors are not parsed, TokenAccessStorage is not available, and authentication via tokens (`--jwt` option or `Authorization: Bearer` header) is rejected.
+
+To use token-based authentication, add `token_processors` section to `config.xml` and define at least one token processor in it.
+Its contents are different for different token processor types.
+
+**Common parameters**
+- `type` -- type of token processor. Supported values: "jwt_static_key", "jwt_static_jwks", "jwt_dynamic_jwks", "azure", "openid". Mandatory. Case-insensitive.
+- `token_cache_lifetime` -- maximum lifetime of cached token (in seconds). Optional, default: 3600.
+- `username_claim` -- name of claim (field) that will be treated as ClickHouse username. Optional, default: "sub".
+- `groups_claim` -- name of claim (field) that contains list of groups user belongs to. This claim will be looked up in the token itself (in case token is a valid JWT, e.g. in Keycloak) or in response from `/userinfo`. Optional, default: "groups".
+
+For each type, there are additional specific parameters (some of them are mandatory).
+If some parameters that are not required for current processor type are specified, they are ignored. 
+
+## JWT (JSON Web Token)
+
+JWT itself is a source of information about user.
+It is decoded locally and its integrity is verified using either a local static key or JWKS (JSON Web Key Set), local or remote.
+
+### JWT with static key:
+```xml
+<clickhouse>
+    <token_processors>
+        <my_static_key_validator>
+          <type>jwt_static_key</type>
+          <algo>HS256</algo>
+          <static_key>my_static_secret</static_key>
+        </my_static_key_validator>
+    </token_processors>
+</clickhouse>
+```
+**Parameters:**
+- `algo` - Algorithm for signature validation. Mandatory. Supported values:
+
+  | HMAC  | RSA   | ECDSA  | PSS   | EdDSA   |
+    |-------| ----- | ------ | ----- | ------- |
+  | HS256 | RS256 | ES256  | PS256 | Ed25519 |
+  | HS384 | RS384 | ES384  | PS384 | Ed448   |
+  | HS512 | RS512 | ES512  | PS512 |         |
+  |       |       | ES256K |       |         |
+  Also supports None (not recommended and must *NEVER* be used in production).
+- `claims` - A string containing a JSON object that should be contained in the token payload. If this parameter is defined, token without corresponding payload will be considered invalid. Optional.
+- `static_key` - key for symmetric algorithms. Mandatory for `HS*` family algorithms.
+- `static_key_in_base64` - indicates if the `static_key` key is base64-encoded. Optional, default: `False`.
+- `public_key` - public key for asymmetric algorithms. Mandatory except for `HS*` family algorithms and `None`.
+- `private_key` - private key for asymmetric algorithms. Optional.
+- `public_key_password` - public key password. Optional.
+- `private_key_password` - private key password. Optional.
+- `expected_issuer` - Expected value of the `iss` (issuer) claim in the JWT. If specified, tokens with a different issuer will be rejected. Optional.
+- `expected_audience` - Expected value of the `aud` (audience) claim in the JWT. If specified, tokens with a different audience will be rejected. Optional.
+- `allow_no_expiration` - If `true`, tokens without the `exp` (expiration) claim are accepted. Otherwise they are rejected. Optional, default: `false`.
+
+### JWT with static JWKS
+```xml
+<clickhouse>
+    <token_processors>
+        <my_static_jwks_validator>
+          <type>jwt_static_jwks</type>
+          <static_jwks>{"keys": [{"kty": "RSA", "alg": "RS256", "kid": "mykid", "n": "_public_key_mod_", "e": "AQAB"}]}</static_jwks>
+        </my_static_jwks_validator>
+    </token_processors>
+</clickhouse>
+```
+
+**Parameters:**
+
+- `static_jwks` - content of JWKS in JSON
+- `static_jwks_file` - path to a file with JWKS
+- `claims` - A string containing a JSON object that should be contained in the token payload. If this parameter is defined, token without corresponding payload will be considered invalid. Optional.
+- `verifier_leeway` - Clock skew tolerance (seconds). Useful for handling small differences in system clocks between ClickHouse and the token issuer. Optional.
+- `expected_issuer` - Expected value of the `iss` (issuer) claim in the JWT. If specified, tokens with a different issuer will be rejected. Optional.
+- `expected_audience` - Expected value of the `aud` (audience) claim in the JWT. If specified, tokens with a different audience will be rejected. Optional.
+- `allow_no_expiration` - If `true`, tokens without the `exp` (expiration) claim are accepted. Otherwise they are rejected. Optional, default: `false`.
+
+:::note
+Only one of `static_jwks` or `static_jwks_file` keys must be present in one verifier
+:::
+
+:::note
+For JWKS-based validators (`jwt_static_jwks` and `jwt_dynamic_jwks`), RS* and ES* family algorithms are supported.
+:::
+
+### JWT with remote JWKS
+```xml
+<clickhouse>
+    <token_processors>
+        <basic_auth_server>
+          <type>jwt_dynamic_jwks</type>
+          <jwks_uri>http://localhost:8000/.well-known/jwks.json</jwks_uri>
+          <jwks_cache_lifetime>3600</jwks_cache_lifetime>
+        </basic_auth_server>
+    </token_processors>
+</clickhouse>
+```
+
+**Parameters:**
+
+- `uri` - JWKS endpoint. Mandatory.
+- `jwks_cache_lifetime` - Period for resend request for refreshing JWKS. Optional, default: 3600.
+- `claims` - A string containing a JSON object that should be contained in the token payload. If this parameter is defined, token without corresponding payload will be considered invalid. Optional.
+- `verifier_leeway` - Clock skew tolerance (seconds). Useful for handling small differences in system clocks between ClickHouse and the token issuer. Optional.
+- `expected_issuer` - Expected value of the `iss` (issuer) claim in the JWT. If specified, tokens with a different issuer will be rejected. Optional.
+- `expected_audience` - Expected value of the `aud` (audience) claim in the JWT. If specified, tokens with a different audience will be rejected. Optional.
+- `allow_no_expiration` - If `true`, tokens without the `exp` (expiration) claim are accepted. Otherwise they are rejected. Optional, default: `false`.
+
+
+## Processors with external providers
+
+Some tokens cannot be decoded and validated locally. External service is needed in this case. "Azure" and "OpenID" (a generic type) are supported now.
+
+### Azure
+```xml
+<clickhouse>
+    <token_processors>
+        <azure_processor>
+          <type>azure</type>
+        </azure_processor>
+    </token_processors>
+</clickhouse>
+```
+
+No additional parameters are required.
+
+### OpenID
+```xml
+<clickhouse>
+    <token_processors>
+        <oid_processor_1>
+          <type>openid</type>
+          <configuration_endpoint>url/.well-known/openid-configuration</configuration_endpoint>
+          <verifier_leeway>60</verifier_leeway>
+          <jwks_cache_lifetime>3600</jwks_cache_lifetime>
+        </oid_processor_1>
+        <oid_processor_2>
+          <type>openid</type>
+          <userinfo_endpoint>url/userinfo</userinfo_endpoint>
+          <token_introspection_endpoint>url/tokeninfo</token_introspection_endpoint>
+          <jwks_uri>url/.well-known/jwks.json</jwks_uri>
+          <verifier_leeway>60</verifier_leeway>
+          <jwks_cache_lifetime>3600</jwks_cache_lifetime>
+        </oid_processor_2>
+    </token_processors>
+</clickhouse>
+```
+
+:::note
+Either `configuration_endpoint` or both `userinfo_endpoint` and `token_introspection_endpoint` (and, optionally, `jwks_uri`) shall be set. If none of them are set or all three are set, this is an invalid configuration that will not be parsed.
+:::
+
+**Parameters:**
+
+- `configuration_endpoint` - URI of OpenID configuration (often ends with `.well-known/openid-configuration`);
+- `userinfo_endpoint` - URI of endpoint that returns user information in exchange for a valid token;
+- `token_introspection_endpoint` - URI of token introspection endpoint (returns information about a valid token);
+- `jwks_uri` - URI of OpenID configuration (often ends with `.well-known/jwks.json`)
+- `jwks_cache_lifetime` - Period for resend request for refreshing JWKS. Optional, default: 3600.
+- `verifier_leeway` - Clock skew tolerance (seconds). Useful for handling small differences in system clocks between ClickHouse and the token issuer. Optional, default: 60
+- `expected_issuer` - Expected value of the `iss` (issuer) claim in the JWT. If specified, tokens with a different issuer will be rejected. Optional.
+- `expected_audience` - Expected value of the `aud` (audience) claim in the JWT. If specified, tokens with a different audience will be rejected. Optional.
+- `allow_no_expiration` - If `true`, tokens without the `exp` (expiration) claim are accepted. Otherwise they are rejected. Optional, default: `false`.
+
+Sometimes a token is a valid JWT. In that case token will be decoded and validated locally if configuration endpoint returns JWKS URI (or `jwks_uri` is specified alongside `userinfo_endpoint` and `token_introspection_endpoint`).
+
+### Tokens cache
+To reduce number of requests to IdP, tokens are cached internally for a maximum period of `token_cache_lifetime` seconds.
+If token expires sooner than `token_cache_lifetime`, then cache entry for this token will only be valid while token is valid.
+If token lifetime is longer than `token_cache_lifetime`, cache entry for this token will be valid for `token_cache_lifetime`. 
+
+## Enabling token authentication for a user in `users.xml` {#enabling-jwt-auth-in-users-xml}
+
+In order to enable token-based authentication for the user, specify `jwt` section instead of `password` or other similar sections in the user definition.
+
+Parameters:
+- `claims` - An optional string containing a json object that should be contained in the token payload.
+
+Example (goes into `users.xml`):
+```xml
+<clickhouse>
+    <my_user>
+        <jwt>
+            <claims>{"resource_access":{"account": {"roles": ["view-profile"]}}}</claims>
+        </jwt>
+    </my_user>
+</clickhouse>
+```
+
+Here, the JWT payload must contain `["view-profile"]` on path `resource_access.account.roles`, otherwise authentication will not succeed even with a valid JWT.
+
+:::note
+Per-user `claims` are enforced only when the token is a JWT (validated by a JWT processor such as `jwt_static_key` or `jwt_dynamic_jwks`). When the user authenticates with an opaque (access) token (e.g. via Azure, OpenID, or Google token processors), claims are not checked and authentication succeeds if the token is otherwise valid.
+:::
+
+```
+{
+...
+  "resource_access": {
+    "account": {
+      "roles": ["view-profile"]
+    }
+  },
+...
+}
+```
+
+:::note
+A user cannot have JWT authentication together with any other authentication method. The presence of any other sections like `password` alongside `jwt` will force ClickHouse to shut down.
+:::
+
+## Enabling token authentication using SQL {#enabling-jwt-auth-using-sql}
+
+Users with "JWT" authentication type cannot be created using SQL now.
+
+## Identity Provider as an External User Directory {#idp-external-user-directory}
+
+If there is no suitable user pre-defined in ClickHouse, authentication is still possible: Identity Provider can be used as source of user information.
+To allow this, add `token` section to the `users_directories` section of the `config.xml` file.
+
+At each login attempt, ClickHouse tries to find the user definition locally and authenticate it as usual.
+If a token is provided but the user is not defined, ClickHouse will treat the user as externally defined and will try to validate the token and get user information from the specified processor.
+If validated successfully, the user will be considered existing and authenticated. The user will be assigned roles from the list specified in the `roles` section. 
+All this implies that the SQL-driven [Access Control and Account Management](/docs/en/guides/sre/user-management/index.md#access-control) is enabled and roles are created using the [CREATE ROLE](/docs/en/sql-reference/statements/create/role.md#create-role-statement) statement.
+
+**Example**
+
+```xml
+<clickhouse>
+    <user_directories>
+        <token>
+            <processor>token_processor_name</processor>
+            <common_roles>
+                <token_test_role_1 />
+            </common_roles>
+            <default_profile>my_profile</default_profile>
+            <roles_filter>
+                \bclickhouse-[a-zA-Z0-9]+\b
+            </roles_filter>
+            <roles_transform>s/-/_/g</roles_transform>
+        </token>
+    </user_directories>
+</clickhouse>
+```
+
+:::note
+For now, no more than one `token` section can be defined inside `user_directories`. This _may_ change in future.
+:::
+
+**Parameters**
+
+- `processor` — Name of one of processors defined in `token_processors` config section described above. This parameter is mandatory and cannot be empty.
+- `common_roles` — Section with a list of locally defined roles that will be assigned to each user retrieved from the IdP. Optional.
+- `default_profile` — Name of a locally defined settings profile that will be assigned to each user retrieved from the IdP. If the profile does not exist, a warning will be logged and the user will be created without a profile. Optional.
+- `roles_filter` — Regex string for groups filtering. Only groups matching this regex will be mapped to roles. Optional.
+- `roles_transform` — Sed-style transform pattern to apply to group names before mapping to roles. Format: `s/pattern/replacement/flags`. The `g` flag applies the replacement globally (all occurrences). Example: `s/-/_/g` converts `clickhouse-grp-dba` to `clickhouse_grp_dba`. Optional.

--- a/src/Access/TokenProcessorsJWT.cpp
+++ b/src/Access/TokenProcessorsJWT.cpp
@@ -1,0 +1,567 @@
+#include "TokenProcessors.h"
+
+#if USE_JWT_CPP
+#include <Common/Base64.h>
+#include <Common/logger_useful.h>
+#include <Poco/String.h>
+#include <openssl/bio.h>
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/param_build.h>
+#include <openssl/pem.h>
+#include <cstring>
+
+namespace DB {
+
+namespace ErrorCodes
+{
+    extern const int AUTHENTICATION_FAILED;
+    extern const int INVALID_CONFIG_PARAMETER;
+}
+
+namespace
+{
+
+bool check_claims(const picojson::value & claims, const picojson::value & payload, const String & path);
+bool check_claims(const picojson::value::object & claims, const picojson::value::object & payload, const String & path)
+{
+    for (const auto & it : claims)
+    {
+        const auto & payload_it = payload.find(it.first);
+        if (payload_it == payload.end())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "Key '{}.{}' not found in JWT payload", path, it.first);
+            return false;
+        }
+        if (!check_claims(it.second, payload_it->second, path + "." + it.first))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool check_claims(const picojson::value::array & claims, const picojson::value::array & payload, const String & path)
+{
+    if (claims.size() > payload.size())
+    {
+        LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload too small for claims key '{}'", path);
+        return false;
+    }
+    for (size_t claims_i = 0; claims_i < claims.size(); ++claims_i)
+    {
+        bool found = false;
+        const auto & claims_val = claims.at(claims_i);
+        for (const auto & payload_val : payload)
+        {
+            if (!check_claims(claims_val, payload_val, path + "[" + std::to_string(claims_i) + "]"))
+                continue;
+            found = true;
+        }
+        if (!found)
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not contain an object matching claims key '{}[{}]'", path, claims_i);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool check_claims(const picojson::value & claims, const picojson::value & payload, const String & path)
+{
+    if (claims.is<picojson::array>())
+    {
+        if (!payload.is<picojson::array>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match key type 'array' in claims '{}'", path);
+            return false;
+        }
+        return check_claims(claims.get<picojson::array>(), payload.get<picojson::array>(), path);
+    }
+    if (claims.is<picojson::object>())
+    {
+        if (!payload.is<picojson::object>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match key type 'object' in claims '{}'", path);
+            return false;
+        }
+        return check_claims(claims.get<picojson::object>(), payload.get<picojson::object>(), path);
+    }
+    if (claims.is<bool>())
+    {
+        if (!payload.is<bool>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match key type 'bool' in claims '{}'", path);
+            return false;
+        }
+        if (claims.get<bool>() != payload.get<bool>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match the value in the '{}' assertions. Expected '{}' but given '{}'", path, claims.get<bool>(), payload.get<bool>());
+            return false;
+        }
+        return true;
+    }
+    if (claims.is<double>())
+    {
+        if (!payload.is<double>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match key type 'double' in claims '{}'", path);
+            return false;
+        }
+        if (claims.get<double>() != payload.get<double>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match the value in the '{}' assertions. Expected '{}' but given '{}'", path, claims.get<double>(), payload.get<double>());
+            return false;
+        }
+        return true;
+    }
+    if (claims.is<std::string>())
+    {
+        if (!payload.is<std::string>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match key type 'std::string' in claims '{}'", path);
+            return false;
+        }
+        if (claims.get<std::string>() != payload.get<std::string>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match the value in the '{}' assertions. Expected '{}' but given '{}'", path, claims.get<std::string>(), payload.get<std::string>());
+            return false;
+        }
+        return true;
+    }
+#ifdef PICOJSON_USE_INT64
+    if (claims.is<int64_t>())
+    {
+        if (!payload.is<int64_t>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match key type 'int64_t' in claims '{}'", path);
+            return false;
+        }
+        if (claims.get<int64_t>() != payload.get<int64_t>())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "JWT payload does not match the value in claims '{}'. Expected '{}' but given '{}'", path, claims.get<int64_t>(), payload.get<int64_t>());
+            return false;
+        }
+        return true;
+    }
+#endif
+    LOG_ERROR(getLogger("TokenAuthentication"), "JWT claim '{}' does not match any known type", path);
+    return false;
+}
+
+bool check_claims(const String & claims, const picojson::value::object & payload)
+{
+    if (claims.empty())
+        return true;
+    picojson::value json;
+    auto errors = picojson::parse(json, claims);
+    if (!errors.empty())
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "Bad JWT claims: {}", errors);
+    if (!json.is<picojson::object>())
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "Bad JWT claims: is not an object");
+    return check_claims(json.get<picojson::value::object>(), payload, "");
+}
+
+std::string create_public_key_from_ec_components(const std::string & x, const std::string & y, int curve_nid)
+{
+    auto decode_base64url = [](const std::string & value)
+    {
+        return jwt::base::decode<jwt::alphabet::base64url>(jwt::base::pad<jwt::alphabet::base64url>(value));
+    };
+
+    auto decoded_x = decode_base64url(x);
+    auto decoded_y = decode_base64url(y);
+
+    size_t coordinate_size = 0;
+    if (curve_nid == NID_X9_62_prime256v1)
+        coordinate_size = 32;
+    else if (curve_nid == NID_secp384r1)
+        coordinate_size = 48;
+    else if (curve_nid == NID_secp521r1)
+        coordinate_size = 66;
+    else
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: unsupported EC curve");
+
+    if (decoded_x.size() > coordinate_size || decoded_y.size() > coordinate_size)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: invalid EC key coordinates length");
+
+    std::vector<unsigned char> public_key_octets(1 + 2 * coordinate_size, 0);
+    public_key_octets[0] = 0x04; // Uncompressed point format.
+    std::memcpy(public_key_octets.data() + 1 + (coordinate_size - decoded_x.size()), decoded_x.data(), decoded_x.size());
+    std::memcpy(public_key_octets.data() + 1 + coordinate_size + (coordinate_size - decoded_y.size()), decoded_y.data(), decoded_y.size());
+
+    const char * group_name = OBJ_nid2sn(curve_nid);
+    if (!group_name)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: unsupported EC curve");
+
+    std::unique_ptr<OSSL_PARAM_BLD, decltype(&OSSL_PARAM_BLD_free)> params_bld(OSSL_PARAM_BLD_new(), OSSL_PARAM_BLD_free);
+    if (!params_bld)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to allocate OpenSSL parameter builder");
+
+    if (OSSL_PARAM_BLD_push_utf8_string(params_bld.get(), OSSL_PKEY_PARAM_GROUP_NAME, group_name, 0) != 1)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to set EC group parameter");
+
+    if (OSSL_PARAM_BLD_push_octet_string(params_bld.get(), OSSL_PKEY_PARAM_PUB_KEY, public_key_octets.data(), public_key_octets.size()) != 1)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to set EC public key parameter");
+
+    std::unique_ptr<OSSL_PARAM, decltype(&OSSL_PARAM_free)> params(OSSL_PARAM_BLD_to_param(params_bld.get()), OSSL_PARAM_free);
+    if (!params)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to build OpenSSL parameters");
+
+    std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)> key_ctx(EVP_PKEY_CTX_new_from_name(nullptr, "EC", nullptr), EVP_PKEY_CTX_free);
+    if (!key_ctx)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to create EVP key context");
+
+    if (EVP_PKEY_fromdata_init(key_ctx.get()) <= 0)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to initialize EVP key import");
+
+    EVP_PKEY * raw_evp_key = nullptr;
+    if (EVP_PKEY_fromdata(key_ctx.get(), &raw_evp_key, EVP_PKEY_PUBLIC_KEY, params.get()) <= 0)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to import EC public key");
+
+    std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> evp_key(raw_evp_key, EVP_PKEY_free);
+
+    std::unique_ptr<BIO, decltype(&BIO_free)> bio(BIO_new(BIO_s_mem()), BIO_free);
+    if (!bio)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to allocate BIO");
+
+    if (PEM_write_bio_PUBKEY(bio.get(), evp_key.get()) != 1)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: failed to encode EC public key");
+
+    char * data = nullptr;
+    auto len = BIO_get_mem_data(bio.get(), &data);
+    return std::string(data, len);
+}
+
+}
+
+namespace
+{
+std::set<String> parseGroupsFromJsonArray(picojson::array groups_array)
+{
+    std::set<String> external_groups_names;
+
+    for (const auto & group : groups_array)
+    {
+        if (group.is<std::string>())
+            external_groups_names.insert(group.get<std::string>());
+    }
+
+    return external_groups_names;
+}
+}
+
+StaticKeyJwtProcessor::StaticKeyJwtProcessor(const String & processor_name_,
+                                             UInt64 token_cache_lifetime_,
+                                             const String & username_claim_,
+                                             const String & groups_claim_,
+                                             const String & expected_issuer_,
+                                             const String & expected_audience_,
+                                             bool allow_no_expiration_,
+                                             const StaticKeyJwtParams & params)
+                                             : ITokenProcessor(processor_name_, token_cache_lifetime_, username_claim_, groups_claim_),
+                                             claims(params.claims), expected_issuer(expected_issuer_), expected_audience(expected_audience_),
+                                             allow_no_expiration(allow_no_expiration_)
+{
+    const String & algo = params.algo;
+    const String & static_key = params.static_key;
+    bool static_key_in_base64 = params.static_key_in_base64;
+    const String & public_key = params.public_key;
+    const String & private_key = params.private_key;
+    const String & public_key_password = params.public_key_password;
+    const String & private_key_password = params.private_key_password;
+
+    if (algo == "ps256"   ||
+        algo == "ps384"   ||
+        algo == "ps512"   ||
+        algo == "ed25519" ||
+        algo == "ed448"   ||
+        algo == "rs256"   ||
+        algo == "rs384"   ||
+        algo == "rs512"   ||
+        algo == "es256"   ||
+        algo == "es256k"  ||
+        algo == "es384"   ||
+        algo == "es512"   )
+    {
+        if (public_key.empty())
+            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "{}: Invalid token processor definition, `public_key` parameter required for {}", processor_name, algo);
+    }
+    else if (algo == "hs256" ||
+             algo == "hs384" ||
+             algo == "hs512" )
+    {
+        if (static_key.empty())
+            throw DB::Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "{}: Invalid token processor definition, `static_key` parameter required for {}", processor_name, algo);
+    }
+    else if (algo != "none")
+        throw DB::Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "{}: Invalid token processor definition, unknown algorithm {}", processor_name, algo);
+
+    if (algo == "none")
+        verifier = verifier.allow_algorithm(jwt::algorithm::none());
+    else if (algo == "ps256")
+        verifier = verifier.allow_algorithm(jwt::algorithm::ps256(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "ps384")
+        verifier = verifier.allow_algorithm(jwt::algorithm::ps384(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "ps512")
+        verifier = verifier.allow_algorithm(jwt::algorithm::ps512(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "ed25519")
+        verifier = verifier.allow_algorithm(jwt::algorithm::ed25519(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "ed448")
+        verifier = verifier.allow_algorithm(jwt::algorithm::ed448(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "rs256")
+        verifier = verifier.allow_algorithm(jwt::algorithm::rs256(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "rs384")
+        verifier = verifier.allow_algorithm(jwt::algorithm::rs384(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "rs512")
+        verifier = verifier.allow_algorithm(jwt::algorithm::rs512(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "es256")
+        verifier = verifier.allow_algorithm(jwt::algorithm::es256(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "es256k")
+        verifier = verifier.allow_algorithm(jwt::algorithm::es256k(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "es384")
+        verifier = verifier.allow_algorithm(jwt::algorithm::es384(public_key, private_key, public_key_password, private_key_password));
+    else if (algo == "es512")
+        verifier = verifier.allow_algorithm(jwt::algorithm::es512(public_key, private_key, public_key_password, private_key_password));
+    else if (algo.starts_with("hs"))
+    {
+        auto key = static_key;
+        if (static_key_in_base64)
+            key = base64Decode(key);
+        if (algo == "hs256")
+            verifier = verifier.allow_algorithm(jwt::algorithm::hs256(key));
+        else if (algo == "hs384")
+            verifier = verifier.allow_algorithm(jwt::algorithm::hs384(key));
+        else if (algo == "hs512")
+            verifier = verifier.allow_algorithm(jwt::algorithm::hs512(key));
+        else
+            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "{}: Invalid token processor definition, unknown algorithm {}", processor_name, algo);
+    }
+    else
+        throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "{}: Invalid token processor definition, unknown algorithm {}", processor_name, algo);
+
+    if (!expected_issuer.empty())
+        verifier = verifier.with_issuer(expected_issuer);
+
+    if (!expected_audience.empty())
+        verifier = verifier.with_audience(expected_audience);
+}
+
+namespace
+{
+bool checkUserClaims(const TokenCredentials & credentials, const String & claims_to_check)
+{
+    try {
+        auto decoded_jwt = jwt::decode(credentials.getToken());
+        return check_claims(claims_to_check, decoded_jwt.get_payload_json());
+    }
+    catch (const std::exception &)
+    {
+        return false;
+    }
+}
+}
+
+bool StaticKeyJwtProcessor::checkClaims(const TokenCredentials & credentials, const String & claims_to_check) const
+{
+    return checkUserClaims(credentials, claims_to_check);
+}
+
+bool JwksJwtProcessor::checkClaims(const TokenCredentials & credentials, const String & claims_to_check) const
+{
+    return checkUserClaims(credentials, claims_to_check);
+}
+
+bool StaticKeyJwtProcessor::resolveAndValidate(TokenCredentials & credentials) const
+{
+    try
+    {
+        auto decoded_jwt = jwt::decode(credentials.getToken());
+        verifier.verify(decoded_jwt);
+
+        if (!allow_no_expiration && !decoded_jwt.has_expires_at())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "{}: Token missing 'exp' claim, rejecting", processor_name);
+            return false;
+        }
+
+        if (!check_claims(claims, decoded_jwt.get_payload_json()))
+            return false;
+
+        if (!decoded_jwt.has_payload_claim(username_claim))
+        {
+            LOG_ERROR(getLogger("TokenAuthentication"), "{}: Specified username_claim {} not found in token", processor_name, username_claim);
+            return false;
+        }
+
+        credentials.setUserName(decoded_jwt.get_payload_claim(username_claim).as_string());
+
+        if (decoded_jwt.has_payload_claim(groups_claim))
+            credentials.setGroups(parseGroupsFromJsonArray(decoded_jwt.get_payload_claim(groups_claim).as_array()));
+        else
+            LOG_TRACE(getLogger("TokenAuthentication"), "{}: Specified groups_claim {} not found in token, no external roles will be mapped", processor_name, groups_claim);
+
+        return true;
+    }
+    catch (const std::exception & ex)
+    {
+        LOG_TRACE(getLogger("TokenAuthentication"), "{}: Failed to validate JWT: {}", processor_name, ex.what());
+        return false;
+    }
+}
+
+bool JwksJwtProcessor::resolveAndValidate(TokenCredentials & credentials) const
+{
+    auto decoded_jwt = jwt::decode(credentials.getToken());
+
+    if (!allow_no_expiration && !decoded_jwt.has_expires_at())
+    {
+        LOG_TRACE(getLogger("TokenAuthentication"), "{}: Token missing 'exp' claim, rejecting", processor_name);
+        return false;
+    }
+
+    if (!decoded_jwt.has_payload_claim(username_claim))
+    {
+        LOG_ERROR(getLogger("TokenAuthentication"), "{}: Specified username_claim not found in token", processor_name);
+        return false;
+    }
+
+    if (!decoded_jwt.has_key_id())
+    {
+        LOG_ERROR(getLogger("TokenAuthentication"), "{}: 'kid' (key ID) claim not found in token", processor_name);
+        return false;
+    }
+
+    if (!provider->getJWKS().has_jwk(decoded_jwt.get_key_id()))
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWKS error: no JWK found for JWT");
+
+    auto jwk = provider->getJWKS().get_jwk(decoded_jwt.get_key_id());
+    auto username = decoded_jwt.get_payload_claim(username_claim).as_string();
+
+    if (!decoded_jwt.has_algorithm())
+    {
+        LOG_ERROR(getLogger("TokenAuthentication"), "{}: Algorithm not specified in token", processor_name);
+        return false;
+    }
+    auto algo = Poco::toLower(decoded_jwt.get_algorithm());
+
+
+    String public_key;
+
+    try
+    {
+        auto x5c = jwk.get_x5c_key_value();
+
+        if (!x5c.empty())
+        {
+            LOG_TRACE(getLogger("TokenAuthentication"), "{}: Verifying {} with 'x5c' key", processor_name, username);
+            public_key = jwt::helper::convert_base64_der_to_pem(x5c);
+        }
+    }
+    catch (const jwt::error::claim_not_present_exception &)
+    {
+        LOG_TRACE(getLogger("TokenAuthentication"), "{}: x5c was not specified in JWK, will try RSA components", processor_name);
+    }
+    catch (const std::bad_cast &)
+    {
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: invalid claim value type found, claims must be strings");
+    }
+
+    if (public_key.empty())
+    {
+        const auto key_type = jwk.get_key_type();
+        if (key_type == "EC")
+        {
+            if (!(jwk.has_jwk_claim("x") && jwk.has_jwk_claim("y")))
+                throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "{}: invalid JWK: missing 'x'/'y' claims for EC key type", processor_name);
+
+            int curve_nid = NID_undef;
+            std::optional<String> expected_crv;
+            if (algo == "es256")
+            {
+                curve_nid = NID_X9_62_prime256v1;
+                expected_crv = "P-256";
+            }
+            else if (algo == "es384")
+            {
+                curve_nid = NID_secp384r1;
+                expected_crv = "P-384";
+            }
+            else if (algo == "es512")
+            {
+                curve_nid = NID_secp521r1;
+                expected_crv = "P-521";
+            }
+
+            if (curve_nid == NID_undef)
+                throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: unknown algorithm {}", algo);
+
+            if (jwk.has_jwk_claim("crv"))
+            {
+                const auto crv = jwk.get_jwk_claim("crv").as_string();
+                if (expected_crv.has_value() && crv != expected_crv.value())
+                    throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: `crv` in JWK does not match JWT algorithm");
+            }
+
+            LOG_TRACE(getLogger("TokenAuthentication"), "{}: `x5c` not present, verifying {} with EC components", processor_name, username);
+            const auto x = jwk.get_jwk_claim("x").as_string();
+            const auto y = jwk.get_jwk_claim("y").as_string();
+            public_key = create_public_key_from_ec_components(x, y, curve_nid);
+        }
+        else if (key_type == "RSA")
+        {
+            if (!(jwk.has_jwk_claim("n") && jwk.has_jwk_claim("e")))
+                throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "{}: invalid JWK: missing 'n'/'e' claims for RSA key type", processor_name);
+            LOG_TRACE(getLogger("TokenAuthentication"), "{}: `issuer` or `x5c` not present, verifying {} with RSA components", processor_name, username);
+            const auto modulus = jwk.get_jwk_claim("n").as_string();
+            const auto exponent = jwk.get_jwk_claim("e").as_string();
+            public_key = jwt::helper::create_public_key_from_rsa_components(modulus, exponent);
+        }
+        else
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "{}: invalid JWK key type '{}'", processor_name, key_type);
+    }
+
+    if (jwk.has_algorithm() && Poco::toLower(jwk.get_algorithm()) != algo)
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT validation error: `alg` in JWK does not match the algorithm used in JWT");
+
+    if (algo == "rs256")
+        verifier = verifier.allow_algorithm(jwt::algorithm::rs256(public_key, "", "", ""));
+    else if (algo == "rs384")
+        verifier = verifier.allow_algorithm(jwt::algorithm::rs384(public_key, "", "", ""));
+    else if (algo == "rs512")
+        verifier = verifier.allow_algorithm(jwt::algorithm::rs512(public_key, "", "", ""));
+    else if (algo == "es256")
+        verifier = verifier.allow_algorithm(jwt::algorithm::es256(public_key, "", "", ""));
+    else if (algo == "es384")
+        verifier = verifier.allow_algorithm(jwt::algorithm::es384(public_key, "", "", ""));
+    else if (algo == "es512")
+        verifier = verifier.allow_algorithm(jwt::algorithm::es512(public_key, "", "", ""));
+    else
+        throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "JWT cannot be validated: unknown algorithm {}", algo);
+
+    verifier = verifier.leeway(verifier_leeway);
+
+    if (!expected_issuer.empty())
+        verifier = verifier.with_issuer(expected_issuer);
+
+    if (!expected_audience.empty())
+        verifier = verifier.with_audience(expected_audience);
+
+    verifier.verify(decoded_jwt);
+
+    if (!claims.empty() && !check_claims(claims, decoded_jwt.get_payload_json()))
+        return false;
+
+    credentials.setUserName(decoded_jwt.get_payload_claim(username_claim).as_string());
+
+    if (decoded_jwt.has_payload_claim(groups_claim))
+        credentials.setGroups(parseGroupsFromJsonArray(decoded_jwt.get_payload_claim(groups_claim).as_array()));
+    else
+        LOG_TRACE(getLogger("TokenAuthentication"), "{}: Specified groups_claim {} not found in token, no external roles will be mapped", processor_name, groups_claim);
+
+    return true;
+}
+
+}
+
+#endif

--- a/tests/integration/test_jwt_auth/jwks_server/server.py
+++ b/tests/integration/test_jwt_auth/jwks_server/server.py
@@ -1,0 +1,41 @@
+import sys
+
+from bottle import response, route, run
+
+
+@route("/.well-known/jwks.json")
+def server():
+    result = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "alg": "RS512",
+                "kid": "mykid",
+                "n": "0RRsKcZ5j9UckjioG4Phvav3dkg2sXP6tQ7ug0yowAo_u2HffB-1OjKuhWTpA3E3YkMKj0RrT-tuUpmZEXqCAipEV7XcfCv3o"
+                     "7Poa7HTq1ti_abVwT_KyfGjoNBBSJH4LTNAyo2J8ySKSDtpAEU52iL7s40Ra6I0vqp7_aRuPF5M4zcHzN3zarG5EfSVSG1-gT"
+                     "kaRv8XJbra0IeIINmKv0F4--ww8ZxXTR6cvI-MsArUiAPwzf7s5dMR4DNRG6YNTrPA0pTOqQE9sRPd62XsfU08plYm27naOUZ"
+                     "O5avIPl1YO5I6Gi4kPdTvv3WFIy-QvoKoPhPCaD6EbdBpe8BbTQ",
+                "e": "AQAB"},
+            {
+                "kty": "EC",
+                "alg": "ES384",
+                "kid": "ecmykid",
+                "crv": "P-384",
+                "x": "ewdB5ypKwp641N5cYmKJvTiwWLIc_IJduJwur2mit1SgQpPZdUwpDV3aNIAmry4Y",
+                "y": "Jajx21k25o2K-ik86kaaawu6O84awaSmvSirJn8WCeEuotu3O-4Gn-ryOMuDsH76",
+            },
+        ]
+    }
+    response.status = 200
+    response.content_type = "application/json"
+    return result
+
+
+@route("/")
+def ping():
+    response.content_type = "text/plain"
+    response.set_header("Content-Length", 2)
+    return "OK"
+
+
+run(host="0.0.0.0", port=int(sys.argv[1]))

--- a/tests/integration/test_jwt_auth/test.py
+++ b/tests/integration/test_jwt_auth/test.py
@@ -1,0 +1,99 @@
+import os
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.mock_servers import start_mock_servers
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "instance",
+    main_configs=["configs/validators.xml"],
+    user_configs=["configs/users.xml"],
+    with_minio=True,
+    # We actually don't need minio, but we need to run dummy resolver
+    # (a shortcut not to change cluster.py in a more unclear way, TBC later).
+)
+client = cluster.add_instance(
+    "client",
+)
+
+
+def run_jwks_server():
+    script_dir = os.path.join(os.path.dirname(__file__), "jwks_server")
+    start_mock_servers(
+        cluster,
+        script_dir,
+        [
+            ("server.py", "resolver", "8080"),
+        ],
+    )
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        run_jwks_server()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def curl_with_jwt(token, ip, https=False):
+    http_prefix = "https" if https else "http"
+    curl = f'curl -H "Authorization: Bearer {token}" "{http_prefix}://{ip}:8123/?query=SELECT%20currentUser()"'
+    return curl
+
+
+# See helpers/ directory if you need to re-create tokens (or understand how they are created)
+def test_static_key(started_cluster):
+    res = client.exec_in_container(
+        [
+            "bash",
+            "-c",
+            curl_with_jwt(
+                token="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqd3RfdXNlciJ9."
+                "kfivQ8qD_oY0UvihydeadD7xvuiO3zSmhFOc_SGbEPQ",
+                ip=cluster.get_instance_ip(instance.name),
+            ),
+        ]
+    )
+    assert res == "jwt_user\n"
+
+
+def test_jwks_server(started_cluster):
+    res = client.exec_in_container(
+        [
+            "bash",
+            "-c",
+            curl_with_jwt(
+                token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzUxMiIsImtpZCI6Im15a2lkIn0."
+                      "eyJzdWIiOiJqd3RfdXNlciIsImlzcyI6InRlc3RfaXNzIn0.MjegqrrVyrMMpkxIM-J_q-"
+                      "Sw68Vk5xZuFpxecLLMFs5qzvnh0jslWtyRfi-ANJeJTONPZM5m0yP1ITt8BExoHWobkkR11bXz0ylYEIOgwxqw"
+                      "36XhL2GkE17p-wMvfhCPhGOVL3b7msDRUKXNN48aAJA-NxRbQFhMr-eEx3HsrZXy17Qc7z-"
+                      "0dINe355kzAInGp6gMk3uksAlJ3vMODK8jE-WYFqXusr5GFhXubZXdE2mK0mIbMUGisOZhZLc4QVwvUsYDLBCgJ2RHr5vm"
+                      "jp17j_ZArIedUJkjeC4o72ZMC97kLVnVw94QJwNvd4YisxL6A_mWLTRq9FqNLD4HmbcOQ",
+                ip=cluster.get_instance_ip(instance.name),
+            ),
+        ]
+    )
+    assert res == "jwt_user\n"
+
+
+def test_jwks_server_ec_es384(started_cluster):
+    res = client.exec_in_container(
+        [
+            "bash",
+            "-c",
+            curl_with_jwt(
+                token="eyJhbGciOiJFUzM4NCIsImtpZCI6ImVjbXlraWQiLCJ0eXAiOiJKV1QifQ."
+                      "eyJzdWIiOiJqd3RfdXNlciIsImlzcyI6InRlc3RfaXNzIn0."
+                      "3iGUcKfc07oLN4XmBA6BJSGSfu7cBsdQ6KAFh1sV64rWYkVL5VzYlAskHaWZ4R9hR3QK0Bv0EPjia8Vo-xdN9jS7-fVB7RF0"
+                      "rGvbTOIuxE-yDumCyji3MYoLpcbOVasU",
+                ip=cluster.get_instance_ip(instance.name),
+            ),
+        ]
+    )
+    assert res == "jwt_user\n"


### PR DESCRIPTION
Cherry-picked from #1596.

---

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add support for EC JWT validation (`ES*` algorithms)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
