### PR TITLE
Antalya 26.3: normalizing format check using lower case

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -889,7 +889,11 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
 
         InputFormatPtr input_format;
         if (context_->getSettingsRef()[Setting::use_parquet_metadata_cache] && use_native_reader_v3
+<<<<<<< HEAD
             && (object_info->getFileFormat().value_or(configuration->getFormat()) == "Parquet")
+=======
+            && (Poco::toLower(object_info->getFileFormat().value_or(configuration->format)) == "parquet")
+>>>>>>> 393b84e8cbc (Merge pull request #102825 from grantholly-clickhouse/fix_iceberg_parquet_lru_cache)
             && !object_info->getObjectMetadata()->etag.empty())
         {
             std::optional<RelativePathWithMetadata> object_with_metadata = object_info->relative_path_with_metadata;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -50,6 +50,7 @@
 #include <fmt/ranges.h>
 #include <Common/ProfileEvents.h>
 #include <Core/SettingsEnums.h>
+#include <Poco/String.h>
 
 namespace fs = std::filesystem;
 namespace ProfileEvents
@@ -889,11 +890,7 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
 
         InputFormatPtr input_format;
         if (context_->getSettingsRef()[Setting::use_parquet_metadata_cache] && use_native_reader_v3
-<<<<<<< HEAD
-            && (object_info->getFileFormat().value_or(configuration->getFormat()) == "Parquet")
-=======
-            && (Poco::toLower(object_info->getFileFormat().value_or(configuration->format)) == "parquet")
->>>>>>> 393b84e8cbc (Merge pull request #102825 from grantholly-clickhouse/fix_iceberg_parquet_lru_cache)
+            && (Poco::toLower(object_info->getFileFormat().value_or(configuration->getFormat())) == "parquet")
             && !object_info->getObjectMetadata()->etag.empty())
         {
             std::optional<RelativePathWithMetadata> object_with_metadata = object_info->relative_path_with_metadata;

--- a/tests/integration/test_storage_iceberg_with_spark_cache/test_filesystem_cache.py
+++ b/tests/integration/test_storage_iceberg_with_spark_cache/test_filesystem_cache.py
@@ -63,6 +63,7 @@ def test_filesystem_cache(started_cluster_iceberg_with_spark, storage_type):
     instance.query(
         f"SELECT * FROM {TABLE_NAME} SETTINGS filesystem_cache_name = 'cache1'",
         query_id=query_id,
+        settings={"use_parquet_metadata_cache": "0"}
     )
 
     instance.query("SYSTEM FLUSH LOGS")


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

Cherry-picked from ClickHouse/ClickHouse#102825.

---

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

It looks like we were not able to use the parquet metadata cache because the parquet format string gets passed many different ways and we were only looking for "Parquet".  For example "PARQUET" from tools like Spark, "Parquet" internally in our code base, and "parquet" if you are following the iceberg spec.

In the future, it would be good to normalize this format string in one place, because we are dealing with this same issue in a few different places in the code.