### PR TITLE
Antalya 26.3: Fix export task not being killed during s3 outage

### DIFF
--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -111,6 +111,16 @@ public:
     void attachQueryForLog(const String & query_, UInt64 normalized_hash = 0);
     void attachInternalProfileEventsQueue(const InternalProfileEventsQueuePtr & profile_queue);
 
+    /// Override the cancellation predicate. All threads that subsequently attach to this
+    /// group via ThreadGroupSwitcher inherit the predicate in their local_data, making
+    /// isQueryCanceled() reflect task-level cancellation without a process-list entry.
+    /// Required for part and partition export cancellation during S3 outage.
+    void setCancelPredicate(QueryIsCanceledPredicate predicate)
+    {
+        std::lock_guard lock(mutex);
+        shared_data.query_is_canceled_predicate = std::move(predicate);
+    }
+
     /// When new query starts, new thread group is created for it, current thread becomes master thread of the query
     static ThreadGroupPtr createForQuery(ContextPtr query_context_, FatalErrorCallback fatal_error_callback_ = {});
 

--- a/src/Storages/MergeTree/ExportPartTask.cpp
+++ b/src/Storages/MergeTree/ExportPartTask.cpp
@@ -175,6 +175,28 @@ bool ExportPartTask::executeStep()
         manifest.query_id,
         local_context);
 
+    /*
+        This is a hack to fix the issue where S3 is out, ClickHouse keeps retrying S3 requests deep
+        in the AWS SDK and never check for the `isCancelled()` flag. That prevents the task from being killed / cancelled. It also prevents the table from being dropped.
+
+        Merges and mutations don't suffer from this problem because they don't make requests to S3 :). Select statements
+        do make requests to S3, but the cancel predicate is properly setup for regular queries.
+
+        I think this is the first time we have a background operation that makes requests to S3, so we need to connect the dots.
+
+        The simples way is this one, and given the release timeline, I am opting for it.
+    */
+    (*exports_list_entry)->thread_group->setCancelPredicate(
+        [weak_this = weak_from_this()]() -> bool
+        {
+            if (auto shared_this = weak_this.lock())
+            {
+                return shared_this->isCancelled();
+            }
+
+            return true;
+        });
+
     SinkToStoragePtr sink;
 
     const auto new_file_path_callback = [&exports_list_entry](const std::string & file_path)
@@ -185,6 +207,8 @@ bool ExportPartTask::executeStep()
 
     try
     {
+        ThreadGroupSwitcher switcher((*exports_list_entry)->thread_group, ThreadName::EXPORT_PART);
+
         const auto filename = buildDestinationFilename(manifest, storage.getStorageID(), local_context);
 
         sink = destination_storage->import(
@@ -232,8 +256,6 @@ bool ExportPartTask::executeStep()
             prefetch,
             local_context,
             getLogger("ExportPartition"));
-
-        ThreadGroupSwitcher switcher((*exports_list_entry)->thread_group, ThreadName::EXPORT_PART);
 
         /// We need to support exporting materialized and alias columns to object storage. For some reason, object storage engines don't support them.
         /// This is a hack that materializes the columns before the export so they can be exported to tables that have matching columns

--- a/src/Storages/MergeTree/ExportPartTask.h
+++ b/src/Storages/MergeTree/ExportPartTask.h
@@ -7,7 +7,7 @@
 namespace DB
 {
 
-class ExportPartTask : public IExecutableTask
+class ExportPartTask : public IExecutableTask, public std::enable_shared_from_this<ExportPartTask>
 {
 public:
     explicit ExportPartTask(


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The drop table operation must signal cancellation to all background tasks and wait until they ack it. This is done checking the `is_cancelled` flag at each pipeline iteration. If S3 is unreachable and s3_retries_attempt is big (by default, it is 500), the pipeline gets stuck deep in the AWS SDK and never gets a chance to check the signal / flag. Making the task "unkillable".

This PR fixes it in a hackish way by overwriting the `query_is_cancelled_predicate`, which is checked by the S3 client retry strategy upon `ShouldRetry` (https://github.com/Altinity/ClickHouse/pull/1564 by @arthurpassos).

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)

Cherry-picked from #1564.

---

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Documentation entry for user-facing changes
...