### PR TITLE
Antalya 26.3 - Review play.html

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -53,6 +53,7 @@
             --border-color: #CCC;
             --shadow-color: rgba(0, 0, 0, 0.1);
             --button-color: var(--altinity-accent);
+            --button-text-color: #000;
             --text-color: #000;
             --text-color-active: #000;
             --button-active-color: var(--altinity-accent);
@@ -435,6 +436,7 @@
             padding: 0.25rem 0.65rem;
             cursor: pointer;
             position: relative;
+            font-size: 100%;
         }
 
         .copy-balloon
@@ -477,6 +479,7 @@
             padding: 0.25rem 0.65rem;
             cursor: pointer;
             position: relative;
+            font-size: 100%;
         }
 
         #download
@@ -692,19 +695,19 @@
                 <button type="submit" class="shadow" id="run">Run</button>
                 <div id="hint">&nbsp;(Ctrl/Cmd+Enter)</div>
                 <query-progress id="query-progress"></query-progress>
-                <div id="copy-div" class="shadow" title="Copy raw result to clipboard">
+                <button type="button" id="copy-div" class="shadow" title="Copy raw result to clipboard" aria-label="Copy raw result to clipboard">
                     <svg id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
                         <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
                     </svg>
-                </div>
-                <div id="download-div" class="shadow">
+                </button>
+                <button type="button" id="download-div" class="shadow" title="Download query result" aria-label="Download query result">
                     <svg id="download" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
                         <polyline points="7 10 12 15 17 10"/>
                         <line x1="12" y1="15" x2="12" y2="3"/>
                     </svg>
-                </div>
+                </button>
                 <div id="theme"><span id="toggle-dark">🌘</span><span id="toggle-light">☀️</span></div>
             </div>
         </form>
@@ -2554,7 +2557,8 @@ let in_flight = false;
 
 // Favicon changes to gray while a query is running, to indicate progress on the browser tab.
 const favicon_default = document.querySelector('link[rel="icon"]').href;
-const favicon_running = 'data:image/svg+xml;base64,' + btoa(atob(favicon_default.split(',')[1]).replace('#ff0', '#bbb'));
+const favicon_svg = atob(favicon_default.split(',')[1]);
+const favicon_running = 'data:image/svg+xml;base64,' + btoa(favicon_svg.replace(/#(?:ff0|199DCF)/i, '#bbb'));
 
 function setFavicon(href) { document.querySelector('link[rel="icon"]').href = href; }
 

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -611,6 +611,7 @@
         }
         #logo text
         {
+            font-size: 14px;
             fill: var(--logo-color);
         }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changes

- Fix running-query favicon not turning grey
- Restore consistent button text styling in the light theme by defining the missing `--button-text-color` token in `:root`.
- Make the copy and download controls proper button elements, preserving their appearance while restoring native keyboard focus and activation behavior.
- Restore the logo ® size after the graph SVG styles were moved into a shadow DOM, fixing the symbol rendering larger than intended and getting clipped.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
