### PR TITLE
Do not make 'describe table' query when schema is known

### DIFF
--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -25,6 +25,7 @@
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageDistributed.h>
 #include <TableFunctions/TableFunctionFactory.h>
+#include <TableFunctions/TableFunctionRemote.h>
 #include <Poco/URI.h>
 #include <Storages/extractTableFunctionFromSelectQuery.h>
 #include <Planner/Utils.h>
@@ -499,6 +500,10 @@ IStorageCluster::RemoteCallVariables IStorageCluster::convertToRemote(
     table_expression->table_function = remote_query;
 
     auto remote_function = TableFunctionFactory::instance().get(remote_query, new_context);
+
+    std::shared_ptr<TableFunctionRemote> remote_table_function = std::dynamic_pointer_cast<TableFunctionRemote>(remote_function);
+    if (remote_table_function)
+        remote_table_function->setActualTableStructure(getInMemoryMetadata().columns);
 
     auto storage = remote_function->execute(query_to_send, new_context, remote_function_name);
 

--- a/src/TableFunctions/CMakeLists.txt
+++ b/src/TableFunctions/CMakeLists.txt
@@ -12,6 +12,7 @@ extract_into_parent_list(clickhouse_table_functions_sources dbms_sources
     ITableFunction.cpp
     TableFunctionView.cpp
     TableFunctionFactory.cpp
+    TableFunctionRemote.cpp
 )
 extract_into_parent_list(clickhouse_table_functions_headers dbms_headers
     ITableFunction.h

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -356,6 +356,9 @@ StoragePtr TableFunctionRemote::executeImpl(const ASTPtr & /*ast_function*/, Con
 
 ColumnsDescription TableFunctionRemote::getActualTableStructure(ContextPtr context, bool /*is_insert_query*/) const
 {
+    if (!remote_table_columns.empty())
+        return remote_table_columns;
+
     assert(cluster);
     return getStructureOfRemoteTable(*cluster, remote_table_id, context, remote_table_function_ptr);
 }

--- a/src/TableFunctions/TableFunctionRemote.h
+++ b/src/TableFunctions/TableFunctionRemote.h
@@ -28,6 +28,8 @@ public:
 
     void setRemoteTableFunction(ASTPtr remote_table_function_ptr_) { remote_table_function_ptr = remote_table_function_ptr_; }
 
+    void setActualTableStructure(ColumnsDescription remote_table_columns_) { remote_table_columns = remote_table_columns_; }
+
 private:
 
     StoragePtr executeImpl(const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns, bool is_insert_query) const override;
@@ -44,6 +46,7 @@ private:
     StorageID remote_table_id = StorageID::createEmpty();
     ASTPtr remote_table_function_ptr;
     ASTPtr sharding_key = nullptr;
+    ColumnsDescription remote_table_columns;
 };
 
 }

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -832,8 +832,8 @@ def test_object_storage_remote_initiator(started_cluster):
         """
     ).splitlines()
 
-    # initial node + describe table + remote initiator + 2 subqueries on replicas
-    assert queries == ["5"]
+    # initial node + remote initiator + 2 subqueries on replicas
+    assert queries == ["4"]
 
     # Cluster with dots in the host names
     query_id = uuid.uuid4().hex
@@ -860,8 +860,8 @@ def test_object_storage_remote_initiator(started_cluster):
         """
     ).splitlines()
 
-    # initial node + describe table + remote initiator + 2 subqueries on replicas
-    assert queries == ["5"]
+    # initial node + remote initiator + 2 subqueries on replicas
+    assert queries == ["4"]
 
     users = node.query(
         f"""
@@ -902,8 +902,8 @@ def test_object_storage_remote_initiator(started_cluster):
         """
     ).splitlines()
 
-    # initial node + describe table + remote initiator + 2 subqueries on replicas
-    assert queries == ["5"]
+    # initial node + remote initiator + 2 subqueries on replicas
+    assert queries == ["4"]
 
     users = node.query(
         f"""
@@ -963,8 +963,8 @@ def test_object_storage_remote_initiator(started_cluster):
         """
     ).splitlines()
 
-    # initial node + describe table + remote initiator + 2 subqueries on replicas
-    assert queries == ["5"]
+    # initial node + remote initiator + 2 subqueries on replicas
+    assert queries == ["4"]
 
     users = node.query(
         f"""
@@ -1427,8 +1427,8 @@ def test_object_storage_remote_initiator_without_cluster_function(started_cluste
         """
     ).splitlines()
 
-    # initial node + describe table + remote initiator
-    assert queries == ["3"]
+    # initial node + remote initiator
+    assert queries == ["2"]
 
     users = node.query(
         f"""
@@ -1472,8 +1472,8 @@ def test_object_storage_remote_initiator_without_cluster_function(started_cluste
         """
     ).splitlines()
 
-    # initial node + describe table + remote initiator + 2 subqueries on replicas
-    assert queries == ["5"]
+    # initial node + remote initiator + 2 subqueries on replicas
+    assert queries == ["4"]
 
     users = node.query(
         f"""

--- a/tests/integration/test_storage_iceberg_with_spark/test_remote_initiator.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_remote_initiator.py
@@ -64,6 +64,7 @@ def test_remote_initiator_after_non_remote(started_cluster_iceberg_with_spark, s
             FROM clusterAllReplicas('cluster_simple', system.query_log)
             WHERE type='QueryFinish' AND initial_query_id='{query_id}'
         """)
+    # initial node + 3 subqueries on replicas
     assert queries == "4\n"
 
     query_id = uuid.uuid4().hex
@@ -83,7 +84,8 @@ def test_remote_initiator_after_non_remote(started_cluster_iceberg_with_spark, s
             FROM clusterAllReplicas('cluster_simple', system.query_log)
             WHERE type='QueryFinish' AND initial_query_id='{query_id}'
         """)
-    assert queries == "6\n"
+    # initial node + remote initiator + 3 subqueries on replicas
+    assert queries == "5\n"
 
     query_id = uuid.uuid4().hex
     res = instance.query(f"""


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not make 'describe table' query when schema is known

### Documentation entry for user-facing changes
With 'object_storage_remote_initiator' setting query to Iceberg table converted to `remote(.., iceberg(...))`
`remote` table function calls `describe table` by default to resolve remote table schema.
But when table is from DataLake catalog, schema already known, 'describe table' query can be avoided.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
