### PR TITLE
Antalya 26.3 - fix which ci runs for external branches from org members

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,6 @@ jobs:
   config_workflow:
     runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
     needs: []
-    if: ${{ github.repository == github.event.pull_request.head.repo.full_name || github.event_name == 'workflow_dispatch' }}
     name: "Config Workflow"
     outputs:
       data: ${{ steps.run.outputs.DATA }}

--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -28,7 +28,7 @@ jobs:
   config_workflow:
     runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
     needs: []
-    if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
+    if: ${{ !contains(fromJson('["MEMBER","COLLABORATOR","OWNER"]'), github.event.pull_request.author_association) }}
     name: "Config Workflow"
     outputs:
       data: ${{ steps.run.outputs.DATA }}

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -43,7 +43,6 @@ workflow = Workflow.Config(
     name="PR",
     event=Workflow.Event.PULL_REQUEST,
     base_branches=[BASE_BRANCH, "releases/*", "antalya-*"],
-    if_condition="github.repository == github.event.pull_request.head.repo.full_name || github.event_name == 'workflow_dispatch'",
     jobs=[
         # JobConfigs.style_check, # NOTE (strtgbb): we don't run style check
         # JobConfigs.docs_job, # NOTE (strtgbb): we don't build docs

--- a/ci/workflows/pull_request_community.py
+++ b/ci/workflows/pull_request_community.py
@@ -44,7 +44,7 @@ workflow = Workflow.Config(
     name="Community PR",
     event=Workflow.Event.PULL_REQUEST,
     base_branches=[BASE_BRANCH, "releases/*", "antalya-*"],
-    if_condition="github.repository != github.event.pull_request.head.repo.full_name",
+    if_condition='!contains(fromJson(\'["MEMBER","COLLABORATOR","OWNER"]\'), github.event.pull_request.author_association)',
     jobs=[
         JobConfigs.fast_test,
         *[job.set_dependency(STYLE_AND_FAST_TESTS) for job in JobConfigs.build_jobs],


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Improve the PR workflow gates so that the community workflow does not run for org members even from external branches.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
