### PR TITLE
Fix test_remote_initiator_after_non_remote

### DIFF
--- a/tests/integration/test_storage_iceberg_with_spark/configs/config.d/cluster.xml
+++ b/tests/integration/test_storage_iceberg_with_spark/configs/config.d/cluster.xml
@@ -16,5 +16,17 @@
                 </replica>
             </shard>
         </cluster_simple>
+        <cluster_23>
+            <shard>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node3</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </cluster_23>
     </remote_servers>
 </clickhouse>

--- a/tests/integration/test_storage_iceberg_with_spark/test_remote_initiator.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_remote_initiator.py
@@ -54,7 +54,7 @@ def test_remote_initiator_after_non_remote(started_cluster_iceberg_with_spark, s
             FROM {TABLE_NAME}
             WHERE number=1
         SETTINGS
-            object_storage_cluster='cluster_simple'
+            object_storage_cluster='cluster_23'
         """,
         query_id = query_id)
     assert res == "1\t1\n"
@@ -64,7 +64,7 @@ def test_remote_initiator_after_non_remote(started_cluster_iceberg_with_spark, s
             FROM clusterAllReplicas('cluster_simple', system.query_log)
             WHERE type='QueryFinish' AND initial_query_id='{query_id}'
         """)
-    assert queries == "4\n"
+    assert queries == "3\n"
 
     query_id = uuid.uuid4().hex
     res = instance.query(f"""
@@ -73,7 +73,7 @@ def test_remote_initiator_after_non_remote(started_cluster_iceberg_with_spark, s
             WHERE number=1
         SETTINGS
             object_storage_remote_initiator=1,
-            object_storage_cluster='cluster_simple'
+            object_storage_cluster='cluster_23'
         """,
         query_id = query_id)
     assert res == "1\t1\n"
@@ -83,7 +83,7 @@ def test_remote_initiator_after_non_remote(started_cluster_iceberg_with_spark, s
             FROM clusterAllReplicas('cluster_simple', system.query_log)
             WHERE type='QueryFinish' AND initial_query_id='{query_id}'
         """)
-    assert queries == "6\n"
+    assert queries == "5\n"
 
     query_id = uuid.uuid4().hex
     res = instance.query(f"""


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix test_storage_iceberg_with_spark/test_remote_initiator.py::test_remote_initiator_after_non_remote

### Documentation entry for user-facing changes
`node1` chooses random node from cluster `cluster_simple` as remote initiator.
But `node1` is a member of `cluster_simple`, and with chance 1/3 it chooses itself.
In this case later optimization 'if remote request is to current node, do not make remote request' makes request as non-remote again, and query creates less subqueries than expected.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
