### PR TITLE
Antalya 26.3: Fix rescheduleTasksFromReplica

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageStableTaskDistributor.cpp
@@ -308,13 +308,14 @@ void StorageObjectStorageStableTaskDistributor::rescheduleTasksFromReplica(size_
             "All replicas were marked as lost"
         );
 
-    for (const auto & file : processed_file_list_ptr->second)
+    auto files = std::move(processed_file_list_ptr->second);
+    replica_to_files_to_be_processed.erase(number_of_current_replica);
+    for (const auto & file : files)
     {
         auto file_replica_idx = getReplicaForFile(file->getPath());
         unprocessed_files.emplace(file->getPath(), std::make_pair(file, file_replica_idx));
         connection_to_files[file_replica_idx].push_back(file);
     }
-    replica_to_files_to_be_processed.erase(number_of_current_replica);
 }
 
 }


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix rescheduleTasksFromReplica (https://github.com/Altinity/ClickHouse/pull/1568 by @ianton-ru).

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)

Cherry-picked from #1568.

---

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Documentation entry for user-facing changes
Fix incorrect change from https://github.com/Altinity/ClickHouse/pull/1414/changes/c523f292e2f8a58f3f18b9ec0f91c4f92294fed9
`getReplicaForFile` uses `replica_to_files_to_be_processed` to find best replica for file, With removing lost replica after `getReplicaForFile` call, `getReplicaForFile` chooses the same replica, so rescheduling makes no sense, files will be choosen only in `getAnyUnprocessedFile` and executed on random replicas.
This PR fixes the order, now files are matched with new best replicas.