### PR TITLE
Antalya 26.1 - Fix community workflow

### DIFF
--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -181,14 +181,14 @@ jobs:
           fi
 
       - name: Upload artifact CH_AMD_DEBUG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_DEBUG
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_DEBUG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_DEBUG
           path: ci/tmp/*.deb
@@ -241,21 +241,21 @@ jobs:
           fi
 
       - name: Upload artifact UNITTEST_AMD_ASAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: UNITTEST_AMD_ASAN
           path: ci/tmp/build/src/unit_tests_dbms
 
 
       - name: Upload artifact CH_AMD_ASAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_ASAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_ASAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_ASAN
           path: ci/tmp/*.deb
@@ -308,21 +308,21 @@ jobs:
           fi
 
       - name: Upload artifact UNITTEST_AMD_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: UNITTEST_AMD_TSAN
           path: ci/tmp/build/src/unit_tests_dbms
 
 
       - name: Upload artifact CH_AMD_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_TSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_TSAN
           path: ci/tmp/*.deb
@@ -375,21 +375,21 @@ jobs:
           fi
 
       - name: Upload artifact UNITTEST_AMD_MSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: UNITTEST_AMD_MSAN
           path: ci/tmp/build/src/unit_tests_dbms
 
 
       - name: Upload artifact CH_AMD_MSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_MSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_MSAM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_MSAM
           path: ci/tmp/*.deb
@@ -442,21 +442,21 @@ jobs:
           fi
 
       - name: Upload artifact UNITTEST_AMD_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: UNITTEST_AMD_UBSAN
           path: ci/tmp/build/src/unit_tests_dbms
 
 
       - name: Upload artifact CH_AMD_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_UBSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_UBSAN
           path: ci/tmp/*.deb
@@ -509,7 +509,7 @@ jobs:
           fi
 
       - name: Upload artifact CH_AMD_BINARY
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_BINARY
           path: ci/tmp/build/programs/self-extracting/clickhouse
@@ -562,14 +562,14 @@ jobs:
           fi
 
       - name: Upload artifact CH_ARM_ASAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_ASAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_ARM_ASAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_ARM_ASAN
           path: ci/tmp/*.deb
@@ -622,7 +622,7 @@ jobs:
           fi
 
       - name: Upload artifact CH_ARM_BIN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_BIN
           path: ci/tmp/build/programs/self-extracting/clickhouse
@@ -675,7 +675,7 @@ jobs:
           fi
 
       - name: Upload artifact CH_ARM_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_TSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
@@ -728,35 +728,35 @@ jobs:
           fi
 
       - name: Upload artifact CH_AMD_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_RELEASE
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact CH_AMD_RELEASE_STRIPPED
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_RELEASE_STRIPPED
           path: ci/tmp/build/programs/self-extracting/clickhouse-stripped
 
 
       - name: Upload artifact DEB_AMD_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_RELEASE
           path: ci/tmp/*.deb
 
 
       - name: Upload artifact RPM_AMD_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: RPM_AMD_RELEASE
           path: ci/tmp/*.rpm
 
 
       - name: Upload artifact TGZ_AMD_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: TGZ_AMD_RELEASE
           path: ci/tmp/*64.tgz*
@@ -809,35 +809,35 @@ jobs:
           fi
 
       - name: Upload artifact CH_ARM_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_RELEASE
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact CH_ARM_RELEASE_STRIPPED
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_RELEASE_STRIPPED
           path: ci/tmp/build/programs/self-extracting/clickhouse-stripped
 
 
       - name: Upload artifact DEB_ARM_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_ARM_RELEASE
           path: ci/tmp/*.deb
 
 
       - name: Upload artifact RPM_ARM_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: RPM_ARM_RELEASE
           path: ci/tmp/*.rpm
 
 
       - name: Upload artifact TGZ_ARM_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: TGZ_ARM_RELEASE
           path: ci/tmp/*64.tgz*
@@ -879,7 +879,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -932,7 +932,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -985,7 +985,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -1038,7 +1038,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -1091,7 +1091,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -1144,7 +1144,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -1197,7 +1197,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -1250,7 +1250,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -1303,7 +1303,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1356,7 +1356,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1409,7 +1409,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1462,7 +1462,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1515,7 +1515,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1568,7 +1568,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1621,7 +1621,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1674,7 +1674,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1727,7 +1727,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1780,7 +1780,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1833,7 +1833,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1886,7 +1886,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1939,7 +1939,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_UBSAN
           path: ./ci/tmp
@@ -1992,7 +1992,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_UBSAN
           path: ./ci/tmp
@@ -2045,7 +2045,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -2098,7 +2098,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -2151,7 +2151,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2204,7 +2204,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2257,7 +2257,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2310,7 +2310,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2363,7 +2363,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -2416,7 +2416,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -2469,7 +2469,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -2522,7 +2522,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -2575,7 +2575,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -2628,7 +2628,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -2681,7 +2681,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -2734,7 +2734,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN
           path: ./ci/tmp
@@ -2787,7 +2787,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -2840,7 +2840,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -2893,7 +2893,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -2946,7 +2946,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -2999,7 +2999,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_BINARY
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_BINARY
           path: ./ci/tmp
@@ -3052,7 +3052,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -3105,7 +3105,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -3158,7 +3158,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -3211,7 +3211,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -3264,7 +3264,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -3317,7 +3317,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -3370,7 +3370,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -3423,7 +3423,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -3476,7 +3476,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -3529,7 +3529,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -3582,7 +3582,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact UNITTEST_AMD_ASAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: UNITTEST_AMD_ASAN
           path: ./ci/tmp
@@ -3635,7 +3635,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact UNITTEST_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: UNITTEST_AMD_TSAN
           path: ./ci/tmp
@@ -3688,7 +3688,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact UNITTEST_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: UNITTEST_AMD_MSAN
           path: ./ci/tmp
@@ -3741,7 +3741,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact UNITTEST_AMD_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: UNITTEST_AMD_UBSAN
           path: ./ci/tmp
@@ -3794,28 +3794,28 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact DEB_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DEB_AMD_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact RPM_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: RPM_AMD_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact TGZ_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: TGZ_AMD_RELEASE
           path: ./ci/tmp
@@ -3868,28 +3868,28 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact DEB_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DEB_ARM_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact RPM_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: RPM_ARM_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact TGZ_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: TGZ_ARM_RELEASE
           path: ./ci/tmp
@@ -3942,7 +3942,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact DEB_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DEB_AMD_RELEASE
           path: ./ci/tmp
@@ -3995,7 +3995,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact DEB_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DEB_ARM_RELEASE
           path: ./ci/tmp

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -343,7 +343,11 @@ def main():
         if not has_stateful:
             has_stateful_tests = False
 
-    targeter = Targeting(info=info)
+    targeter = (
+        Targeting(info=info)
+        if is_flaky_check or is_bugfix_validation or is_targeted_check
+        else None
+    )
     if is_flaky_check or is_bugfix_validation:
         if info.is_local_run:
             assert (

--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -1035,7 +1035,7 @@ def get_optimal_test_batch(
     # Compute group durations as sum of known test durations within the group
     # TODO: fix in private
     #   ERROR: Failed to get secret [PRIVATE_CI_DB_URL]
-    if info and not info.is_local_run:
+    if info and not info.is_local_run and not info.is_community_pr:
         durations = get_tests_execution_time(info, job_options)
         if not durations:
             print("WARNING: CIDB durations not found, using static TEST_DURATIONS")

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -220,7 +220,7 @@ jobs:
 
         TEMPLATE_GH_UPLOAD = """
       - name: Upload artifact {NAME}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: {NAME}
           path: {PATH}
@@ -228,7 +228,7 @@ jobs:
 
         TEMPLATE_GH_DOWNLOAD = """
       - name: Download artifact {NAME}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: {NAME}
           path: {PATH}

--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -63,16 +63,16 @@
   message: 'DB::Exception: Unknown storage policy `azure_cache`'
 - name: 02286_drop_filesystem_cache
   reason: fails when azure storage is not set up
-  message: 'DB::Exception: Unknown storage policy `azure_cache`'
+  message: 'DB::Exception: Cannot wrap disk `azure`'
 - name: 02242_system_filesystem_cache_log_table
   reason: fails when azure storage is not set up
   message: 'DB::Exception: Unknown storage policy `azure_cache`'
 - name: 02241_filesystem_cache_on_write_operations
   reason: fails when azure storage is not set up
-  message: 'DB::Exception: Unknown storage policy `azure_cache`'
+  message: 'DB::Exception: Cannot wrap disk `azure`'
 - name: 02240_system_filesystem_cache_table
   reason: fails when azure storage is not set up
-  message: 'DB::Exception: Unknown storage policy `azure_cache`'
+  message: 'DB::Exception: Cannot wrap disk `azure`'
 - name: 02226_filesystem_cache_profile_events
   reason: fails when azure storage is not set up
   message: 'DB::Exception: Unknown storage policy `azure_cache`'


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Fix stateless test runner unconditionally creating the test targeter object, which requires secrets.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [x] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
