### PR TITLE
Fix cluster functions with hive partitioning

### DIFF
--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -650,6 +650,20 @@ QueryProcessingStage::Enum IStorageCluster::getQueryProcessingStage(
     return QueryProcessingStage::Enum::FetchColumns;
 }
 
+NamesAndTypesList IStorageCluster::getHivePartitionColumnsWithoutVirtuals() const
+{
+    // Virtual columns can contain hive columns, so we remove these hive coulmns to avoid duplicates.
+    // In non-cluster case these columns are filtered in DB::prepareReadingFromFormat function.
+    auto virtual_columns = getVirtualsList();
+    NamesAndTypesList hive_partition_filtered;
+    for (const auto & hive_name_and_type : hive_partition_columns_to_read_from_file_path)
+    {
+        if (!virtual_columns.contains(hive_name_and_type.name))
+            hive_partition_filtered.emplace_back(hive_name_and_type);
+    }
+    return hive_partition_filtered;
+}
+
 ContextPtr ReadFromCluster::updateSettings(const Settings & settings)
 {
     Settings new_settings{settings};

--- a/src/Storages/IStorageCluster.h
+++ b/src/Storages/IStorageCluster.h
@@ -105,6 +105,10 @@ protected:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method writeFallBackToPure is not supported by storage {}", getName());
     }
 
