### PR TITLE
Support for 'time' type in Iceberg

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -159,6 +159,9 @@ static void insertNumber(IColumn & column, WhichDataType type, T value)
         case TypeIndex::DateTime64:
             assert_cast<ColumnDecimal<DateTime64> &>(column).insertValue(static_cast<Int64>(value));
             break;
+        case TypeIndex::Time64:
+            assert_cast<ColumnDecimal<Time64> &>(column).insertValue(static_cast<Int64>(value));
+            break;
         case TypeIndex::IPv4:
             assert_cast<ColumnIPv4 &>(column).insertValue(IPv4(static_cast<UInt32>(value)));
             break;
@@ -307,6 +310,8 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
                 return createDecimalDeserializeFn<DataTypeDecimal256>(root_node, target_type, false);
             if (target.isDateTime64())
                 return createDecimalDeserializeFn<DataTypeDateTime64>(root_node, target_type, false);
+            if (target.isTime64())
+                return createDecimalDeserializeFn<DataTypeTime64>(root_node, target_type, false);
             break;
         case avro::AVRO_INT:
             if (target_type->isValueRepresentedByNumber())
@@ -1300,8 +1305,11 @@ DataTypePtr AvroSchemaReader::avroNodeToDataType(avro::NodePtr node)
     {
         case avro::Type::AVRO_INT:
         {
-            if (node->logicalType().type() == avro::LogicalType::DATE)
+            auto logical_type = node->logicalType();
+            if (logical_type.type() == avro::LogicalType::DATE)
                 return {std::make_shared<DataTypeDate32>()};
+            if (logical_type.type() == avro::LogicalType::TIME_MILLIS)
+                return {std::make_shared<DataTypeTime64>(3)};
 
             return {std::make_shared<DataTypeInt32>()};
         }
@@ -1312,6 +1320,10 @@ DataTypePtr AvroSchemaReader::avroNodeToDataType(avro::NodePtr node)
                 return {std::make_shared<DataTypeDateTime64>(3)};
             if (logical_type.type() == avro::LogicalType::TIMESTAMP_MICROS)
                 return {std::make_shared<DataTypeDateTime64>(6)};
+            if (logical_type.type() == avro::LogicalType::TIME_MILLIS)
+                return {std::make_shared<DataTypeTime64>(3)};
+            if (logical_type.type() == avro::LogicalType::TIME_MICROS)
+                return {std::make_shared<DataTypeTime64>(6)};
 
             return std::make_shared<DataTypeInt64>();
         }

--- a/src/Processors/Formats/Impl/Parquet/PrepareForWrite.cpp
+++ b/src/Processors/Formats/Impl/Parquet/PrepareForWrite.cpp
@@ -21,6 +21,7 @@
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeFixedString.h>
+#include <DataTypes/DataTypeTime64.h>
 #include <DataTypes/DataTypeCustom.h>
 
 /// This file deals with schema conversion and with repetition and definition levels.
