### PR TITLE
Stable 23.8 - update runner labels

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -48,7 +48,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_images_check.py --suffix aarch64
       - name: Upload images files to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: changed_images_aarch64
           path: ${{ runner.temp }}/docker_images_check/changed_images_aarch64.json
@@ -65,7 +65,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_images_check.py --suffix amd64
       - name: Upload images files to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: changed_images_amd64
           path: ${{ runner.temp }}/docker_images_check/changed_images_amd64.json
@@ -94,7 +94,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_manifests_merge.py --suffix amd64 --suffix aarch64
       - name: Upload images files to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: changed_images
           path: ${{ runner.temp }}/changed_images.json

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_images_check.py --suffix aarch64
       - name: Upload images files to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: changed_images_aarch64
           path: ${{ runner.temp }}/docker_images_check/changed_images_aarch64.json
@@ -49,7 +49,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_images_check.py --suffix amd64
       - name: Upload images files to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: changed_images_amd64
           path: ${{ runner.temp }}/docker_images_check/changed_images_amd64.json
@@ -78,7 +78,7 @@ jobs:
           cd "$GITHUB_WORKSPACE/tests/ci"
           python3 docker_manifests_merge.py --suffix amd64 --suffix aarch64
       - name: Upload images files to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: changed_images
           path: ${{ runner.temp }}/changed_images.json

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -161,7 +161,7 @@ jobs:
           SUITE=${{ matrix.SUITE }}
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}
@@ -205,7 +205,7 @@ jobs:
           SUITE=alter
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}
@@ -251,7 +251,7 @@ jobs:
           STORAGE=/${{ matrix.STORAGE }}
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}
@@ -300,7 +300,7 @@ jobs:
           STORAGE=/ssl
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}
@@ -345,7 +345,7 @@ jobs:
           SUITE=ldap/${{ matrix.SUITE }}
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}
@@ -385,7 +385,7 @@ jobs:
           SUITE=parquet
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}
@@ -430,7 +430,7 @@ jobs:
           STORAGE=${{ matrix.STORAGE}}
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}
@@ -481,7 +481,7 @@ jobs:
           STORAGE=/${{ matrix.STORAGE }}
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}
@@ -534,7 +534,7 @@ jobs:
           STORAGE=/${{ matrix.STORAGE }}
           EOF
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.REPORTS_PATH }}
           name: build_report_package_${{ inputs.arch }}

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -91,13 +91,13 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Download changed aarch64 images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: changed_images_aarch64
           path: ${{ runner.temp }}
 
       - name: Download changed amd64 images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: changed_images_amd64
           path: ${{ runner.temp }}
@@ -669,7 +669,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: build_report_package_release
           path: ${{ env.REPORTS_PATH }}
@@ -711,7 +711,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: build_report_package_aarch64
           path: ${{ env.REPORTS_PATH }}

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -30,7 +30,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   DockerHubPushAarch64:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none]
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
     steps:
       - name: Check out repository code
         uses: Altinity/checkout@19599efdf36c4f3f30eb55d5bb388896faea69f6
@@ -52,7 +52,7 @@ jobs:
           path: ${{ runner.temp }}/docker_images_check/changed_images_aarch64.json
 
   DockerHubPushAmd64:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none]
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker]
     steps:
       - name: Check out repository code
         uses: Altinity/checkout@19599efdf36c4f3f30eb55d5bb388896faea69f6
@@ -75,7 +75,7 @@ jobs:
 
   DockerHubPush:
     needs: [DockerHubPushAmd64, DockerHubPushAarch64]
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none]
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker]
     steps:
       - name: Check out repository code
         uses: Altinity/checkout@19599efdf36c4f3f30eb55d5bb388896faea69f6
@@ -119,7 +119,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Compatibility check X86
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       timeout_minutes: 180
       run_command: |
         cd "$REPO_COPY/tests/ci"
@@ -131,7 +131,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Compatibility check Aarch64
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-on-demand, altinity-func-tester-aarch64
       timeout_minutes: 180
       run_command: |
         cd "$REPO_COPY/tests/ci"
@@ -148,7 +148,7 @@ jobs:
       build_name: package_release
       checkout_depth: 0
       timeout_minutes: 180
