### PR TITLE
Antalya 25.8: CI release branch + stateless test fixes (03707, 03211)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4179,7 +4179,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester
-      commit: 92f4413c775fc750e826951f5d235766c562a98f
+      commit: release
       arch: x86
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 210
@@ -4191,7 +4191,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester-aarch64
-      commit: 92f4413c775fc750e826951f5d235766c562a98f
+      commit: release
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 210

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4046,7 +4046,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester
-      commit: 92f4413c775fc750e826951f5d235766c562a98f
+      commit: release
       arch: x86
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 210
@@ -4058,7 +4058,7 @@ jobs:
     secrets: inherit
     with:
       runner_type: altinity-regression-tester-aarch64
-      commit: 92f4413c775fc750e826951f5d235766c562a98f
+      commit: release
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout_minutes: 210

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -36,7 +36,7 @@ class AltinityWorkflowTemplates:
           echo "Workflow Run Report: [View Report]($REPORT_LINK)" >> $GITHUB_STEP_SUMMARY
 """
     # Additional jobs
-    REGRESSION_HASH = f"92f4413c775fc750e826951f5d235766c562a98f"
+    REGRESSION_HASH = f"release"
     ALTINITY_JOBS = {
         "GrypeScan": r"""
   GrypeScanServer:

--- a/tests/queries/0_stateless/03211_nested_json_merges.sql.j2
+++ b/tests/queries/0_stateless/03211_nested_json_merges.sql.j2
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, long, no-tsan, no-asan, no-msan, no-ubsan
+-- Tags: no-fasttest, long, no-debug, no-tsan, no-asan, no-msan, no-ubsan
 
 SET enable_json_type = 1;
 

--- a/tests/queries/0_stateless/03707_set_index_bad_get_null_bug.sql
+++ b/tests/queries/0_stateless/03707_set_index_bad_get_null_bug.sql
@@ -1,3 +1,5 @@
+set enable_parallel_replicas = 0;
+
 drop table if exists test;
 CREATE table test
 (


### PR DESCRIPTION
This PR switches CI to use the `clickhouse-regression` `release` branch (instead of a pinned commit) and includes two small stateless test fixes that mirror upstream `master`:

- Disables parallel replicas in `03707_set_index_bad_get_null_bug` (matches the change in ClickHouse/ClickHouse#90309 that was never backported to upstream `25.8`)
- Adds the `no-debug` tag to `03211_nested_json_merges` (cherry-pick of upstream commit `429dafce1e` from ClickHouse/ClickHouse#95084)

Both of these were causing recurring failures on `antalya-25.8`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)