### PR TITLE
Stable 25.8 - enable ci on stable-* branches

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,7 +11,7 @@ on:
         type: boolean
         default: false
   push:
-    branches: ['antalya', 'releases/*', 'antalya-*']
+    branches: ['antalya', 'releases/*', 'antalya-*', 'stable-*']
     tags: ['*']
 
 env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ on:
         type: boolean
         default: false
   pull_request:
-    branches: ['antalya', 'releases/*', 'antalya-*']
+    branches: ['antalya', 'releases/*', 'antalya-*', 'stable-*']
 
 env:
   # Force the stdout and stderr streams to be unbuffered

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -8,7 +8,7 @@ from ci.workflows.pull_request import REGULAR_BUILD_NAMES
 workflow = Workflow.Config(
     name="MasterCI",
     event=Workflow.Event.PUSH,
-    branches=[BASE_BRANCH, "releases/*", "antalya-*"],
+    branches=[BASE_BRANCH, "releases/*", "antalya-*", "stable-*"],
     tags=["*"],
     jobs=[
         # *JobConfigs.tidy_build_arm_jobs,

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -23,7 +23,7 @@ REGULAR_BUILD_NAMES = [job.name for job in JobConfigs.build_jobs]
 workflow = Workflow.Config(
     name="PR",
     event=Workflow.Event.PULL_REQUEST,
-    base_branches=[BASE_BRANCH, "releases/*", "antalya-*"],
+    base_branches=[BASE_BRANCH, "releases/*", "antalya-*", "stable-*"],
     jobs=[
         # JobConfigs.style_check, # NOTE (strtgbb): we don't run style check
         # JobConfigs.docs_job, # NOTE (strtgbb): we don't build docs


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
