### PR TITLE
Antalya 26.3: mkmk-1: combined port of 2 PRs

### DIFF
--- a/src/Storages/prepareReadingFromFormat.cpp
+++ b/src/Storages/prepareReadingFromFormat.cpp
@@ -260,19 +260,23 @@ Names filterTupleColumnsToRead(NamesAndTypesList & requested_columns)
 
 ReadFromFormatInfo updateFormatPrewhereInfo(const ReadFromFormatInfo & info, const FilterDAGInfoPtr & row_level_filter, const PrewhereInfoPtr & prewhere_info)
 {
-    chassert(prewhere_info);
+    chassert(prewhere_info || row_level_filter);
 
-    if (info.prewhere_info || info.row_level_filter)
+    if (info.prewhere_info)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "updateFormatPrewhereInfo called more than once");
 
     ReadFromFormatInfo new_info;
     new_info.prewhere_info = prewhere_info;
+    new_info.row_level_filter = row_level_filter;
 
     /// Removes columns that are only used as prewhere input.
     /// Adds prewhere outputs (the actual prewhere filter column is only added if
     /// !remove_prewhere_column; but there may also be subexpressions computed by prewhere
     /// expression and preserved for use further down the query pipeline).
-    new_info.format_header = SourceStepWithFilter::applyPrewhereActions(info.format_header, row_level_filter, prewhere_info);
+    /// If row_level_filter was already applied in a previous call, don't re-apply it;
+    /// only apply the new prewhere_info on top.
+    new_info.format_header = SourceStepWithFilter::applyPrewhereActions(
+        info.format_header, info.row_level_filter ? nullptr : row_level_filter, prewhere_info);
 
     /// We assume that any format that supports prewhere also supports subset of subcolumns, so we
     /// don't need to replace subcolumns with their nested columns etc.

--- a/tests/queries/0_stateless/04053_row_policy_object_storage.reference
+++ b/tests/queries/0_stateless/04053_row_policy_object_storage.reference
@@ -1,0 +1,7 @@
+--- Row policy filters URL Parquet table ---
+1	a
+2	b
+--- Row policy with WHERE on URL Parquet table ---
+1	a
+--- Row policy count on URL Parquet table ---
+2

--- a/tests/queries/0_stateless/04053_row_policy_object_storage.sh
+++ b/tests/queries/0_stateless/04053_row_policy_object_storage.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database, no-fasttest
+
+# Regression test: row policy on a URL table with Parquet format caused
+# "Logical error: 'prewhere_info'" because updateFormatPrewhereInfo asserted
+# prewhere_info was non-null, but only row_level_filter was set.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user04053_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP TABLE IF EXISTS ${db}.source_data;
+CREATE TABLE ${db}.source_data (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO ${db}.source_data VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+DROP TABLE IF EXISTS ${db}.url_parquet;
+CREATE TABLE ${db}.url_parquet (id UInt32, value String)
+ENGINE = URL('http://127.0.0.1:${CLICKHOUSE_PORT_HTTP}/?query=SELECT+*+FROM+${db}.source_data+FORMAT+Parquet', 'Parquet');
+
+DROP USER IF EXISTS ${user};
+CREATE USER ${user} IDENTIFIED WITH no_password;
+GRANT SELECT ON ${db}.url_parquet TO ${user};
+
+DROP ROW POLICY IF EXISTS rp_04053 ON ${db}.url_parquet;
+CREATE ROW POLICY rp_04053 ON ${db}.url_parquet FOR SELECT USING id <= 2 TO ${user};
+EOF
+
+echo "--- Row policy filters URL Parquet table ---"
+${CLICKHOUSE_CLIENT} --user ${user} --query "SELECT * FROM ${db}.url_parquet ORDER BY id"
+
+echo "--- Row policy with WHERE on URL Parquet table ---"
+${CLICKHOUSE_CLIENT} --user ${user} --query "SELECT * FROM ${db}.url_parquet WHERE value = 'a' ORDER BY id"
+
+echo "--- Row policy count on URL Parquet table ---"
+${CLICKHOUSE_CLIENT} --user ${user} --query "SELECT count() FROM ${db}.url_parquet"
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP ROW POLICY IF EXISTS rp_04053 ON ${db}.url_parquet;
+DROP USER IF EXISTS ${user};
+DROP TABLE IF EXISTS ${db}.url_parquet;
+DROP TABLE IF EXISTS ${db}.source_data;
+EOF


### PR DESCRIPTION
> **This PR needs manual intervention.**
> Cherry-pick of #1597 could not be resolved automatically (AI resolver was disabled, exhausted its iteration budget, or gave up).
> The branch contains the first 1 commit(s) of the group; 0 later PR(s) were not attempted.
> Conflicted files at the failure point:
> - `src/Storages/ObjectStorage/StorageObjectStorageSource.cpp`
> Resolve the conflict locally, push the fix, and mark this PR ready for review.

### Changelog category (leave one):

- CI Fix or Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix exception "Logical error: `prewhere_info`" when querying URL/S3 Parquet tables with a row-level security policy and no PREWHERE clause (https://github.com/ClickHouse/ClickHouse/pull/100361 by @alexey-milovidov, https://github.com/Altinity/ClickHouse/pull/1597 by @mkmkme).

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)

Combined port of 2 PR(s) (group `mkmk-1`). Cherry-picked from ClickHouse/ClickHouse#100361, #1597.

- ClickHouse/ClickHouse#100361 — Fix exception in `updateFormatPrewhereInfo` when only row-level filter is set
- #1597 — Antalya-26.1: Fix row policies silently ignored on Iceberg tables with PREWHERE enabled


---
### ClickHouse/ClickHouse#100361: Fix exception in `updateFormatPrewhereInfo` when only row-level filter is set

`updateFormatPrewhereInfo` asserted that `prewhere_info` was non-null, but callers in `StorageObjectStorage` and `StorageURL` invoke it when either `prewhere_info` or `row_level_filter` is set. When a row policy exists on a URL/S3 table with Parquet format (which supports PREWHERE) and the query has no PREWHERE clause, only `row_level_filter` is populated — triggering the assertion.

Additionally, `row_level_filter` was never stored into the new `ReadFromFormatInfo`, so it would be silently lost.

Fix: relax the assertion to accept either being set, and store `row_level_filter` in the output.

Found in: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99537&sha=e2a32dfbb945f62e07bd3f66c206a71b584b96b1&name_0=PR&name_1=Stress%20test%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/99537

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
### #1597: Antalya-26.1: Fix row policies silently ignored on Iceberg tables with PREWHERE enabled

The Iceberg read optimization (`allow_experimental_iceberg_read_optimization`) identifies constant columns from Iceberg metadata and removes them from the read request. When all requested columns become constant, it sets `need_only_count = true`, which tells the Parquet reader to skip all initialization — including `preparePrewhere` — and just return the raw row count from file metadata.

This completely bypasses `row_level_filter` (row policies) and `prewhere_info`, returning unfiltered row counts. The InterpreterSelectQuery relies on the storage to apply these filters when `supportsPrewhere` is true and does not add a fallback FilterStep to the query plan, so the filter is silently lost.

The fix prevents `need_only_count` from being set when an active `row_level_filter` or `prewhere_info` exists in the format filter info.

Fixes #1595

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Documentation entry for user-facing changes
...