### PR TITLE
Fix Client::login segfault on empty hosts_and_ports (#103603)

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -451,7 +451,14 @@ catch (...)
 #if USE_JWT_CPP && USE_SSL
 void Client::login()
 {
-    std::string host = hosts_and_ports.front().host;
+    /// hosts_and_ports is populated only from explicit --host. When the host
+    /// came from --connection or top-level <host> in config, it stays empty,
+    /// and hosts_and_ports.front() dereferences a null vector slot → SIGSEGV
+    /// in Client::main (upstream issue #103603). Fall back to the
+    /// config-derived value, which always exists by this point.
+    std::string host = !hosts_and_ports.empty()
+        ? hosts_and_ports.front().host
+        : getClientConfiguration().getString("host", "");
     std::string auth_url = getClientConfiguration().getString("oauth-url", "");
     std::string client_id = getClientConfiguration().getString("oauth-client-id", "");
     std::string audience = getClientConfiguration().getString("oauth-audience", "");


### PR DESCRIPTION
## Summary

`Client::login` dereferenced `hosts_and_ports.front().host` unconditionally, but `hosts_and_ports` is populated only from explicit `--host`. When the host comes from `--connection` or top-level `<host>` in the client config, the vector stays empty and `front()` SIGSEGVs in `Client::main` before any OAuth round-trip happens.

Fall back to `getClientConfiguration().getString("host", "")` when the vector is empty; that value is always set by this point because `initialize()` resolves the host from `--host` / `--connection` / config / env before reaching this code.

This is the upstream issue tracked at https://github.com/ClickHouse/ClickHouse/issues/103603 — same crash, same fix. Worth porting upstream.

## Test plan
- [x] Build clean against `antalya-26.1`
- [x] `clickhouse client --connection X` (where X has no `<host>` resolved into `hosts_and_ports`) no longer crashes; reaches the OAuth flow as designed
- [x] Behavior unchanged when `--host` is explicit (vector is non-empty, takes the original path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)