+    NamesAndTypesList getHivePartitionColumnsWithoutVirtuals() const;
+
+    NamesAndTypesList hive_partition_columns_to_read_from_file_path;
+
 private:
     static ClusterPtr getClusterImpl(ContextPtr context, const String & cluster_name_, size_t max_hosts = 0);
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -612,16 +612,6 @@ RemoteQueryExecutor::Extension StorageObjectStorageCluster::getTaskIteratorExten
     ClusterPtr cluster,
     StorageMetadataPtr storage_metadata_snapshot) const
 {
-    // Virtual columns can contain hive columns, so we remove these hive coulmns to avoid duplicates.
-    // In non-cluster case these columns are filtered in DB::prepareReadingFromFormat function.
-    auto virtual_columns = getVirtualsList();
-    NamesAndTypesList hive_partition_filtered;
-    for (const auto & hive_name_and_type : hive_partition_columns_to_read_from_file_path)
-    {
-        if (!virtual_columns.contains(hive_name_and_type.name))
-            hive_partition_filtered.emplace_back(hive_name_and_type);
-    }
-
     auto iterator = StorageObjectStorageSource::createFileIterator(
         configuration,
         configuration->getQuerySettings(local_context),
@@ -631,8 +621,8 @@ RemoteQueryExecutor::Extension StorageObjectStorageCluster::getTaskIteratorExten
         local_context,
         predicate,
         filter,
-        virtual_columns,
-        hive_partition_filtered,
+        getVirtualsList(),
+        getHivePartitionColumnsWithoutVirtuals(),
         nullptr,
         local_context->getFileProgressCallback(),
         /*ignore_archive_globs=*/false,

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.cpp
@@ -612,6 +612,16 @@ RemoteQueryExecutor::Extension StorageObjectStorageCluster::getTaskIteratorExten
     ClusterPtr cluster,
     StorageMetadataPtr storage_metadata_snapshot) const
 {
+    // Virtual columns can contain hive columns, so we remove these hive coulmns to avoid duplicates.
+    // In non-cluster case these columns are filtered in DB::prepareReadingFromFormat function.
+    auto virtual_columns = getVirtualsList();
+    NamesAndTypesList hive_partition_filtered;
+    for (const auto & hive_name_and_type : hive_partition_columns_to_read_from_file_path)
+    {
+        if (!virtual_columns.contains(hive_name_and_type.name))
+            hive_partition_filtered.emplace_back(hive_name_and_type);
+    }
+
     auto iterator = StorageObjectStorageSource::createFileIterator(
         configuration,
         configuration->getQuerySettings(local_context),
@@ -621,8 +631,8 @@ RemoteQueryExecutor::Extension StorageObjectStorageCluster::getTaskIteratorExten
         local_context,
         predicate,
         filter,
-        getVirtualsList(),
-        hive_partition_columns_to_read_from_file_path,
+        virtual_columns,
+        hive_partition_filtered,
         nullptr,
         local_context->getFileProgressCallback(),
         /*ignore_archive_globs=*/false,

--- a/src/Storages/ObjectStorage/StorageObjectStorageCluster.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageCluster.h
@@ -214,7 +214,6 @@ private:
     const String engine_name;
     StorageObjectStorageConfigurationPtr configuration;
     const ObjectStoragePtr object_storage;
-    NamesAndTypesList hive_partition_columns_to_read_from_file_path;
     bool cluster_name_in_settings;
 
     /// non-clustered storage to fall back on pure realisation if needed

--- a/src/Storages/StorageFileCluster.cpp
+++ b/src/Storages/StorageFileCluster.cpp
@@ -141,22 +141,12 @@ private:
 RemoteQueryExecutor::Extension StorageFileCluster::getTaskIteratorExtension(
     const ActionsDAG::Node * predicate, const ActionsDAG * /* filter */, const ContextPtr & context, ClusterPtr, StorageMetadataPtr) const
 {
-    // Virtual columns can contain hive columns, so we remove these hive coulmns to avoid duplicates.
-    // In non-cluster case these columns are filtered in DB::prepareReadingFromFormat function.
-    auto virtual_columns = getVirtualsList();
-    NamesAndTypesList hive_partition_filtered;
-    for (const auto & hive_name_and_type : hive_partition_columns_to_read_from_file_path)
-    {
-        if (!virtual_columns.contains(hive_name_and_type.name))
-            hive_partition_filtered.emplace_back(hive_name_and_type);
-    }
-
     auto callback = std::make_shared<FileTaskIterator>(
         paths,
         std::nullopt,
         predicate,
-        virtual_columns,
-        hive_partition_filtered,
+        getVirtualsList(),
+        getHivePartitionColumnsWithoutVirtuals(),
         context
     );
     return RemoteQueryExecutor::Extension{.task_iterator = std::move(callback)};

--- a/src/Storages/StorageFileCluster.cpp
+++ b/src/Storages/StorageFileCluster.cpp
@@ -68,16 +68,23 @@ StorageFileCluster::StorageFileCluster(
 
     auto & storage_columns = storage_metadata.columns;
 
+    const auto sample_path = paths.empty() ? "" : paths.front();
+
     /// Not grabbing the file_columns because it is not necessary to do it here.
     std::tie(hive_partition_columns_to_read_from_file_path, std::ignore) = HivePartitioningUtils::setupHivePartitioningForFileURLLikeStorage(
         storage_columns,
-        paths.empty() ? "" : paths.front(),
+        sample_path,
         columns_.empty(),
         std::nullopt,
         context);
 
     storage_metadata.setConstraints(constraints_);
-    setVirtuals(VirtualColumnUtils::getVirtualsForFileLikeStorage(storage_metadata.columns, context));
+    setVirtuals(VirtualColumnUtils::getVirtualsForFileLikeStorage(
+        storage_metadata.columns,
+        context,
+        std::nullopt,
+        PartitionStrategyFactory::StrategyType::NONE,
+        sample_path));
     setInMemoryMetadata(storage_metadata);
 }
 
@@ -134,12 +141,22 @@ private:
 RemoteQueryExecutor::Extension StorageFileCluster::getTaskIteratorExtension(
     const ActionsDAG::Node * predicate, const ActionsDAG * /* filter */, const ContextPtr & context, ClusterPtr, StorageMetadataPtr) const
 {
+    // Virtual columns can contain hive columns, so we remove these hive coulmns to avoid duplicates.
+    // In non-cluster case these columns are filtered in DB::prepareReadingFromFormat function.
+    auto virtual_columns = getVirtualsList();
+    NamesAndTypesList hive_partition_filtered;
+    for (const auto & hive_name_and_type : hive_partition_columns_to_read_from_file_path)
+    {
+        if (!virtual_columns.contains(hive_name_and_type.name))
+            hive_partition_filtered.emplace_back(hive_name_and_type);
+    }
+
     auto callback = std::make_shared<FileTaskIterator>(
         paths,
         std::nullopt,
         predicate,
-        getVirtualsList(),
-        hive_partition_columns_to_read_from_file_path,
+        virtual_columns,
+        hive_partition_filtered,
         context
     );
     return RemoteQueryExecutor::Extension{.task_iterator = std::move(callback)};

--- a/src/Storages/StorageFileCluster.h
+++ b/src/Storages/StorageFileCluster.h
@@ -45,7 +45,6 @@ private:
     Strings paths;
     String filename;
     String format_name;
-    NamesAndTypesList hive_partition_columns_to_read_from_file_path;
 };
 
 }

--- a/src/Storages/StorageURLCluster.cpp
+++ b/src/Storages/StorageURLCluster.cpp
@@ -162,12 +162,22 @@ private:
 RemoteQueryExecutor::Extension StorageURLCluster::getTaskIteratorExtension(
     const ActionsDAG::Node * predicate, const ActionsDAG * /* filter */, const ContextPtr & context, ClusterPtr, StorageMetadataPtr) const
 {
+    // Virtual columns can contain hive columns, so we remove these hive coulmns to avoid duplicates.
+    // In non-cluster case these columns are filtered in DB::prepareReadingFromFormat function.
+    auto virtual_columns = getVirtualsList();
+    NamesAndTypesList hive_partition_filtered;
+    for (const auto & hive_name_and_type : hive_partition_columns_to_read_from_file_path)
+    {
+        if (!virtual_columns.contains(hive_name_and_type.name))
+            hive_partition_filtered.emplace_back(hive_name_and_type);
+    }
+
     auto callback = std::make_shared<UrlTaskIterator>(
         uri,
         context->getSettingsRef()[Setting::glob_expansion_max_elements],
         predicate,
-        getVirtualsList(),
-        hive_partition_columns_to_read_from_file_path,
+        virtual_columns,
+        hive_partition_filtered,
         context
     );
     return RemoteQueryExecutor::Extension{.task_iterator = std::move(callback)};

--- a/src/Storages/StorageURLCluster.cpp
+++ b/src/Storages/StorageURLCluster.cpp
@@ -162,22 +162,12 @@ private:
 RemoteQueryExecutor::Extension StorageURLCluster::getTaskIteratorExtension(
     const ActionsDAG::Node * predicate, const ActionsDAG * /* filter */, const ContextPtr & context, ClusterPtr, StorageMetadataPtr) const
 {
-    // Virtual columns can contain hive columns, so we remove these hive coulmns to avoid duplicates.
-    // In non-cluster case these columns are filtered in DB::prepareReadingFromFormat function.
-    auto virtual_columns = getVirtualsList();
-    NamesAndTypesList hive_partition_filtered;
-    for (const auto & hive_name_and_type : hive_partition_columns_to_read_from_file_path)
-    {
-        if (!virtual_columns.contains(hive_name_and_type.name))
-            hive_partition_filtered.emplace_back(hive_name_and_type);
-    }
-
     auto callback = std::make_shared<UrlTaskIterator>(
         uri,
         context->getSettingsRef()[Setting::glob_expansion_max_elements],
         predicate,
-        virtual_columns,
-        hive_partition_filtered,
+        getVirtualsList(),
+        getHivePartitionColumnsWithoutVirtuals(),
         context
     );
     return RemoteQueryExecutor::Extension{.task_iterator = std::move(callback)};

--- a/src/Storages/StorageURLCluster.h
+++ b/src/Storages/StorageURLCluster.h
@@ -47,7 +47,6 @@ private:
 
     String uri;
     String format_name;
-    NamesAndTypesList hive_partition_columns_to_read_from_file_path;
 };
 
 

--- a/tests/integration/test_file_cluster/test.py
+++ b/tests/integration/test_file_cluster/test.py
@@ -215,11 +215,6 @@ def test_format_detection(started_cluster):
 
 
 def test_hive_partitioning_with_where_condition(started_cluster):
-    """
-    Hive partition columns are also exposed as virtual columns. fileCluster passes both
-    lists to createPathAndFileFilterDAG without deduplication (unlike s3Cluster), which
-    duplicates block columns and triggers SIZES_OF_COLUMNS_DOESNT_MATCH when filtering.
-    """
     test_id = uuid.uuid4().hex[:8]
     hive_glob = f"hive_file_cluster_{test_id}/date=*/data.csv"
 

--- a/tests/integration/test_file_cluster/test.py
+++ b/tests/integration/test_file_cluster/test.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 import time
+import uuid
 
 import pytest
 
@@ -211,3 +212,65 @@ def test_format_detection(started_cluster):
         "select * from fileCluster('my_cluster', 'file_for_format_detection*', auto, 's String, i UInt32', auto) ORDER BY (i, s)"
     )
     assert result == expected_result
+
+
+def test_hive_partitioning_with_where_condition(started_cluster):
+    """
+    Hive partition columns are also exposed as virtual columns. fileCluster passes both
+    lists to createPathAndFileFilterDAG without deduplication (unlike s3Cluster), which
+    duplicates block columns and triggers SIZES_OF_COLUMNS_DOESNT_MATCH when filtering.
+    """
+    test_id = uuid.uuid4().hex[:8]
+    hive_glob = f"hive_file_cluster_{test_id}/date=*/data.csv"
+
+    for node_name in ("s0_0_0", "s0_0_1", "s0_1_0"):
+        node = started_cluster.instances[node_name]
+        for i in range(1, 5):
+            node.query(
+                f"""
+                INSERT INTO TABLE FUNCTION file(
+                    'hive_file_cluster_{test_id}/date=2000-01-0{i}/data.csv', 'CSVWithNames', 'd UInt64')
+                SELECT number FROM numbers(10)
+                SETTINGS engine_file_truncate_on_insert=1
+                """
+            )
+
+    node = started_cluster.instances["s0_0_0"]
+
+    result = node.query(
+        f"""
+        SELECT count() FROM file('{hive_glob}', 'CSVWithNames', 'd UInt64')
+        WHERE date='2000-01-02'
+        SETTINGS use_hive_partitioning=1
+        """
+    )
+    assert result.strip() == "10"
+
+    result = node.query(
+        f"""
+        SELECT date, d FROM file('{hive_glob}', 'CSVWithNames', 'd UInt64')
+        WHERE date='2000-01-02'
+        LIMIT 1
+        SETTINGS use_hive_partitioning=1
+        """
+    )
+    assert "2000-01-02" in result
+
+    result = node.query(
+        f"""
+        SELECT count() FROM fileCluster('my_cluster', '{hive_glob}', 'CSVWithNames', 'd UInt64')
+        WHERE date='2000-01-02'
+        SETTINGS use_hive_partitioning=1
+        """
+    )
+    assert result.strip() == "10"
+
+    result = node.query(
+        f"""
+        SELECT date, d FROM fileCluster('my_cluster', '{hive_glob}', 'CSVWithNames', 'd UInt64')
+        WHERE date='2000-01-02'
+        LIMIT 1
+        SETTINGS use_hive_partitioning=1
+        """
+    )
+    assert "2000-01-02" in result

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -1492,7 +1492,7 @@ def test_object_storage_remote_initiator_without_cluster_function(started_cluste
                      "s0_1_0\tfoo"]
 
 
-def test_hive_partitioning(started_cluster):
+def test_hive_partitioning_with_where_condition(started_cluster):
     node = started_cluster.instances["s0_0_0"]
 
     for i in range(1, 5):

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -1490,3 +1490,37 @@ def test_object_storage_remote_initiator_without_cluster_function(started_cluste
     assert users[1:] == ["s0_0_0\tdefault",
                      "s0_0_1\tfoo",
                      "s0_1_0\tfoo"]
+
+
+def test_hive_partitioning(started_cluster):
+    node = started_cluster.instances["s0_0_0"]
+
+    for i in range(1, 5):
+        node.query(
+            f"""
+            INSERT INTO FUNCTION s3('http://minio1:9001/root/hive/date=2000-01-0{i}/data.csv',
+                'minio','{minio_secret_key}','CSVWithNames','d UInt64')
+            SELECT number FROM numbers(10)
+            SETTINGS s3_truncate_on_insert=1
+            """)
+
+    # Direct query
+    result = node.query(
+        f"""
+        SELECT count() FROM s3('http://minio1:9001/root/hive/date=*/data.csv',
+            'minio','{minio_secret_key}','CSVWithNames','d UInt64')
+        WHERE date='2000-01-02'
+        SETTINGS use_hive_partitioning=1
+        """
+    )
+    assert result.strip() == "10"
+
+    result = node.query(
+        f"""
+        SELECT count() FROM s3Cluster('cluster_simple', 'http://minio1:9001/root/hive/date=*/data.csv',
+            'minio','{minio_secret_key}','CSVWithNames','d UInt64')
+        WHERE date='2000-01-02'
+        SETTINGS use_hive_partitioning=1
+        """
+    )
+    assert result.strip() == "10"

--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -1494,11 +1494,12 @@ def test_object_storage_remote_initiator_without_cluster_function(started_cluste
 
 def test_hive_partitioning_with_where_condition(started_cluster):
     node = started_cluster.instances["s0_0_0"]
+    test_id = uuid.uuid4().hex[:8]
 
     for i in range(1, 5):
         node.query(
             f"""
-            INSERT INTO FUNCTION s3('http://minio1:9001/root/hive/date=2000-01-0{i}/data.csv',
+            INSERT INTO FUNCTION s3('http://minio1:9001/root/hive/{test_id}/date=2000-01-0{i}/data.csv',
                 'minio','{minio_secret_key}','CSVWithNames','d UInt64')
             SELECT number FROM numbers(10)
             SETTINGS s3_truncate_on_insert=1
@@ -1507,7 +1508,7 @@ def test_hive_partitioning_with_where_condition(started_cluster):
     # Direct query
     result = node.query(
         f"""
-        SELECT count() FROM s3('http://minio1:9001/root/hive/date=*/data.csv',
+        SELECT count() FROM s3('http://minio1:9001/root/hive/{test_id}/date=*/data.csv',
             'minio','{minio_secret_key}','CSVWithNames','d UInt64')
         WHERE date='2000-01-02'
         SETTINGS use_hive_partitioning=1
@@ -1517,7 +1518,7 @@ def test_hive_partitioning_with_where_condition(started_cluster):
 
     result = node.query(
         f"""
-        SELECT count() FROM s3Cluster('cluster_simple', 'http://minio1:9001/root/hive/date=*/data.csv',
+        SELECT count() FROM s3Cluster('cluster_simple', 'http://minio1:9001/root/hive/{test_id}/date=*/data.csv',
             'minio','{minio_secret_key}','CSVWithNames','d UInt64')
         WHERE date='2000-01-02'
         SETTINGS use_hive_partitioning=1

--- a/tests/integration/test_storage_url/test.py
+++ b/tests/integration/test_storage_url/test.py
@@ -42,6 +42,42 @@ def test_partition_by():
     assert result.strip() == "1\t2\t3"
 
 
+def test_hive_partitioning_with_where_condition():
+    """
+    Same hive + virtual column overlap as s3Cluster/fileCluster: urlCluster must not pass
+    duplicate hive partition names into createPathAndFileFilterDAG.
+    """
+    test_id = uuid.uuid4().hex[:8]
+    base_url = f"http://nginx:80/hive_url_cluster_{test_id}"
+
+    node1.query(
+        f"""
+        INSERT INTO FUNCTION url(url_file, url='{base_url}/date=2000-01-01/data.csv', format='CSVWithNames', structure='d UInt64')
+        SELECT number FROM numbers(10)
+        """
+    )
+
+    # 'ur' table function does not work with globs, so we have to test hive partitioning with a single file.
+    result = node1.query(
+        f"""
+        SELECT count() FROM url('{base_url}/date=2000-01-01/data.csv', 'CSVWithNames', 'd UInt64')
+        WHERE date='2000-01-01'
+        SETTINGS use_hive_partitioning=1
+        """
+    )
+    assert result.strip() == "10"
+
+    result = node1.query(
+        f"""
+        SELECT count() FROM urlCluster(
+            'test_cluster_two_shards', '{base_url}/date=2000-01-01/data.csv', 'CSVWithNames', 'd UInt64')
+        WHERE date='2000-01-01'
+        SETTINGS use_hive_partitioning=1
+        """
+    )
+    assert result.strip() == "10"
+
+
 def test_url_cluster():
     result = node1.query(
         f"select * from urlCluster('test_cluster_two_shards', 'http://nginx:80/test_1', 'TSV', 'column1 UInt32, column2 UInt32, column3 UInt32')"

--- a/tests/integration/test_storage_url/test.py
+++ b/tests/integration/test_storage_url/test.py
@@ -43,10 +43,6 @@ def test_partition_by():
 
 
 def test_hive_partitioning_with_where_condition():
-    """
-    Same hive + virtual column overlap as s3Cluster/fileCluster: urlCluster must not pass
-    duplicate hive partition names into createPathAndFileFilterDAG.
-    """
     test_id = uuid.uuid4().hex[:8]
     base_url = f"http://nginx:80/hive_url_cluster_{test_id}"
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix cluster functions with hive partitioning

### Documentation entry for user-facing changes
Solved #1855
List of virtual columns can include hive columns.
In non-cluster case iterator is created with filtered list of hive columns, where virtual columns columns are removed (see https://github.com/Altinity/ClickHouse/blob/antalya-26.3/src/Storages/prepareReadingFromFormat.cpp#L49).
In cluster case iterator was created with full lists. As result, hive columns added twice, later first column was filled with data, second was empty, and attempt to filter failed with error `SIZES_OF_COLUMNS_DOESNT_MATCH`,


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