@@ -475,7 +476,21 @@ void preparePrimitiveColumn(ColumnPtr column, DataTypePtr type, const std::strin
         case TypeIndex::Decimal128: decimal(16, getDecimalPrecision(*type), getDecimalScale(*type)); break;
         case TypeIndex::Decimal256: decimal(32, getDecimalPrecision(*type), getDecimalScale(*type)); break;
 
-        case TypeIndex::Time: types(T::INT32, C::UINT_32, int_type(32, false)); break;
+        case TypeIndex::Time:
+        {
+            parq::TimeUnit unit;
+            unit.__set_MICROS({});
+
+            parq::TimeType tt;
+            tt.__set_isAdjustedToUTC(false);
+            tt.__set_unit(unit);
+
+            parq::LogicalType t;
+            t.__set_TIME(tt);
+            types(T::INT64, parq::ConvertedType::TIME_MICROS, t);
+            state.datetime_multiplier = 1'000'000;
+            break;
+        }
 
         case TypeIndex::Time64:
         {
@@ -484,13 +499,7 @@ void preparePrimitiveColumn(ColumnPtr column, DataTypePtr type, const std::strin
             const auto & dt = assert_cast<const DataTypeTime64 &>(*type);
             UInt32 scale = dt.getScale();
             UInt32 converted_scale;
-            if (scale <= 3)
-            {
-                converted = parq::ConvertedType::TIME_MILLIS;
-                unit.__set_MILLIS({});
-                converted_scale = 3;
-            }
-            else if (scale <= 6)
+            if (scale <= 6)
             {
                 converted = parq::ConvertedType::TIME_MICROS;
                 unit.__set_MICROS({});
@@ -507,9 +516,7 @@ void preparePrimitiveColumn(ColumnPtr column, DataTypePtr type, const std::strin
             }
 
             parq::TimeType tt;
-            /// (Shouldn't we check the Time64's timezone parameter here? No, the actual number
-            /// in Time64 column is always in UTC, regardless of the timezone parameter.)
-            tt.__set_isAdjustedToUTC(true);
+            tt.__set_isAdjustedToUTC(false);
             tt.__set_unit(unit);
             parq::LogicalType t;
             t.__set_TIME(tt);

--- a/src/Processors/Formats/Impl/Parquet/PrepareForWrite.cpp
+++ b/src/Processors/Formats/Impl/Parquet/PrepareForWrite.cpp
@@ -475,6 +475,49 @@ void preparePrimitiveColumn(ColumnPtr column, DataTypePtr type, const std::strin
         case TypeIndex::Decimal128: decimal(16, getDecimalPrecision(*type), getDecimalScale(*type)); break;
         case TypeIndex::Decimal256: decimal(32, getDecimalPrecision(*type), getDecimalScale(*type)); break;
 
+        case TypeIndex::Time: types(T::INT32, C::UINT_32, int_type(32, false)); break;
+
+        case TypeIndex::Time64:
+        {
+            std::optional<parq::ConvertedType::type> converted;
+            parq::TimeUnit unit;
+            const auto & dt = assert_cast<const DataTypeTime64 &>(*type);
+            UInt32 scale = dt.getScale();
+            UInt32 converted_scale;
+            if (scale <= 3)
+            {
+                converted = parq::ConvertedType::TIME_MILLIS;
+                unit.__set_MILLIS({});
+                converted_scale = 3;
+            }
+            else if (scale <= 6)
+            {
+                converted = parq::ConvertedType::TIME_MICROS;
+                unit.__set_MICROS({});
+                converted_scale = 6;
+            }
+            else if (scale <= 9)
+            {
+                unit.__set_NANOS({});
+                converted_scale = 9;
+            }
+            else
+            {
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected Time64 scale: {}", scale);
+            }
+
+            parq::TimeType tt;
+            /// (Shouldn't we check the Time64's timezone parameter here? No, the actual number
+            /// in Time64 column is always in UTC, regardless of the timezone parameter.)
+            tt.__set_isAdjustedToUTC(true);
+            tt.__set_unit(unit);
+            parq::LogicalType t;
+            t.__set_TIME(tt);
+            types(T::INT64, converted, t);
+            state.datetime_multiplier = DataTypeTime64::getScaleMultiplier(converted_scale - scale);
+            break;
+        }
+
         default:
             throw Exception(ErrorCodes::UNKNOWN_TYPE, "Internal type '{}' of column '{}' is not supported for conversion into Parquet data format.", type->getFamilyName(), name);
     }

--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -411,6 +411,26 @@ struct ConverterDateTime
     }
 };
 
+struct ConverterTime
+{
+    using Statistics = StatisticsNumeric<Int64, Int64>;
+
+    using Col = ColumnVector<Int32>;
+    const Col & column;
+    PODArray<Int64> buf;
+    Int64 multiplier;
+
+    ConverterTime(const ColumnPtr & c, Int64 multiplier_) : column(assert_cast<const Col &>(*c)), multiplier(multiplier_) {}
+
+    const Int64 * getBatch(size_t offset, size_t count)
+    {
+        buf.resize(count);
+        for (size_t i = 0; i < count; ++i)
+            buf[i] = static_cast<Int64>(column.getData()[offset + i]) * multiplier;
+        return buf.data();
+    }
+};
+
 struct ConverterString
 {
     using Statistics = StatisticsStringRef;
@@ -1175,7 +1195,12 @@ void writeColumnChunkBody(
                 N(Int16, Int32Type);
             break;
         }
-        case TypeIndex::Int32  : N(Int32,  Int32Type); break;
+        case TypeIndex::Int32:
+            if (s.type->getTypeId() == TypeIndex::Time)
+                writeColumnImpl<parquet::Int64Type>(s, options, out, ConverterTime(s.primitive_column, s.datetime_multiplier));
+            else
+                N(Int32,  Int32Type);
+            break;
         case TypeIndex::Int64  : N(Int64,  Int64Type); break;
 
         case TypeIndex::UInt32:

--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -360,16 +360,17 @@ struct ConverterNumeric
     }
 };
 
-struct ConverterDateTime64WithMultiplier
+template <typename TYPE>
+struct ConverterTimeType64WithMultiplierImpl
 {
     using Statistics = StatisticsNumeric<Int64, Int64>;
 
-    using Col = ColumnDecimal<DateTime64>;
+    using Col = ColumnDecimal<TYPE>;
     const Col & column;
     Int64 multiplier;
     PODArray<Int64> buf;
 
-    ConverterDateTime64WithMultiplier(const ColumnPtr & c, Int64 multiplier_) : column(assert_cast<const Col &>(*c)), multiplier(multiplier_) {}
+    ConverterTimeType64WithMultiplierImpl(const ColumnPtr & c, Int64 multiplier_) : column(assert_cast<const Col &>(*c)), multiplier(multiplier_) {}
 
     const Int64 * getBatch(size_t offset, size_t count)
     {
@@ -386,6 +387,9 @@ struct ConverterDateTime64WithMultiplier
         return buf.data();
     }
 };
+
+using ConverterDateTime64WithMultiplier = ConverterTimeType64WithMultiplierImpl<DateTime64>;
+using ConverterTime64WithMultiplier = ConverterTimeType64WithMultiplierImpl<Time64>;
 
 /// Multiply DateTime by 1000 to get milliseconds (because Parquet doesn't support seconds).
 struct ConverterDateTime
@@ -1184,7 +1188,6 @@ void writeColumnChunkBody(
                 writeColumnImpl<parquet::Int64Type>(s, options, out, ConverterDateTime(s.primitive_column));
             }
             break;
-
         #undef N
 
         case TypeIndex::Float32:
@@ -1252,6 +1255,17 @@ void writeColumnChunkBody(
         case TypeIndex::Decimal128: D(Decimal128); break;
         case TypeIndex::Decimal256: D(Decimal256); break;
         #undef D
+
+        case TypeIndex::Time64:
+            if (s.datetime_multiplier == 1)
+                writeColumnImpl<parquet::Int64Type>(
+                    s, options, out, ConverterNumeric<ColumnDecimal<Time64>, Int64, Int64>(
+                        s.primitive_column));
+            else
+                writeColumnImpl<parquet::Int64Type>(
+                    s, options, out, ConverterTime64WithMultiplier(
+                        s.primitive_column, s.datetime_multiplier));
+            break;
 
         default:
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected column type: {}", s.primitive_column->getFamilyName());

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Constant.h
@@ -41,6 +41,7 @@ DEFINE_ICEBERG_FIELD(time);
 DEFINE_ICEBERG_FIELD(timestamp);
 DEFINE_ICEBERG_FIELD(timestamptz);
 DEFINE_ICEBERG_FIELD(type)
+DEFINE_ICEBERG_FIELD(logicalType); /// this field has a camelCase name
 DEFINE_ICEBERG_FIELD(transform);
 DEFINE_ICEBERG_FIELD(direction);
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -129,6 +129,8 @@ bool canDumpIcebergStats(const Field & field, DataTypePtr type)
         case TypeIndex::Date32:
         case TypeIndex::Int64:
         case TypeIndex::DateTime64:
+        case TypeIndex::Time:
+        case TypeIndex::Time64:
         case TypeIndex::String:
             return true;
         default:
@@ -157,6 +159,8 @@ std::vector<uint8_t> dumpFieldToBytes(const Field & field, DataTypePtr type)
         case TypeIndex::Int64:
             return dumpValue(field.safeGet<Int64>());
         case TypeIndex::DateTime64:
+        case TypeIndex::Time:
+        case TypeIndex::Time64:
             return dumpValue(field.safeGet<Decimal64>().getValue().value);
         case TypeIndex::String:
         {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -157,10 +157,10 @@ std::vector<uint8_t> dumpFieldToBytes(const Field & field, DataTypePtr type)
         case TypeIndex::Date32:
             return dumpValue(field.safeGet<Int32>());
         case TypeIndex::Int64:
-            return dumpValue(field.safeGet<Int64>());
-        case TypeIndex::DateTime64:
         case TypeIndex::Time:
+            return dumpValue(field.safeGet<Int64>());
         case TypeIndex::Time64:
+        case TypeIndex::DateTime64:
             return dumpValue(field.safeGet<Decimal64>().getValue().value);
         case TypeIndex::String:
         {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -155,9 +155,9 @@ std::vector<uint8_t> dumpFieldToBytes(const Field & field, DataTypePtr type)
         case TypeIndex::Int32:
         case TypeIndex::Date:
         case TypeIndex::Date32:
+        case TypeIndex::Time:
             return dumpValue(field.safeGet<Int32>());
         case TypeIndex::Int64:
-        case TypeIndex::Time:
             return dumpValue(field.safeGet<Int64>());
         case TypeIndex::Time64:
         case TypeIndex::DateTime64:
@@ -640,8 +640,8 @@ void generateManifestFile(
 
                 case Field::Types::Decimal64:
                 {
-                    auto type_id = partition_types[i]->getTypeId();
-                    if (type_id == TypeIndex::Time64 || type_id == TypeIndex::Time)
+                    const WhichDataType which(*partition_types[i]);
+                    if (which.isTime64())
                     { /// Need to write logical type into Avro
                         auto scale = getDecimalScale(*partition_types[i]);
                         if (scale == 0)
@@ -659,7 +659,7 @@ void generateManifestFile(
                         {
                             throw Exception(
                                 ErrorCodes::BAD_ARGUMENTS,
-                                "Avro file supports only seconds, milliseconds and microsecods for time, partition precision: {}", scale);
+                                "Avro file supports only seconds, milliseconds and microseconds for time, partition precision: {}", scale);
                         }
                     }
                     else

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -387,7 +387,16 @@ void extendSchemaForPartitions(
         Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
         field->set(Iceberg::f_field_id, 1000 + i);
         field->set(Iceberg::f_name, partition_columns[i]);
-        field->set(Iceberg::f_type, getAvroType(partition_types[i]));
+        auto logical_type = getAvroLogicalType(partition_types[i]);
+        if (!logical_type.isEmpty())
+        {
+            Poco::JSON::Object::Ptr type_field = new Poco::JSON::Object;
+            type_field->set(Iceberg::f_type, getAvroType(partition_types[i]));
+            type_field->set(Iceberg::f_logicalType, logical_type);
+            field->set(Iceberg::f_type, type_field);
+        }
+        else
+            field->set(Iceberg::f_type, getAvroType(partition_types[i]));
         partition_fields->add(field);
     }
 
@@ -630,10 +639,34 @@ void generateManifestFile(
                     break;
 
                 case Field::Types::Decimal64:
-                    partition_record.field(partition_columns[i]) =
-                        avro::GenericDatum(partition_values[i].safeGet<Decimal64>().getValue());
+                {
+                    auto type_id = partition_types[i]->getTypeId();
+                    if (type_id == TypeIndex::Time64 || type_id == TypeIndex::Time)
+                    { /// Need to write logical type into Avro
+                        auto scale = getDecimalScale(*partition_types[i]);
+                        if (scale == 0)
+                            partition_record.field(partition_columns[i]) =
+                                avro::GenericDatum(partition_values[i].safeGet<Decimal64>().getValue());
+                        else if (scale == 3 || scale == 6)
+                        {
+                            avro::NodePtr node = std::make_shared<avro::NodePrimitive>(avro::AVRO_LONG);
+                            node->setLogicalType(avro::LogicalType(scale == 3 ? avro::LogicalType::TIME_MILLIS : avro::LogicalType::TIME_MICROS));
+                            int64_t value = partition_values[i].safeGet<Decimal64>().getValue();
+                            auto datum = avro::GenericDatum(node, value);
+                            partition_record.field(partition_columns[i]) = datum;
+                        }
+                        else
+                        {
+                            throw Exception(
+                                ErrorCodes::BAD_ARGUMENTS,
+                                "Avro file supports only seconds, milliseconds and microsecods for time, partition precision: {}", scale);
+                        }
+                    }
+                    else
+                        partition_record.field(partition_columns[i]) =
+                            avro::GenericDatum(partition_values[i].safeGet<Decimal64>().getValue());
                     break;
-
+                }
                 case Field::Types::Null:
                     break;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -12,6 +12,7 @@
 #include <Core/TypeId.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeTime64.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/IDataType.h>
 #include <Databases/DataLake/Common.h>
@@ -146,6 +147,46 @@ std::vector<uint8_t> dumpValue(T value)
     return bytes;
 }
 
+DataTypePtr getTimeTypeOrNull(DataTypePtr type)
+{
+    if (type->isNullable())
+        return getTimeTypeOrNull(assert_cast<const DataTypeNullable *>(type.get())->getNestedType());
+
+    const WhichDataType which(type);
+    if (which.isTime() || which.isTime64())
+        return type;
+
+    return nullptr;
+}
+
+Int64 getTimeValueInMicroseconds(const Field & field, DataTypePtr type)
+{
+    if (type->isNullable())
+        return getTimeValueInMicroseconds(field, assert_cast<const DataTypeNullable *>(type.get())->getNestedType());
+
+    const WhichDataType which(type);
+    if (which.isTime())
+    {
+        if (field.getType() == Field::Types::Int64)
+            return field.safeGet<Int64>() * 1'000'000;
+        if (field.getType() == Field::Types::UInt64)
+            return static_cast<Int64>(field.safeGet<UInt64>()) * 1'000'000;
+        return static_cast<Int64>(field.safeGet<Int32>()) * 1'000'000;
+    }
+
+    if (which.isTime64())
+    {
+        const auto scale = getDecimalScale(*type);
+        if (scale > 6)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
+
+        const auto value = field.safeGet<Decimal64>().getValue().value;
+        return value * DataTypeTime64::getScaleMultiplier(6 - scale).value;
+    }
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected Time or Time64, got {}", type->getName());
+}
+
 std::vector<uint8_t> dumpFieldToBytes(const Field & field, DataTypePtr type)
 {
     switch (type->getTypeId())
@@ -155,11 +196,13 @@ std::vector<uint8_t> dumpFieldToBytes(const Field & field, DataTypePtr type)
         case TypeIndex::Int32:
         case TypeIndex::Date:
         case TypeIndex::Date32:
-        case TypeIndex::Time:
             return dumpValue(field.safeGet<Int32>());
+        case TypeIndex::Time:
+            return dumpValue(getTimeValueInMicroseconds(field, type));
         case TypeIndex::Int64:
             return dumpValue(field.safeGet<Int64>());
         case TypeIndex::Time64:
+            return dumpValue(getTimeValueInMicroseconds(field, type));
         case TypeIndex::DateTime64:
             return dumpValue(field.safeGet<Decimal64>().getValue().value);
         case TypeIndex::String:
@@ -615,6 +658,14 @@ void generateManifestFile(
         avro::GenericRecord & partition_record = data_file.field("partition").value<avro::GenericRecord>();
         for (size_t i = 0; i < partition_columns.size(); ++i)
         {
+            auto partition_time_type = getTimeTypeOrNull(partition_types[i]);
+            if (!partition_values[i].isNull() && partition_time_type)
+            {
+                partition_record.field(partition_columns[i]) =
+                    avro::GenericDatum(getTimeValueInMicroseconds(partition_values[i], partition_types[i]));
+                continue;
+            }
+
             switch (partition_values[i].getType())
             {
                 case Field::Types::Int64:
@@ -639,34 +690,9 @@ void generateManifestFile(
                     break;
 
                 case Field::Types::Decimal64:
-                {
-                    const WhichDataType which(*partition_types[i]);
-                    if (which.isTime64())
-                    { /// Need to write logical type into Avro
-                        auto scale = getDecimalScale(*partition_types[i]);
-                        if (scale == 0)
-                            partition_record.field(partition_columns[i]) =
-                                avro::GenericDatum(partition_values[i].safeGet<Decimal64>().getValue());
-                        else if (scale == 3 || scale == 6)
-                        {
-                            avro::NodePtr node = std::make_shared<avro::NodePrimitive>(avro::AVRO_LONG);
-                            node->setLogicalType(avro::LogicalType(scale == 3 ? avro::LogicalType::TIME_MILLIS : avro::LogicalType::TIME_MICROS));
-                            int64_t value = partition_values[i].safeGet<Decimal64>().getValue();
-                            auto datum = avro::GenericDatum(node, value);
-                            partition_record.field(partition_columns[i]) = datum;
-                        }
-                        else
-                        {
-                            throw Exception(
-                                ErrorCodes::BAD_ARGUMENTS,
-                                "Avro file supports only seconds, milliseconds and microseconds for time, partition precision: {}", scale);
-                        }
-                    }
-                    else
-                        partition_record.field(partition_columns[i]) =
-                            avro::GenericDatum(partition_values[i].safeGet<Decimal64>().getValue());
+                    partition_record.field(partition_columns[i]) =
+                        avro::GenericDatum(partition_values[i].safeGet<Decimal64>().getValue());
                     break;
-                }
                 case Field::Types::Null:
                     break;
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -243,7 +243,7 @@ DataTypePtr IcebergSchemaProcessor::getSimpleType(const String & type_name, Cont
     if (type_name == f_date)
         return std::make_shared<DataTypeDate32>();
     if (type_name == f_time)
-        return std::make_shared<DataTypeInt64>();
+        return std::make_shared<DataTypeTime64>(6);
     if (type_name == f_timestamp)
         return std::make_shared<DataTypeDateTime64>(6);
     if (type_name == f_timestamptz)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -564,8 +564,17 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
         case TypeIndex::Int64:
         case TypeIndex::DateTime:
         case TypeIndex::DateTime64:
-        case TypeIndex::Time64:
             return "long";
+        case TypeIndex::Time64:
+        {
+            auto scale = getDecimalScale(*type);
+            if (scale == 0 || scale == 3)
+                return "int";
+            else if (scale == 6)
+                return "long";
+            else
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
+        }
         case TypeIndex::Float32:
             return "float";
         case TypeIndex::Float64:
@@ -585,8 +594,14 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
 
 Poco::Dynamic::Var getAvroLogicalType(DataTypePtr type)
 {
-    auto type_id = type->getTypeId();
-    if (type_id == TypeIndex::Time || type_id == TypeIndex::Time64)
+    if (type->isNullable())
+    {
+        auto type_nullable = std::static_pointer_cast<const DataTypeNullable>(type);
+        return getAvroLogicalType(type_nullable->getNestedType());
+    }
+
+    const WhichDataType which(type);
+    if (which.isTime64())
     {
         auto scale = getDecimalScale(*type);
         switch (scale)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -563,6 +563,7 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
         case TypeIndex::Int64:
         case TypeIndex::DateTime:
         case TypeIndex::DateTime64:
+        case TypeIndex::Time64:
             return "long";
         case TypeIndex::Float32:
             return "float";

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -482,8 +482,11 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
         case TypeIndex::DateTime64:
             return {"timestamp", true};
         case TypeIndex::Time:
-        case TypeIndex::Time64:
             return {"time", true};
+        case TypeIndex::Time64:
+            if (getDecimalScale(*type) <= 6)
+                return {"time", true};
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
         case TypeIndex::String:
             return {"string", true};
         case TypeIndex::UUID:
@@ -558,19 +561,17 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
         case TypeIndex::Int32:
         case TypeIndex::Date:
         case TypeIndex::Date32:
-        case TypeIndex::Time:
             return "int";
         case TypeIndex::UInt64:
         case TypeIndex::Int64:
         case TypeIndex::DateTime:
         case TypeIndex::DateTime64:
+        case TypeIndex::Time:
             return "long";
         case TypeIndex::Time64:
         {
             auto scale = getDecimalScale(*type);
-            if (scale == 0 || scale == 3)
-                return "int";
-            else if (scale == 6)
+            if (scale <= 6)
                 return "long";
             else
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
@@ -601,20 +602,14 @@ Poco::Dynamic::Var getAvroLogicalType(DataTypePtr type)
     }
 
     const WhichDataType which(type);
+    if (which.isTime())
+        return "time-micros";
     if (which.isTime64())
     {
         auto scale = getDecimalScale(*type);
-        switch (scale)
-        { /// Apache avro has millis and micros time precisions, https://avro.apache.org/docs/1.11.0/spec.html
-            case 0:
-                return Poco::Dynamic::Var();
-            case 3:
-                return "time-millis";
-            case 6:
-                return "time-micros";
-            default:
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported time precision for avro {}({})", type->getName(), scale);
-        }
+        if (scale <= 6)
+            return "time-micros";
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported time precision for avro {}({})", type->getName(), scale);
     }
     return Poco::Dynamic::Var();
 }

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -8,6 +8,7 @@
 #include <Core/Settings.h>
 #include <Core/TypeId.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypesDecimal.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -580,6 +581,27 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
         default:
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
     }
+}
+
+Poco::Dynamic::Var getAvroLogicalType(DataTypePtr type)
+{
+    auto type_id = type->getTypeId();
+    if (type_id == TypeIndex::Time || type_id == TypeIndex::Time64)
+    {
+        auto scale = getDecimalScale(*type);
+        switch (scale)
+        { /// Apache avro has millis and micros time precisions, https://avro.apache.org/docs/1.11.0/spec.html
+            case 0:
+                return Poco::Dynamic::Var();
+            case 3:
+                return "time-millis";
+            case 6:
+                return "time-micros";
+            default:
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported time precision for avro {}({})", type->getName(), scale);
+        }
+    }
+    return Poco::Dynamic::Var();
 }
 
 Poco::JSON::Object::Ptr getPartitionField(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -481,6 +481,7 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
         case TypeIndex::DateTime64:
             return {"timestamp", true};
         case TypeIndex::Time:
+        case TypeIndex::Time64:
             return {"time", true};
         case TypeIndex::String:
             return {"string", true};

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
@@ -79,6 +79,7 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
 
 std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter);
 Poco::Dynamic::Var getAvroType(DataTypePtr type);
+Poco::Dynamic::Var getAvroLogicalType(DataTypePtr type);
 
 /// Converts a ClickHouse PARTITION BY AST into the corresponding Iceberg partition-spec JSON object.
 /// column_name_to_source_id maps each column name to the Iceberg field-id from the table schema.

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -25,6 +25,7 @@ from pyiceberg.types import (
     NestedField,
     StringType,
     StructType,
+    TimeType,
     TimestampType,
     TimestamptzType
 )
@@ -1051,3 +1052,95 @@ def test_cluster_joins(started_cluster):
     )
 
     assert res == "Jack\tBlack\nJack\tSilver\nJohn\tBlack\nJohn\tSilver\n"
+
+
+@pytest.mark.parametrize("storage_type", ["s3"])
+def test_partitioning_by_time(started_cluster, storage_type):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_partitioning_by_time_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    namespace = f"{root_namespace}.A"
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(namespace)
+
+    schema = Schema(
+        NestedField(
+            field_id=1,
+            name="key",
+            field_type=TimeType(),
+            required=False
+        ),
+        NestedField(
+            field_id=2,
+            name="value",
+            field_type=StringType(),
+            required=False,
+        ),
+    )
+
+    partition_spec = PartitionSpec(
+        PartitionField(
+            source_id=1, field_id=1000, transform=IdentityTransform(), name="partition_key"
+        )
+    )
+
+    table = create_table(catalog, namespace, table_name, schema=schema, partition_spec=partition_spec)
+    data = [{"key": dtime(12,0,0), "value": "test"}]
+    df = pa.Table.from_pylist(data)
+    table.append(df)
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}`") == "12:00:00.000000\ttest\n"
+
+
+@pytest.mark.parametrize("storage_type", ["s3"])
+def test_partitioning_by_string(started_cluster, storage_type):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_partitioning_by_string_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    namespace = f"{root_namespace}.A"
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(namespace)
+
+    schema = Schema(
+        NestedField(
+            field_id=1,
+            name="key",
+            field_type=StringType(),
+            required=False
+        ),
+        NestedField(
+            field_id=2,
+            name="value",
+            field_type=StringType(),
+            required=False,
+        ),
+        NestedField(
+            field_id=3,
+            name="time_value",
+            field_type=TimeType(),
+            required=False,
+        ),
+    )
+
+    partition_spec = PartitionSpec(
+        PartitionField(
+            source_id=1, field_id=1000, transform=IdentityTransform(), name="partition_key"
+        )
+    )
+
+    table = create_table(catalog, namespace, table_name, schema=schema, partition_spec=partition_spec)
+    data = [{"key": "a:b,c[d=e/f%g?h", "value": "test", "time_value": dtime(12,0,0)}]
+    df = pa.Table.from_pylist(data)
+    table.append(df)
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}`") == "a:b,c[d=e/f%g?h\ttest\t12:00:00.000000\n"

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1054,8 +1054,7 @@ def test_cluster_joins(started_cluster):
     assert res == "Jack\tBlack\nJack\tSilver\nJohn\tBlack\nJohn\tSilver\n"
 
 
-@pytest.mark.parametrize("storage_type", ["s3"])
-def test_partitioning_by_time(started_cluster, storage_type):
+def test_partitioning_by_time(started_cluster):
     node = started_cluster.instances["node1"]
 
     test_ref = f"test_partitioning_by_time_{uuid.uuid4()}"
@@ -1103,8 +1102,7 @@ def test_partitioning_by_time(started_cluster, storage_type):
     assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}` WHERE key <= '13:00:00.000000' ORDER BY key") == "12:00:00.000000\ttest1\n13:00:00.000000\ttest2\n"
 
 
-@pytest.mark.parametrize("storage_type", ["s3"])
-def test_partitioning_by_string(started_cluster, storage_type):
+def test_partitioning_by_string(started_cluster):
     node = started_cluster.instances["node1"]
 
     test_ref = f"test_partitioning_by_string_{uuid.uuid4()}"

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -5,7 +5,7 @@ import os
 import random
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time as dtime
 
 import pyarrow as pa
 import pytest
@@ -25,9 +25,9 @@ from pyiceberg.types import (
     NestedField,
     StringType,
     StructType,
-    TimeType,
     TimestampType,
-    TimestamptzType
+    TimestamptzType,
+    TimeType,
 )
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1088,13 +1088,19 @@ def test_partitioning_by_time(started_cluster, storage_type):
     )
 
     table = create_table(catalog, namespace, table_name, schema=schema, partition_spec=partition_spec)
-    data = [{"key": dtime(12,0,0), "value": "test"}]
+    data = [{"key": dtime(12,0,0), "value": "test1"},
+            {"key": dtime(13,0,0), "value": "test2"},
+            {"key": dtime(14,0,0), "value": "test3"},
+            ]
     df = pa.Table.from_pylist(data)
     table.append(df)
 
     create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
 
-    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}`") == "12:00:00.000000\ttest\n"
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}` ORDER BY key") == "12:00:00.000000\ttest1\n13:00:00.000000\ttest2\n14:00:00.000000\ttest3\n"
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}` WHERE key = '13:00:00.000000' ORDER BY key") == "13:00:00.000000\ttest2\n"
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}` WHERE key >= '13:00:00.000000' ORDER BY key") == "13:00:00.000000\ttest2\n14:00:00.000000\ttest3\n"
+    assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}` WHERE key <= '13:00:00.000000' ORDER BY key") == "12:00:00.000000\ttest1\n13:00:00.000000\ttest2\n"
 
 
 @pytest.mark.parametrize("storage_type", ["s3"])

--- a/tests/integration/test_storage_iceberg_no_spark/test_write_time.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_write_time.py
@@ -3,7 +3,19 @@ from helpers.config_cluster import minio_secret_key, minio_access_key
 from helpers.iceberg_utils import get_uuid_str
 
 
-@pytest.mark.parametrize("time_type", ["Time", "Time64(0)", "Time64(3)", "Time64(6)"])
+@pytest.mark.parametrize(
+    "time_type",
+    [
+        "Time",
+        "Time64(0)",
+        "Time64(3)",
+        "Time64(6)",
+        "Nullable(Time)",
+        "Nullable(Time64(0))",
+        "Nullable(Time64(3))",
+        "Nullable(Time64(6))",
+    ],
+)
 def test_write_time(started_cluster_iceberg_no_spark, time_type):
     node = started_cluster_iceberg_no_spark.instances["node1"]
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_write_time.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_write_time.py
@@ -3,12 +3,9 @@ from helpers.config_cluster import minio_secret_key, minio_access_key
 from helpers.iceberg_utils import get_uuid_str
 
 
-@pytest.mark.parametrize("time_type", ["Time", "Time64"])
+@pytest.mark.parametrize("time_type", ["Time", "Time64(0)", "Time64(3)", "Time64(6)"])
 def test_write_time(started_cluster_iceberg_no_spark, time_type):
     node = started_cluster_iceberg_no_spark.instances["node1"]
-
-    if time_type == "Time64":
-        time_type = "Time64(6)"
 
     TABLE_NAME = "test_partitioning_by_time_" + get_uuid_str()
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_write_time.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_write_time.py
@@ -1,0 +1,27 @@
+import pytest
+from helpers.config_cluster import minio_secret_key, minio_access_key
+from helpers.iceberg_utils import get_uuid_str
+
+
+@pytest.mark.parametrize("time_type", ["Time", "Time64"])
+def test_write_time(started_cluster_iceberg_no_spark, time_type):
+    node = started_cluster_iceberg_no_spark.instances["node1"]
+
+    if time_type == "Time64":
+        time_type = "Time64(6)"
+
+    TABLE_NAME = "test_partitioning_by_time_" + get_uuid_str()
+
+    node.query(
+        f"CREATE TABLE `{TABLE_NAME}` (key {time_type}, value String) ENGINE = IcebergLocal('/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}', 'Parquet') PARTITION BY key",
+        settings={"allow_experimental_insert_into_iceberg": 1, 'write_full_path_in_iceberg_metadata': 1}
+        )
+    node.query(
+        f"INSERT INTO `{TABLE_NAME}` VALUES ('12:00:00', 'test1'), ('13:00:00', 'test2'), ('14:00:00', 'test3');",
+        settings={"allow_experimental_insert_into_iceberg": 1, 'write_full_path_in_iceberg_metadata': 1}
+        )
+
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` ORDER BY key") == "12:00:00.000000\ttest1\n13:00:00.000000\ttest2\n14:00:00.000000\ttest3\n"
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key = '13:00:00.000000' ORDER BY key") == "13:00:00.000000\ttest2\n"
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key >= '13:00:00.000000' ORDER BY key") == "13:00:00.000000\ttest2\n14:00:00.000000\ttest3\n"
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key <= '13:00:00.000000' ORDER BY key") == "12:00:00.000000\ttest1\n13:00:00.000000\ttest2\n"

--- a/tests/integration/test_storage_iceberg_no_spark/test_write_time.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_write_time.py
@@ -13,15 +13,20 @@ def test_write_time(started_cluster_iceberg_no_spark, time_type):
     TABLE_NAME = "test_partitioning_by_time_" + get_uuid_str()
 
     node.query(
-        f"CREATE TABLE `{TABLE_NAME}` (key {time_type}, value String) ENGINE = IcebergLocal('/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}', 'Parquet') PARTITION BY key",
+        f"CREATE TABLE `{TABLE_NAME}` (key {time_type}, value {time_type}, comment String) ENGINE = IcebergLocal('/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}', 'Parquet') PARTITION BY key",
         settings={"allow_experimental_insert_into_iceberg": 1, 'write_full_path_in_iceberg_metadata': 1}
         )
     node.query(
-        f"INSERT INTO `{TABLE_NAME}` VALUES ('12:00:00', 'test1'), ('13:00:00', 'test2'), ('14:00:00', 'test3');",
+        f"INSERT INTO `{TABLE_NAME}` VALUES ('12:00:00', '12:10:00', 'test1'), ('13:00:00', '13:10:00', 'test2'), ('14:00:00', '14:10:00', 'test3');",
         settings={"allow_experimental_insert_into_iceberg": 1, 'write_full_path_in_iceberg_metadata': 1}
         )
 
-    assert node.query(f"SELECT * FROM `{TABLE_NAME}` ORDER BY key") == "12:00:00.000000\ttest1\n13:00:00.000000\ttest2\n14:00:00.000000\ttest3\n"
-    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key = '13:00:00.000000' ORDER BY key") == "13:00:00.000000\ttest2\n"
-    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key >= '13:00:00.000000' ORDER BY key") == "13:00:00.000000\ttest2\n14:00:00.000000\ttest3\n"
-    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key <= '13:00:00.000000' ORDER BY key") == "12:00:00.000000\ttest1\n13:00:00.000000\ttest2\n"
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` ORDER BY key") == "12:00:00.000000\t12:10:00.000000\ttest1\n13:00:00.000000\t13:10:00.000000\ttest2\n14:00:00.000000\t14:10:00.000000\ttest3\n"
+    # Partition pruning
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key = '13:00:00.000000' ORDER BY key") == "13:00:00.000000\t13:10:00.000000\ttest2\n"
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key >= '13:00:00.000000' ORDER BY key") == "13:00:00.000000\t13:10:00.000000\ttest2\n14:00:00.000000\t14:10:00.000000\ttest3\n"
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE key <= '13:00:00.000000' ORDER BY key") == "12:00:00.000000\t12:10:00.000000\ttest1\n13:00:00.000000\t13:10:00.000000\ttest2\n"
+    # Min/Max pruning
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE value = '13:10:00.000000' ORDER BY key") == "13:00:00.000000\t13:10:00.000000\ttest2\n"
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE value >= '13:10:00.000000' ORDER BY key") == "13:00:00.000000\t13:10:00.000000\ttest2\n14:00:00.000000\t14:10:00.000000\ttest3\n"
+    assert node.query(f"SELECT * FROM `{TABLE_NAME}` WHERE value <= '13:10:00.000000' ORDER BY key") == "12:00:00.000000\t12:10:00.000000\ttest1\n13:00:00.000000\t13:10:00.000000\ttest2\n"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support for 'time' type in Iceberg, read and write.

### Documentation entry for user-facing changes
Solved #1535 

This changes time format,.
Was - seconds from midnight:
```
SELECT * FROM datalake.`namespace.table`

43200
```
Now - time with microseconds
```
SELECT * FROM datalake.`namespace.table`

12:00:00.000000
```


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