-      runner_type: altinity-on-demand, altinity-type-ccx53, altinity-in-hil, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-builder
       additional_envs: |
         CLICKHOUSE_STABLE_VERSION_SUFFIX=altinitystable
 
@@ -160,7 +160,7 @@ jobs:
       build_name: package_aarch64
       checkout_depth: 0
       timeout_minutes: 180
-      runner_type: altinity-on-demand, altinity-type-ccx53, altinity-in-hil, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-builder
       additional_envs: |
         CLICKHOUSE_STABLE_VERSION_SUFFIX=altinitystable
 
@@ -172,7 +172,7 @@ jobs:
       build_name: package_asan
       checkout_depth: 0
       timeout_minutes: 180
-      runner_type: altinity-on-demand, altinity-type-ccx53, altinity-in-hil, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-builder
       additional_envs: |
         CLICKHOUSE_STABLE_VERSION_SUFFIX=altinitystable
 
@@ -184,7 +184,7 @@ jobs:
       build_name: package_ubsan
       checkout_depth: 0
       timeout_minutes: 180
-      runner_type: altinity-on-demand, altinity-type-ccx53, altinity-in-hil, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-builder
       additional_envs: |
         CLICKHOUSE_STABLE_VERSION_SUFFIX=altinitystable
 
@@ -196,7 +196,7 @@ jobs:
       build_name: package_tsan
       checkout_depth: 0
       timeout_minutes: 180
-      runner_type: altinity-on-demand, altinity-type-ccx53, altinity-in-hil, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-builder
       additional_envs: |
         CLICKHOUSE_STABLE_VERSION_SUFFIX=altinitystable
 
@@ -208,7 +208,7 @@ jobs:
       build_name: package_msan
       checkout_depth: 0
       timeout_minutes: 180
-      runner_type: altinity-on-demand, altinity-type-ccx53, altinity-in-hil, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-builder
       additional_envs: |
         CLICKHOUSE_STABLE_VERSION_SUFFIX=altinitystable
 
@@ -220,7 +220,7 @@ jobs:
       build_name: package_debug
       checkout_depth: 0
       timeout_minutes: 180
-      runner_type: altinity-on-demand, altinity-type-ccx53, altinity-in-hil, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-builder
       additional_envs: |
         CLICKHOUSE_STABLE_VERSION_SUFFIX=altinitystable
 
@@ -231,7 +231,7 @@ jobs:
     needs:
       - BuilderDebRelease
       - BuilderDebAarch64
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-cpx41, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none]
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker]
     timeout-minutes: 180
     steps:
       - name: Check out repository code
@@ -267,7 +267,7 @@ jobs:
     secrets: inherit
     with:
       test_name: ClickHouse build check
-      runner_type: altinity-on-demand, altinity-type-cax11, altinity-in-hel1, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-style-checker-aarch64
       timeout_minutes: 180
       additional_envs: |
         NEEDS_DATA<<NDENV
@@ -282,7 +282,7 @@ jobs:
       - BuilderDebRelease
       - BuilderDebAarch64
       - SignRelease
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-cax11, altinity-in-hel1, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none]
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
     timeout-minutes: 180
     steps:
       - name: Check out repository code
@@ -303,7 +303,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Install packages (amd64)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       run_command: |
         cd "$REPO_COPY/tests/ci"
         python3 install_check.py "$CHECK_NAME"
@@ -314,7 +314,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Install packages (arm64)
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-on-demand, altinity-func-tester-aarch64
       run_command: |
         cd "$REPO_COPY/tests/ci"
         python3 install_check.py "$CHECK_NAME"
@@ -328,7 +328,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateless tests (release)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=10800
       run_command: |
@@ -341,7 +341,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateless tests (aarch64)
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-style-checker-aarch64
       additional_envs: |
         KILL_TIMEOUT=10800
       run_command: |
