### PR TITLE
Fix object_storage_remote_initiator test

### DIFF
--- a/tests/integration/test_storage_iceberg/test.py
+++ b/tests/integration/test_storage_iceberg/test.py
@@ -4284,32 +4284,6 @@ def test_object_storage_remote_initiator(started_cluster, format_version, storag
         """
     ).strip()
 
-    # Simple cluster
-    query_id = uuid.uuid4().hex
-    result = instance.query(
-        f"""
-        SELECT * from {TABLE_NAME}
-        ORDER BY ALL
-        SETTINGS object_storage_remote_initiator=1
-        """,
-        query_id = query_id,
-    ).strip()
-
-    assert result == expected_result
-
-    instance.query("SYSTEM FLUSH LOGS ON CLUSTER 'cluster_simple'")
-    queries = instance.query(
-        f"""
-        SELECT count()
-            FROM clusterAllReplicas('cluster_simple', system.query_log)
-            WHERE type='QueryFinish' AND initial_query_id='{query_id}'
-            FORMAT TSV
-        """
-    ).splitlines()
-
-    # non cluster request - only on initial node
-    assert queries == ["1"]
-
     # Remote initiator. Use 'cluster_second' to avoid choosing node1 as initiator, it can reduce number of subqueries
     query_id = uuid.uuid4().hex
 
@@ -4431,24 +4405,6 @@ def test_object_storage_remote_initiator(started_cluster, format_version, storag
     assert queries == ["1"]
 
     query_id = uuid.uuid4().hex
-    result = instance.query(f"SELECT * FROM {table_function} ORDER BY ALL SETTINGS object_storage_remote_initiator=1", query_id=query_id).strip()
-
-    assert result == expected_result
-
-    instance.query("SYSTEM FLUSH LOGS ON CLUSTER 'cluster_simple'")
-    queries = instance.query(
-        f"""
-        SELECT count()
-            FROM clusterAllReplicas('cluster_simple', system.query_log)
-            WHERE type='QueryFinish' AND initial_query_id='{query_id}'
-            FORMAT TSV
-        """
-    ).splitlines()
-
-    # initial node
-    assert queries == ["1"]
-
-    query_id = uuid.uuid4().hex
     result = instance.query(f"SELECT * FROM {table_function} ORDER BY ALL SETTINGS object_storage_remote_initiator=1, object_storage_cluster='cluster_second'", query_id=query_id).strip()
 
     assert result == expected_result
@@ -4468,24 +4424,6 @@ def test_object_storage_remote_initiator(started_cluster, format_version, storag
 
     query_id = uuid.uuid4().hex
     result = instance.query(f"SELECT * FROM {table_function_with_structure} ORDER BY ALL", query_id=query_id).strip()
-
-    assert result == expected_result
-
-    instance.query("SYSTEM FLUSH LOGS ON CLUSTER 'cluster_simple'")
-    queries = instance.query(
-        f"""
-        SELECT count()
-            FROM clusterAllReplicas('cluster_simple', system.query_log)
-            WHERE type='QueryFinish' AND initial_query_id='{query_id}'
-            FORMAT TSV
-        """
-    ).splitlines()
-
-    # initial node
-    assert queries == ["1"]
-
-    query_id = uuid.uuid4().hex
-    result = instance.query(f"SELECT * FROM {table_function_with_structure} ORDER BY ALL SETTINGS object_storage_remote_initiator=1", query_id=query_id).strip()
 
     assert result == expected_result
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix test_storage_iceberg/test.py::test_object_storage_remote_initiator

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
