### PR TITLE
Antalya 26.1: Remove foreign branding

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -460,8 +460,7 @@ void Client::login()
     {
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
-            "Could not retrieve authentication endpoints for host '{}'. Please specify --oauth-url and --oauth-client-id if you are "
-            "not using ClickHouse Cloud.",
+            "Could not retrieve authentication endpoints for host '{}'. Please specify --oauth-url and --oauth-client-id.",
             host);
     }
 
@@ -732,8 +731,7 @@ void Client::addExtraOptions(OptionsDescription & options_description)
         ("login", po::value<std::string>()->implicit_value(""),
             "Authenticate via OAuth2. Optional mode: 'browser' (auth-code + PKCE, opens browser) "
             "or 'device' (device flow, prints URL + code). "
-            "Example: --login=browser or --login=device. "
-            "Bare --login uses the ClickHouse Cloud auto-login path.")
+            "Example: --login=browser or --login=device.")
         ("oauth-credentials", po::value<std::string>(),
             "Path to OAuth credentials JSON file "
             "(default: ~/.clickhouse-client/oauth_client.json)")

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -657,9 +657,6 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
 
             message << R"(
 
-If you use ClickHouse Cloud, the password can be reset at https://clickhouse.cloud/
-on the settings page for the corresponding service.
-
 If you have installed ClickHouse and forgot password you can reset it in the configuration file.
 The password for default user is typically located at /etc/clickhouse-server/users.d/default-password.xml
 and deleting this file will reset the password.

--- a/src/Client/CloudJWTProvider.cpp
+++ b/src/Client/CloudJWTProvider.cpp
@@ -132,7 +132,7 @@ void CloudJWTProvider::exchangeIdPTokenForClickHouseJWT(bool show_messages)
     if (!endpoints)
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
-            "Cannot determine token exchange endpoint from hostname {}. Please provide a ClickHouse Cloud hostname.",
+            "Cannot determine token exchange endpoint from hostname {}.",
             host_str);
 
     Poco::URI exchange_url = Poco::URI(endpoints->api_host + "/.api/auth/tokenExchange");
@@ -172,7 +172,7 @@ void CloudJWTProvider::exchangeIdPTokenForClickHouseJWT(bool show_messages)
     clickhouse_jwt_expires_at = Poco::Timestamp::fromEpochTime(jwt::decode(clickhouse_jwt).get_payload_claim("exp").as_integer());
 
     if (show_messages)
-        output_stream << "Authenticated with ClickHouse Cloud.\n" << std::endl;
+        output_stream << "Authenticated.\n" << std::endl;
 }
 
 }

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6222,8 +6222,7 @@ This setting takes a ClickHouse version number as a string, like `22.3`, `22.8`.
 Disabled by default.
 
 :::note
-In ClickHouse Cloud, the service-level default compatibility setting must be set by ClickHouse Cloud support. Please [open a case](https://clickhouse.cloud/support) to have it set.
-However, the compatibility setting can be overridden at the user, role, profile, query, or session level using standard ClickHouse setting mechanisms such as `SET compatibility = '22.3'` in a session or `SETTINGS compatibility = '22.3'` in a query.
+The compatibility setting can be overridden at the user, role, profile, query, or session level using standard ClickHouse setting mechanisms such as `SET compatibility = '22.3'` in a session or `SETTINGS compatibility = '22.3'` in a query.
 :::
 )", 0) \
     \

--- a/tests/queries/0_stateless/03362_basic_auth_interactive_not_with_authorization_never.reference
+++ b/tests/queries/0_stateless/03362_basic_auth_interactive_not_with_authorization_never.reference
@@ -1,3 +1,2 @@
 1
 < HTTP/1.1 403 Forbidden
-If you use ClickHouse Cloud, the password can be reset at https://clickhouse.cloud/

--- a/tests/queries/0_stateless/03362_basic_auth_interactive_not_with_authorization_never.sh
+++ b/tests/queries/0_stateless/03362_basic_auth_interactive_not_with_authorization_never.sh
@@ -11,4 +11,4 @@ ${CLICKHOUSE_CURL} -H 'Authorization: never' "$URL?query=SELECT%201"
 # If the Authorization is set to "never", and the credentials are provided in URL parameters,
 # the server will return 403 instead of 401 Unauthorized, so there will be no prompt in the browser.
 URL="${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?user=default&password=invalid_password"
-${CLICKHOUSE_CURL} -H 'Authorization: never' -v "$URL?query=SELECT%201" 2>&1 | grep -P '403 Forbidden|ClickHouse Cloud'
+${CLICKHOUSE_CURL} -H 'Authorization: never' -v "$URL?query=SELECT%201" 2>&1 | grep -P '403 Forbidden'


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove foreign branding

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
