### PR TITLE
Fix /play download popover keyboard focus behavior

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -723,7 +723,7 @@
             </a>
             <a id="cloud-logo" href="https://altinity.cloud/">&#9729;</a>
         </p>
-        <div id="download-dropdown">
+        <div id="download-dropdown" role="dialog" aria-label="Download query result">
             <div>
                 <div class="download-option">
                     <label for="download-format">Format:</label>
@@ -2969,6 +2969,8 @@ document.getElementById('download-div').addEventListener('click', function(e) {
 
         dropdown.style.top = (button_rect.top - context_rect.top) + 'px';
         dropdown.style.left = (button_rect.left - context_rect.left + button_rect.width - dropdown_rect.width) + 'px';
+
+        document.getElementById('download-format').focus();
     }
 });
 
@@ -2977,10 +2979,44 @@ document.getElementById('download-dropdown').addEventListener('click', function(
     e.stopPropagation();
 });
 
+// Keyboard handling inside the download dialog: focus trap + Escape to close
+document.getElementById('download-dropdown').addEventListener('keydown', function(e) {
+    const dropdown = document.getElementById('download-dropdown');
+    if (!dropdown.classList.contains('show')) return;
+
+    if (e.key === 'Escape') {
+        e.preventDefault();
+        dropdown.classList.remove('show');
+        document.getElementById('download-div').focus();
+        return;
+    }
+
+    if (e.key === 'Tab') {
+        const focusable = dropdown.querySelectorAll(
+            'select, input:not([type=hidden]), button, [tabindex]:not([tabindex="-1"])'
+        );
+        const visible = Array.from(focusable).filter(el => el.offsetParent !== null);
+        if (visible.length === 0) return;
+
+        const first = visible[0];
+        const last = visible[visible.length - 1];
+
+        if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+        }
+    }
+});
+
 // Close dropdown when clicking outside
 document.addEventListener('click', function() {
     const dropdown = document.getElementById('download-dropdown');
-    dropdown.classList.remove('show');
+    if (dropdown.classList.contains('show')) {
+        dropdown.classList.remove('show');
+    }
 });
 
 // Handle "Other" format selection
@@ -3051,6 +3087,7 @@ document.getElementById('download-button').addEventListener('click', async funct
 
     // Close dropdown
     document.getElementById('download-dropdown').classList.remove('show');
+    document.getElementById('download-div').focus();
 });
 </script>
 </html>

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -564,7 +564,6 @@
         }
 
         /* Show keyboard focus clearly for download controls. */
-        #download-div:focus-visible,
         #download-format:focus-visible,
         #download-format-other:focus-visible,
         #download-button:focus-visible

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -563,6 +563,16 @@
             }
         }
 
+        /* Show keyboard focus clearly for download controls. */
+        #download-div:focus-visible,
+        #download-format:focus-visible,
+        #download-format-other:focus-visible,
+        #download-button:focus-visible
+        {
+            outline: 2px solid var(--border-color-selected);
+            outline-offset: 2px;
+        }
+
         #theme
         {
             grid-area: theme;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix keyboard accessibility in the `/play` Download popover: focus now moves into the popover on open, Tab/Shift+Tab navigation is contained inside it, focus is restored on Escape/after. Download, and outside-click close no longer steals focus


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