@@ -354,7 +354,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateless tests (asan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=10800
       batches: 4
@@ -368,7 +368,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateless tests (tsan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=10800
       batches: 4
@@ -382,7 +382,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateless tests (ubsan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=10800
       batches: 4
@@ -396,7 +396,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateless tests (msan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=10800
       batches: 4
@@ -410,7 +410,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateless tests (debug)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=10800
       batches: 4
@@ -427,7 +427,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateful tests (release)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=3600
       run_command: |
@@ -440,7 +440,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateful tests (aarch64)
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-in-hel1, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-style-checker-aarch64
       additional_envs: |
         KILL_TIMEOUT=3600
       run_command: |
@@ -453,7 +453,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateful tests (asan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=3600
       run_command: |
@@ -466,7 +466,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateful tests (tsan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=3600
       run_command: |
@@ -479,7 +479,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateful tests (msan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=3600
       run_command: |
@@ -492,7 +492,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateful tests (ubsan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=3600
       run_command: |
@@ -505,7 +505,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stateful tests (debug)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       additional_envs: |
         KILL_TIMEOUT=3600
       run_command: |
@@ -521,7 +521,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stress test (asan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       timeout_minutes: 180
       run_command: |
         cd "$REPO_COPY/tests/ci"
@@ -533,7 +533,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stress test (tsan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       timeout_minutes: 180
       run_command: |
         cd "$REPO_COPY/tests/ci"
@@ -545,7 +545,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stress test (msan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       run_command: |
         cd "$REPO_COPY/tests/ci"
         python3 stress_check.py "$CHECK_NAME"
@@ -556,7 +556,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stress test (ubsan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       timeout_minutes: 180
       run_command: |
         cd "$REPO_COPY/tests/ci"
@@ -568,7 +568,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Stress test (debug)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash,  altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       timeout_minutes: 180
       run_command: |
         cd "$REPO_COPY/tests/ci"
@@ -583,7 +583,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Integration tests (asan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       batches: 4
       timeout_minutes: 180
       run_command: |
@@ -596,7 +596,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Integration tests (asan, analyzer)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       batches: 6
       timeout_minutes: 180
       run_command: |
@@ -609,7 +609,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Integration tests (tsan)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       batches: 6
       timeout_minutes: 180
       run_command: |
@@ -622,7 +622,7 @@ jobs:
     secrets: inherit
     with:
       test_name: Integration tests (release)
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none
+      runner_type: altinity-on-demand, altinity-func-tester
       batches: 6
       timeout_minutes: 180
       run_command: |
@@ -637,7 +637,7 @@ jobs:
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
-      runner_type: altinity-on-demand, altinity-type-cpx51, altinity-image-x86-app-docker-ce, altinity-setup-regression
+      runner_type: altinity-on-demand, altinity-regression-tester
       commit: release
       arch: release 
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -647,14 +647,14 @@ jobs:
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
-      runner_type: altinity-on-demand, altinity-type-cax41, altinity-image-arm-app-docker-ce, altinity-setup-regression
+      runner_type: altinity-on-demand, altinity-regression-tester-aarch64
       commit: release
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
   SignRelease:
     needs: [BuilderDebRelease]
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-cax11, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none]
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
     timeout-minutes: 180
     steps:
       - name: Set envs
@@ -695,7 +695,7 @@ jobs:
 
   SignAarch64:
     needs: [BuilderDebAarch64]
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-cax11, altinity-image-arm-snapshot-22.04-arm, altinity-startup-snapshot, altinity-setup-none]
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
     timeout-minutes: 180
     steps:
       - name: Set envs
@@ -771,7 +771,7 @@ jobs:
       - RegressionTestsAarch64
       - SignRelease
       - SignAarch64
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-cpx41, altinity-in-ash, altinity-image-x86-snapshot-22.04-amd, altinity-startup-snapshot, altinity-setup-none]
+    runs-on: [self-hosted, altinity-on-demand, altinity-style-checker]
     steps:
       - name: Check out repository code
         uses: Altinity/checkout@19599efdf36c4f3f30eb55d5bb388896faea69f6

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -123,7 +123,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Download changed images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: changed_images
           path: ${{ env.IMAGES_PATH }}

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -147,7 +147,7 @@ jobs:
           job_type: test
 
       - name: Download json reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: build_report_package_*
           path: ${{ env.REPORTS_PATH }}


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
