### PR TITLE
26.4 - CICD GH artifacts

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -274,6 +274,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_DEBUG_GH
+        id: upload_CH_AMD_DEBUG_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_DEBUG_GH
+        if: steps.upload_CH_AMD_DEBUG_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_asan_ubsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
@@ -318,6 +330,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (amd_asan_ubsan)' --workflow "MasterCI" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_AMD_ASAN_UBSAN_GH
+        id: upload_CH_AMD_ASAN_UBSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_ASAN_UBSAN_GH
+        if: steps.upload_CH_AMD_ASAN_UBSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -364,6 +388,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_TSAN_GH
+        id: upload_CH_AMD_TSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_TSAN_GH
+        if: steps.upload_CH_AMD_TSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_msan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
@@ -409,6 +445,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_MSAN_GH
+        id: upload_CH_AMD_MSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_MSAN_GH
+        if: steps.upload_CH_AMD_MSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_binary:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
@@ -453,6 +501,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (amd_binary)' --workflow "MasterCI" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_AMD_BINARY_GH
+        id: upload_CH_AMD_BINARY_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_BINARY_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_BINARY_GH
+        if: steps.upload_CH_AMD_BINARY_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_BINARY_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_debug:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -543,6 +603,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (arm_asan_ubsan)' --workflow "MasterCI" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_ARM_ASAN_UBSAN_GH
+        id: upload_CH_ARM_ASAN_UBSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_ARM_ASAN_UBSAN_GH
+        if: steps.upload_CH_ARM_ASAN_UBSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64]
@@ -723,6 +795,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (arm_binary)' --workflow "MasterCI" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_ARM_BIN_GH
+        id: upload_CH_ARM_BIN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_ARM_BIN_GH
+        if: steps.upload_CH_ARM_BIN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_llvm_coverage_per_test:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -1300,6 +1384,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1344,6 +1435,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1390,6 +1488,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1434,6 +1539,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1480,6 +1592,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1524,6 +1643,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1570,6 +1696,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1614,6 +1747,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1660,6 +1800,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1704,6 +1851,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1750,6 +1904,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1794,6 +1955,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1840,6 +2008,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1884,6 +2059,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1930,6 +2112,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1974,6 +2163,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2020,6 +2216,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2064,6 +2267,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2110,6 +2320,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2154,6 +2371,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2200,6 +2424,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2245,6 +2476,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_ARM_BIN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2289,6 +2527,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_BIN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2695,6 +2940,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2739,6 +2991,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2785,6 +3044,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2829,6 +3095,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2875,6 +3148,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2919,6 +3199,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2965,6 +3252,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -3009,6 +3303,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -4990,6 +5291,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -5125,6 +5433,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -5169,6 +5484,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -5215,6 +5537,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -5259,6 +5588,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -5305,6 +5641,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -5349,6 +5692,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -5395,6 +5745,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -5439,6 +5796,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -367,6 +367,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_DEBUG_GH
+        id: upload_CH_AMD_DEBUG_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_DEBUG_GH
+        if: steps.upload_CH_AMD_DEBUG_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_asan_ubsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
@@ -411,6 +423,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (amd_asan_ubsan)' --workflow "PR" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_AMD_ASAN_UBSAN_GH
+        id: upload_CH_AMD_ASAN_UBSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_ASAN_UBSAN_GH
+        if: steps.upload_CH_AMD_ASAN_UBSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -457,6 +481,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_TSAN_GH
+        id: upload_CH_AMD_TSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_TSAN_GH
+        if: steps.upload_CH_AMD_TSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_msan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
@@ -502,6 +538,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_MSAN_GH
+        id: upload_CH_AMD_MSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_MSAN_GH
+        if: steps.upload_CH_AMD_MSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_binary:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
@@ -546,6 +594,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (amd_binary)' --workflow "PR" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_AMD_BINARY_GH
+        id: upload_CH_AMD_BINARY_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_BINARY_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_BINARY_GH
+        if: steps.upload_CH_AMD_BINARY_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_BINARY_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_debug:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -636,6 +696,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (arm_asan_ubsan)' --workflow "PR" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_ARM_ASAN_UBSAN_GH
+        id: upload_CH_ARM_ASAN_UBSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_ARM_ASAN_UBSAN_GH
+        if: steps.upload_CH_ARM_ASAN_UBSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64]
@@ -817,6 +889,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_ARM_BIN_GH
+        id: upload_CH_ARM_BIN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_ARM_BIN_GH
+        if: steps.upload_CH_ARM_BIN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_release:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
@@ -943,6 +1027,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -987,6 +1078,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1033,6 +1131,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1077,6 +1182,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1123,6 +1235,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1167,6 +1286,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1213,6 +1339,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1257,6 +1390,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1303,6 +1443,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1347,6 +1494,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1393,6 +1547,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1437,6 +1598,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1483,6 +1651,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1527,6 +1702,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1573,6 +1755,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1617,6 +1806,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1663,6 +1859,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1707,6 +1910,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1753,6 +1963,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1797,6 +2014,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1843,6 +2067,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1887,6 +2118,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -1933,6 +2171,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1977,6 +2222,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2023,6 +2275,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2067,6 +2326,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2113,6 +2379,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_ARM_BIN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2157,6 +2430,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_BIN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2203,6 +2483,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2247,6 +2534,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2293,6 +2587,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2337,6 +2638,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2383,6 +2691,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2427,6 +2742,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -2473,6 +2795,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -2517,6 +2846,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -4228,6 +4564,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -4363,6 +4706,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_DEBUG_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -4407,6 +4757,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_ASAN_UBSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run
@@ -4453,6 +4810,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_AMD_TSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -4497,6 +4861,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_AMD_MSAN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run

--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -175,14 +175,14 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_AMD_DEBUG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_DEBUG
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_DEBUG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_DEBUG
           path: ci/tmp/*.deb
@@ -233,21 +233,21 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact UNITTEST_AMD_ASAN_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: UNITTEST_AMD_ASAN_UBSAN
           path: ci/tmp/build/src/unit_tests_dbms
 
 
       - name: Upload artifact CH_AMD_ASAN_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_ASAN_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_ASAN_UBSAN
           path: ci/tmp/*.deb
@@ -298,21 +298,21 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact UNITTEST_AMD_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: UNITTEST_AMD_TSAN
           path: ci/tmp/build/src/unit_tests_dbms
 
 
       - name: Upload artifact CH_AMD_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_TSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_TSAN
           path: ci/tmp/*.deb
@@ -363,21 +363,21 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact UNITTEST_AMD_MSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: UNITTEST_AMD_MSAN
           path: ci/tmp/build/src/unit_tests_dbms
 
 
       - name: Upload artifact CH_AMD_MSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_MSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_MSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_MSAN
           path: ci/tmp/*.deb
@@ -428,7 +428,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_AMD_BINARY
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_BINARY
           path: ci/tmp/build/programs/self-extracting/clickhouse
@@ -479,14 +479,14 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_ARM_DEBUG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_DEBUG
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_ARM_DEBUG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_ARM_DEBUG
           path: ci/tmp/*.deb
@@ -537,14 +537,14 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_ARM_ASAN_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_ASAN_UBSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_ARM_ASAN_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_ARM_ASAN_UBSAN
           path: ci/tmp/*.deb
@@ -595,14 +595,14 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_ARM_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_TSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_ARM_TSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_ARM_TSAN
           path: ci/tmp/*.deb
@@ -653,14 +653,14 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_ARM_MSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_MSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_ARM_MSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_ARM_MSAN
           path: ci/tmp/*.deb
@@ -711,14 +711,14 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_ARM_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_UBSAN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_ARM_UBSAN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_ARM_UBSAN
           path: ci/tmp/*.deb
@@ -769,14 +769,14 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_ARM_BIN
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_BIN
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact PARSER_MEMORY_PROFILER
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: PARSER_MEMORY_PROFILER
           path: ci/tmp/build/src/Parsers/examples/parser_memory_profiler
@@ -827,28 +827,28 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_AMD_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_AMD_RELEASE
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_AMD_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_AMD_RELEASE
           path: ci/tmp/*.deb
 
 
       - name: Upload artifact RPM_AMD_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: RPM_AMD_RELEASE
           path: ci/tmp/*.rpm
 
 
       - name: Upload artifact TGZ_AMD_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: TGZ_AMD_RELEASE
           path: ci/tmp/*64.tgz*
@@ -899,28 +899,28 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
       - name: Upload artifact CH_ARM_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CH_ARM_RELEASE
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
       - name: Upload artifact DEB_ARM_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: DEB_ARM_RELEASE
           path: ci/tmp/*.deb
 
 
       - name: Upload artifact RPM_ARM_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: RPM_ARM_RELEASE
           path: ci/tmp/*.rpm
 
 
       - name: Upload artifact TGZ_ARM_RELEASE
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: TGZ_ARM_RELEASE
           path: ci/tmp/*64.tgz*
@@ -962,7 +962,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1013,7 +1013,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -1064,7 +1064,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -1115,7 +1115,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -1166,7 +1166,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1217,7 +1217,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1268,7 +1268,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1319,7 +1319,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1370,7 +1370,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1421,7 +1421,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1472,7 +1472,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1523,7 +1523,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1574,7 +1574,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1625,7 +1625,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1676,7 +1676,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1727,7 +1727,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -1778,7 +1778,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1829,7 +1829,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_DEBUG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_DEBUG
           path: ./ci/tmp
@@ -1880,7 +1880,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1931,7 +1931,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -1982,7 +1982,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2033,7 +2033,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2084,7 +2084,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -2135,7 +2135,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -2186,7 +2186,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -2237,7 +2237,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -2288,7 +2288,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -2339,7 +2339,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -2390,7 +2390,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -2441,7 +2441,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -2492,7 +2492,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -2543,7 +2543,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -2594,7 +2594,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -2645,7 +2645,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_BIN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_BIN
           path: ./ci/tmp
@@ -2696,7 +2696,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2747,7 +2747,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2798,7 +2798,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2849,7 +2849,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2900,7 +2900,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -2951,7 +2951,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_TSAN
           path: ./ci/tmp
@@ -3002,7 +3002,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -3053,7 +3053,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -3104,7 +3104,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -3155,7 +3155,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -3206,7 +3206,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -3257,7 +3257,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_MSAN
           path: ./ci/tmp
@@ -3308,7 +3308,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact UNITTEST_AMD_ASAN_UBSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: UNITTEST_AMD_ASAN_UBSAN
           path: ./ci/tmp
@@ -3359,7 +3359,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact UNITTEST_AMD_TSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: UNITTEST_AMD_TSAN
           path: ./ci/tmp
@@ -3410,7 +3410,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact UNITTEST_AMD_MSAN
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: UNITTEST_AMD_MSAN
           path: ./ci/tmp
@@ -3461,28 +3461,28 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_AMD_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact DEB_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DEB_AMD_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact RPM_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: RPM_AMD_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact TGZ_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: TGZ_AMD_RELEASE
           path: ./ci/tmp
@@ -3533,28 +3533,28 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact CH_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: CH_ARM_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact DEB_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DEB_ARM_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact RPM_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: RPM_ARM_RELEASE
           path: ./ci/tmp
 
 
       - name: Download artifact TGZ_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: TGZ_ARM_RELEASE
           path: ./ci/tmp
@@ -3605,7 +3605,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact DEB_AMD_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DEB_AMD_RELEASE
           path: ./ci/tmp
@@ -3656,7 +3656,7 @@ jobs:
           ENV_SETUP_SCRIPT_EOF
 
       - name: Download artifact DEB_ARM_RELEASE
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DEB_ARM_RELEASE
           path: ./ci/tmp

--- a/.github/workflows/regression-reusable-suite.yml
+++ b/.github/workflows/regression-reusable-suite.yml
@@ -93,6 +93,7 @@ jobs:
       build_sha: ${{ inputs.build_sha }}
       pr_number: ${{ github.event.number }}
       artifacts: builds
+      GH_BINARY_ARTIFACT_NAME: ${{ inputs.runner_arch == 'aarch64' && 'CH_ARM_BIN_GH' || 'CH_AMD_BINARY_GH' }}
       # Args
       args: --test-to-end
         --no-colors
@@ -127,7 +128,30 @@ jobs:
       - name: 🛠️ Setup
         run: .github/setup.sh
 
+      - name: 📥 Try get binary from GH artifact
+        id: get_binary_gh
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.GH_BINARY_ARTIFACT_NAME }}
+          path: ${{ runner.temp }}/gh_binary
+
+      - name: 🔎 Resolve binary source
+        id: resolve_binary_source
+        run: |
+          GH_BINARY="${{ runner.temp }}/gh_binary/clickhouse"
+          if [ -f "$GH_BINARY" ]; then
+            chmod +x "$GH_BINARY"
+            echo "clickhouse_path=$GH_BINARY" >> "$GITHUB_ENV"
+            echo "has_gh_binary=true" >> "$GITHUB_OUTPUT"
+            echo "Using GH artifact binary: $GH_BINARY"
+          else
+            echo "has_gh_binary=false" >> "$GITHUB_OUTPUT"
+            echo "GH artifact binary not found, fallback to S3 URL resolution"
+          fi
+
       - name: 📦 Get deb url
+        if: ${{ steps.resolve_binary_source.outputs.has_gh_binary != 'true' }}
         env:
           S3_BASE_URL: https://altinity-build-artifacts.s3.amazonaws.com/
           PR_NUMBER: ${{ github.event.pull_request.number || 0 }}

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -275,6 +275,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_DEBUG_GH
+        id: upload_CH_AMD_DEBUG_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_DEBUG_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_DEBUG_GH
+        if: steps.upload_CH_AMD_DEBUG_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_asan_ubsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
@@ -321,6 +333,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (amd_asan_ubsan)' --workflow "Release Builds" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_AMD_ASAN_UBSAN_GH
+        id: upload_CH_AMD_ASAN_UBSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_ASAN_UBSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_ASAN_UBSAN_GH
+        if: steps.upload_CH_AMD_ASAN_UBSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -369,6 +393,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_TSAN_GH
+        id: upload_CH_AMD_TSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_TSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_TSAN_GH
+        if: steps.upload_CH_AMD_TSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_msan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
@@ -416,6 +452,18 @@ jobs:
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
+      - name: Upload artifact CH_AMD_MSAN_GH
+        id: upload_CH_AMD_MSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_MSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_MSAN_GH
+        if: steps.upload_CH_AMD_MSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+
   build_amd_binary:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
@@ -462,6 +510,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (amd_binary)' --workflow "Release Builds" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_AMD_BINARY_GH
+        id: upload_CH_AMD_BINARY_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_AMD_BINARY_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_AMD_BINARY_GH
+        if: steps.upload_CH_AMD_BINARY_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_BINARY_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_debug:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -556,6 +616,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (arm_asan_ubsan)' --workflow "Release Builds" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_ARM_ASAN_UBSAN_GH
+        id: upload_CH_ARM_ASAN_UBSAN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_ARM_ASAN_UBSAN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_ARM_ASAN_UBSAN_GH
+        if: steps.upload_CH_ARM_ASAN_UBSAN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64]
@@ -744,6 +816,18 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (arm_binary)' --workflow "Release Builds" --ci 2>&1 | python3 -u -c 'import sys,datetime
           prefix=lambda: datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
+
+      - name: Upload artifact CH_ARM_BIN_GH
+        id: upload_CH_ARM_BIN_GH
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ci/tmp/build/programs/self-extracting/clickhouse
+          retention-days: 1
+      - name: Warn on failed upload of CH_ARM_BIN_GH
+        if: steps.upload_CH_ARM_BIN_GH.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -1065,6 +1149,13 @@ jobs:
           EOF
           ENV_SETUP_SCRIPT_EOF
 
+      - name: Download artifact CH_ARM_BIN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ./ci/tmp
+
       - name: Run
         id: run
         run: |
@@ -1111,6 +1202,13 @@ jobs:
           ${{ toJson(needs) }}
           EOF
           ENV_SETUP_SCRIPT_EOF
+
+      - name: Download artifact CH_ARM_BIN_GH
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: CH_ARM_BIN_GH
+          path: ./ci/tmp
 
       - name: Run
         id: run

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -441,6 +441,17 @@ class ArtifactNames:
     CH_RISCV64 = "CH_RISCV64_BIN"
     CH_S390X = "CH_S390X_BIN"
     CH_LOONGARCH64 = "CH_LOONGARCH64_BIN"
+    CH_AMD_DEBUG_GH = "CH_AMD_DEBUG_GH"
+    CH_AMD_BINARY_GH = "CH_AMD_BINARY_GH"
+    CH_ARM_BINARY_GH = "CH_ARM_BIN_GH"
+    CH_AMD_ASAN_UBSAN_GH = "CH_AMD_ASAN_UBSAN_GH"
+    CH_AMD_ASAN_GH = "CH_AMD_ASAN_GH"
+    CH_AMD_TSAN_GH = "CH_AMD_TSAN_GH"
+    CH_AMD_MSAN_GH = "CH_AMD_MSAN_GH"
+    CH_AMD_UBSAN_GH = "CH_AMD_UBSAN_GH"
+    CH_ARM_ASAN_UBSAN_GH = "CH_ARM_ASAN_UBSAN_GH"
+    CH_ARM_ASAN_GH = "CH_ARM_ASAN_GH"
+    CH_ARM_TSAN_GH = "CH_ARM_TSAN_GH"
 
     FAST_TEST = "FAST_TEST"
     UNITTEST_AMD_ASAN_UBSAN = "UNITTEST_AMD_ASAN_UBSAN"
@@ -556,6 +567,25 @@ class ArtifactConfigs:
             ArtifactNames.CH_RISCV64,
             ArtifactNames.CH_S390X,
             ArtifactNames.CH_LOONGARCH64,
+        ]
+    )
+    clickhouse_binaries_gh = Artifact.Config(
+        name="...",
+        type=Artifact.Type.GH,
+        path=f"{TEMP_DIR}/build/programs/self-extracting/clickhouse",
+    ).parametrize(
+        names=[
+            ArtifactNames.CH_AMD_DEBUG_GH,
+            ArtifactNames.CH_AMD_BINARY_GH,
+            ArtifactNames.CH_ARM_BINARY_GH,
+            ArtifactNames.CH_AMD_ASAN_UBSAN_GH,
+            ArtifactNames.CH_AMD_ASAN_GH,
+            ArtifactNames.CH_AMD_TSAN_GH,
+            ArtifactNames.CH_AMD_MSAN_GH,
+            ArtifactNames.CH_AMD_UBSAN_GH,
+            ArtifactNames.CH_ARM_ASAN_UBSAN_GH,
+            ArtifactNames.CH_ARM_ASAN_GH,
+            ArtifactNames.CH_ARM_TSAN_GH,
         ]
     )
     clickhouse_stripped_binaries = Artifact.Config(

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -250,13 +250,18 @@ class JobConfigs:
     ).parametrize(
         Job.ParamSet(
             parameter=BuildTypes.AMD_DEBUG,
-            provides=[ArtifactNames.CH_AMD_DEBUG, ArtifactNames.DEB_AMD_DEBUG],
+            provides=[
+                ArtifactNames.CH_AMD_DEBUG,
+                ArtifactNames.CH_AMD_DEBUG_GH,
+                ArtifactNames.DEB_AMD_DEBUG,
+            ],
             runs_on=RunnerLabels.BUILDER_AMD,
         ),
         Job.ParamSet(
             parameter=BuildTypes.AMD_ASAN_UBSAN,
             provides=[
                 ArtifactNames.CH_AMD_ASAN_UBSAN,
+                ArtifactNames.CH_AMD_ASAN_UBSAN_GH,
                 ArtifactNames.DEB_AMD_ASAN_UBSAN,
                 ArtifactNames.UNITTEST_AMD_ASAN_UBSAN,
             ],
@@ -266,6 +271,7 @@ class JobConfigs:
             parameter=BuildTypes.AMD_TSAN,
             provides=[
                 ArtifactNames.CH_AMD_TSAN,
+                ArtifactNames.CH_AMD_TSAN_GH,
                 ArtifactNames.DEB_AMD_TSAN,
                 ArtifactNames.UNITTEST_AMD_TSAN,
             ],
@@ -275,6 +281,7 @@ class JobConfigs:
             parameter=BuildTypes.AMD_MSAN,
             provides=[
                 ArtifactNames.CH_AMD_MSAN,
+                ArtifactNames.CH_AMD_MSAN_GH,
                 ArtifactNames.DEB_AMD_MSAN,
                 ArtifactNames.UNITTEST_AMD_MSAN,
             ],
@@ -282,7 +289,10 @@ class JobConfigs:
         ),
         Job.ParamSet(
             parameter=BuildTypes.AMD_BINARY,
-            provides=[ArtifactNames.CH_AMD_BINARY],
+            provides=[
+                ArtifactNames.CH_AMD_BINARY,
+                ArtifactNames.CH_AMD_BINARY_GH,
+            ],
             runs_on=RunnerLabels.BUILDER_AMD,
         ),
         Job.ParamSet(
@@ -294,6 +304,7 @@ class JobConfigs:
             parameter=BuildTypes.ARM_ASAN_UBSAN,
             provides=[
                 ArtifactNames.CH_ARM_ASAN_UBSAN,
+                ArtifactNames.CH_ARM_ASAN_UBSAN_GH,
                 ArtifactNames.DEB_ARM_ASAN_UBSAN,
             ],
             runs_on=RunnerLabels.ARM_LARGE,
@@ -320,6 +331,7 @@ class JobConfigs:
             parameter=BuildTypes.ARM_BINARY,
             provides=[
                 ArtifactNames.CH_ARM_BINARY,
+                ArtifactNames.CH_ARM_BINARY_GH,
                 ArtifactNames.PARSER_MEMORY_PROFILER,
             ],
             runs_on=RunnerLabels.BUILDER_AMD,
@@ -379,6 +391,7 @@ class JobConfigs:
         #     parameter=BuildTypes.ARM_TSAN,
         #     provides=[
         #         ArtifactNames.CH_ARM_TSAN,
+        #         ArtifactNames.CH_ARM_TSAN_GH,
         #     ],
         #     runs_on=RunnerLabels.ARM_LARGE,
         # ),
@@ -516,7 +529,7 @@ class JobConfigs:
         Job.ParamSet(
             parameter="amd_asan_ubsan, flaky check",
             runs_on=RunnerLabels.AMD_MEDIUM,
-            requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
+            requires=[ArtifactNames.CH_AMD_ASAN_UBSAN_GH],
         ),
         Job.ParamSet(
             parameter="amd_tsan, flaky check",
@@ -538,7 +551,7 @@ class JobConfigs:
         Job.ParamSet(
             parameter="arm_asan_ubsan, targeted",
             runs_on=RunnerLabels.ARM_LARGE,
-            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN],
+            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN_GH],
         ),
     )
     # --root/--privileged/--cgroupns=host is required for clickhouse-test --memory-limit
@@ -568,7 +581,7 @@ class JobConfigs:
                 "./ci/jobs/queries",
             ],
         ),
-        requires=[ArtifactNames.CH_AMD_DEBUG],
+        requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         runs_on=RunnerLabels.AMD_SMALL,
     )
     functional_tests_jobs = common_ft_job_config.parametrize(
@@ -576,7 +589,7 @@ class JobConfigs:
             Job.ParamSet(
                 parameter=f"amd_asan_ubsan, distributed plan, parallel, {batch}/{total_batches}",
                 runs_on=RunnerLabels.AMD_MEDIUM_CPU,
-                requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
+                requires=[ArtifactNames.CH_AMD_ASAN_UBSAN_GH],
             )
             for total_batches in (2,)
             for batch in range(1, total_batches + 1)
@@ -584,7 +597,7 @@ class JobConfigs:
         Job.ParamSet(
             parameter="amd_asan_ubsan, db disk, distributed plan, sequential",
             runs_on=RunnerLabels.FUNC_TESTER_AMD,
-            requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
+            requires=[ArtifactNames.CH_AMD_ASAN_UBSAN_GH],
         ),
         Job.ParamSet( # NOTE (strtgbb): llvm cov jobs not configured yet. Determine if useful first.
             parameter="amd_llvm_coverage, old analyzer, s3 storage, DatabaseReplicated, WasmEdge, parallel",
@@ -625,18 +638,18 @@ class JobConfigs:
         Job.ParamSet(
             parameter="amd_debug, parallel",
             runs_on=RunnerLabels.FUNC_TESTER_AMD,
-            requires=[ArtifactNames.CH_AMD_DEBUG],
+            requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         ),
         Job.ParamSet(
             parameter="amd_debug, sequential",
             runs_on=RunnerLabels.FUNC_TESTER_AMD,
-            requires=[ArtifactNames.CH_AMD_DEBUG],
+            requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         ),
         *[
             Job.ParamSet(
                 parameter=f"amd_tsan, parallel, {batch}/{total_batches}",
                 runs_on=RunnerLabels.FUNC_TESTER_AMD,
-                requires=[ArtifactNames.CH_AMD_TSAN],
+                requires=[ArtifactNames.CH_AMD_TSAN_GH],
             )
             for total_batches in (2,)
             for batch in range(1, total_batches + 1)
@@ -645,7 +658,7 @@ class JobConfigs:
             Job.ParamSet(
                 parameter=f"amd_tsan, sequential, {batch}/{total_batches}",
                 runs_on=RunnerLabels.FUNC_TESTER_AMD,
-                requires=[ArtifactNames.CH_AMD_TSAN],
+                requires=[ArtifactNames.CH_AMD_TSAN_GH],
             )
             for total_batches in (2,)
             for batch in range(1, total_batches + 1)
@@ -654,7 +667,7 @@ class JobConfigs:
             Job.ParamSet(
                 parameter=f"amd_msan, WasmEdge, parallel, {batch}/{total_batches}",
                 runs_on=RunnerLabels.FUNC_TESTER_AMD,
-                requires=[ArtifactNames.CH_AMD_MSAN],
+                requires=[ArtifactNames.CH_AMD_MSAN_GH],
             )
             for total_batches in (4,)
             for batch in range(1, total_batches + 1)
@@ -663,26 +676,26 @@ class JobConfigs:
             Job.ParamSet(
                 parameter=f"amd_msan, WasmEdge, sequential, {batch}/{total_batches}",
                 runs_on=RunnerLabels.FUNC_TESTER_AMD,
-                requires=[ArtifactNames.CH_AMD_MSAN],
+                requires=[ArtifactNames.CH_AMD_MSAN_GH],
             )
             for total_batches in (2,)
             for batch in range(1, total_batches + 1)
         ],
         Job.ParamSet(
             parameter="amd_debug, distributed plan, s3 storage, parallel",
-            runs_on=RunnerLabels.AMD_MEDIUM,  # large machine - no boost, why?
-            requires=[ArtifactNames.CH_AMD_DEBUG],
+            runs_on=RunnerLabels.FUNC_TESTER_AMD,  # large machine - no boost, why?
+            requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         ),
         Job.ParamSet(
             parameter="amd_debug, distributed plan, s3 storage, sequential",
             runs_on=RunnerLabels.FUNC_TESTER_AMD,
-            requires=[ArtifactNames.CH_AMD_DEBUG],
+            requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         ),
         *[
             Job.ParamSet(
                 parameter=f"amd_tsan, s3 storage, parallel, {batch}/{total_batches}",
-                runs_on=RunnerLabels.AMD_MEDIUM,
-                requires=[ArtifactNames.CH_AMD_TSAN],
+                runs_on=RunnerLabels.FUNC_TESTER_AMD,
+                requires=[ArtifactNames.CH_AMD_TSAN_GH],
             )
             for total_batches in (2,)
             for batch in range(1, total_batches + 1)
@@ -691,20 +704,20 @@ class JobConfigs:
             Job.ParamSet(
                 parameter=f"amd_tsan, s3 storage, sequential, {batch}/{total_batches}",
                 runs_on=RunnerLabels.FUNC_TESTER_AMD,
-                requires=[ArtifactNames.CH_AMD_TSAN],
+                requires=[ArtifactNames.CH_AMD_TSAN_GH],
             )
             for total_batches in (2,)
             for batch in range(1, total_batches + 1)
         ],
         Job.ParamSet(
             parameter="arm_binary, parallel",
-            runs_on=RunnerLabels.ARM_MEDIUM_CPU,
-            requires=[ArtifactNames.CH_ARM_BINARY],
+            runs_on=RunnerLabels.FUNC_TESTER_ARM,
+            requires=[ArtifactNames.CH_ARM_BINARY_GH],
         ),
         Job.ParamSet(
             parameter="arm_binary, sequential",
             runs_on=RunnerLabels.FUNC_TESTER_ARM,
-            requires=[ArtifactNames.CH_ARM_BINARY],
+            requires=[ArtifactNames.CH_ARM_BINARY_GH],
         ),
     )
     functional_tests_jobs_coverage = common_ft_job_config.parametrize(
@@ -723,13 +736,13 @@ class JobConfigs:
     ).parametrize(
         Job.ParamSet(
             parameter="arm_asan_ubsan, azure, parallel",
-            runs_on=RunnerLabels.ARM_MEDIUM,
-            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN],
+            runs_on=RunnerLabels.FUNC_TESTER_ARM,
+            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN_GH],
         ),
         Job.ParamSet(
             parameter="arm_asan_ubsan, azure, sequential",
             runs_on=RunnerLabels.FUNC_TESTER_ARM,
-            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN],
+            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN_GH],
         ),
     )
     bugfix_validation_it_job = (
@@ -854,7 +867,7 @@ class JobConfigs:
             Job.ParamSet(
                 parameter=f"amd_asan_ubsan, db disk, {batch}/{total_batches}",
                 runs_on=RunnerLabels.AMD_MEDIUM,
-                requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
+                requires=[ArtifactNames.CH_AMD_ASAN_UBSAN_GH],
             )
             for total_batches in (4,)
             for batch in range(1, total_batches + 1)
@@ -865,7 +878,7 @@ class JobConfigs:
             Job.ParamSet(
                 parameter=f"amd_asan_ubsan, db disk, old analyzer, {batch}/{total_batches}",
                 runs_on=RunnerLabels.AMD_MEDIUM,
-                requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
+                requires=[ArtifactNames.CH_AMD_ASAN_UBSAN_GH],
             )
             for total_batches in (6,)
             for batch in range(1, total_batches + 1)
@@ -905,7 +918,7 @@ class JobConfigs:
             Job.ParamSet(
                 parameter=f"amd_asan_ubsan, flaky",
                 runs_on=RunnerLabels.AMD_MEDIUM,
-                requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
+                requires=[ArtifactNames.CH_AMD_ASAN_UBSAN_GH],
             )
         )
     )
@@ -988,7 +1001,7 @@ class JobConfigs:
         Job.ParamSet(
             parameter=f"amd_asan_ubsan, targeted",
             runs_on=RunnerLabels.AMD_MEDIUM,
-            requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
+            requires=[ArtifactNames.CH_AMD_ASAN_UBSAN_GH],
         )
     )
     # Keeper stress job config — shared by PR and nightly workflows.
@@ -1060,7 +1073,7 @@ class JobConfigs:
         Job.ParamSet(
             parameter="arm_asan_ubsan",
             runs_on=RunnerLabels.FUNC_TESTER_ARM,
-            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN],
+            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN_GH],
         ),
         Job.ParamSet(
             parameter="amd_tsan",
@@ -1093,12 +1106,12 @@ class JobConfigs:
         Job.ParamSet(
             parameter="amd_debug, targeted",
             runs_on=RunnerLabels.FUNC_TESTER_AMD,
-            requires=[ArtifactNames.CH_AMD_DEBUG],
+            requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         ),
         Job.ParamSet(
             parameter="amd_debug, targeted, old_compatibility",
             runs_on=RunnerLabels.FUNC_TESTER_AMD,
-            requires=[ArtifactNames.CH_AMD_DEBUG],
+            requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         ),
 
     )
@@ -1121,22 +1134,22 @@ class JobConfigs:
         Job.ParamSet(
             parameter="amd_debug",
             runs_on=RunnerLabels.AMD_MEDIUM,
-            requires=[ArtifactNames.CH_AMD_DEBUG],
+            requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         ),
         Job.ParamSet(
             parameter="arm_asan_ubsan",
             runs_on=RunnerLabels.ARM_MEDIUM,
-            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN],
+            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN_GH],
         ),
         Job.ParamSet(
             parameter="amd_tsan",
             runs_on=RunnerLabels.AMD_MEDIUM,
-            requires=[ArtifactNames.CH_AMD_TSAN],
+            requires=[ArtifactNames.CH_AMD_TSAN_GH],
         ),
         Job.ParamSet(
             parameter="amd_msan",
             runs_on=RunnerLabels.AMD_MEDIUM,
-            requires=[ArtifactNames.CH_AMD_MSAN],
+            requires=[ArtifactNames.CH_AMD_MSAN_GH],
         ),
     )
     stress_test_serverfuzz_jobs = common_stress_job_config.parametrize(
@@ -1225,22 +1238,22 @@ class JobConfigs:
         Job.ParamSet(
             parameter="experimental, serverfuzz, amd_debug",
             runs_on=RunnerLabels.AMD_MEDIUM,
-            requires=[ArtifactNames.CH_AMD_DEBUG],
+            requires=[ArtifactNames.CH_AMD_DEBUG_GH],
         ),
         Job.ParamSet(
             parameter="experimental, serverfuzz, arm_asan_ubsan",
             runs_on=RunnerLabels.ARM_MEDIUM,
-            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN],
+            requires=[ArtifactNames.CH_ARM_ASAN_UBSAN_GH],
         ),
         Job.ParamSet(
             parameter="experimental, serverfuzz, amd_tsan",
             runs_on=RunnerLabels.AMD_MEDIUM,
-            requires=[ArtifactNames.CH_AMD_TSAN],
+            requires=[ArtifactNames.CH_AMD_TSAN_GH],
         ),
         Job.ParamSet(
             parameter="experimental, serverfuzz, amd_msan",
             runs_on=RunnerLabels.AMD_MEDIUM,
-            requires=[ArtifactNames.CH_AMD_MSAN],
+            requires=[ArtifactNames.CH_AMD_MSAN_GH],
         ),
     )
     performance_comparison_with_master_head_jobs = Job.Config(

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -2,6 +2,7 @@ import dataclasses
 import hashlib
 import json
 import platform
+import os
 import sys
 import traceback
 from pathlib import Path

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -192,16 +192,19 @@ class Runner:
         if job.requires and not _is_praktika_job(job.name):
             print("Download required artifacts")
             required_artifacts = []
+            required_gh_artifacts = []
             job_names_with_provides = {
                 j.name for j in workflow.jobs if j.provides
             }
+            # GH artifacts are downloaded by workflow YAML steps. Track them here only
+            # to fallback to matching S3 artifacts when the GH artifact is unavailable.
             for requires_artifact_name in job.requires:
                 for artifact in workflow.artifacts:
-                    if (
-                        artifact.name == requires_artifact_name
-                        and artifact.type == Artifact.Type.S3
-                    ):
-                        required_artifacts.append(artifact)
+                    if artifact.name == requires_artifact_name:
+                        if artifact.type == Artifact.Type.S3:
+                            required_artifacts.append(artifact)
+                        elif artifact.type == Artifact.Type.GH:
+                            required_gh_artifacts.append(artifact)
                         break
                 else:
                     if requires_artifact_name in job_names_with_provides:
@@ -256,6 +259,87 @@ class Runner:
                     if artifact.compress_zst:
                         Utils.decompress_file(Path(Settings.INPUT_DIR) / artifact_path)
 
+            # GH artifacts are downloaded by workflow YAML steps. If they are missing (e.g. rerun after
+            # short GH retention expiry), attempt fallback to matching S3 artifact by name.
+            for gh_artifact in required_gh_artifacts:
+                if isinstance(gh_artifact.path, (tuple, list)):
+                    gh_paths = gh_artifact.path
+                else:
+                    gh_paths = [gh_artifact.path]
+
+                expected_local_paths = []
+                unresolved_pattern = False
+                for gh_path in gh_paths:
+                    if "*" in gh_path:
+                        unresolved_pattern = True
+                        continue
+                    expected_local_paths.append(Path(Settings.INPUT_DIR) / Path(gh_path).name)
+
+                if expected_local_paths and all(p.exists() for p in expected_local_paths):
+                    continue
+
+                if unresolved_pattern and not expected_local_paths:
+                    print(
+                        f"WARNING: Cannot resolve expected local path for GH artifact [{gh_artifact.name}] with wildcard path [{gh_artifact.path}] - skip S3 fallback"
+                    )
+                    continue
+
+                s3_fallback_name = (
+                    gh_artifact.name[:-3]
+                    if gh_artifact.name.endswith("_GH")
+                    else gh_artifact.name
+                )
+                s3_fallback_artifact = None
+                for artifact in workflow.artifacts:
+                    if (
+                        artifact.name == s3_fallback_name
+                        and artifact.type == Artifact.Type.S3
+                    ):
+                        s3_fallback_artifact = artifact
+                        break
+
+                if not s3_fallback_artifact:
+                    print(
+                        f"WARNING: GH artifact [{gh_artifact.name}] is missing and no S3 fallback artifact [{s3_fallback_name}] is configured"
+                    )
+                    continue
+
+                print(
+                    f"GH artifact [{gh_artifact.name}] is missing; fallback to S3 artifact [{s3_fallback_artifact.name}]"
+                )
+                fallback_prefix = env.get_s3_prefix()
+
+                fallback_artifact = dataclasses.replace(s3_fallback_artifact)
+                if fallback_artifact.compress_zst:
+                    assert not isinstance(
+                        fallback_artifact.path, (tuple, list)
+                    ), "Not yes supported for compressed artifacts"
+                    fallback_artifact.path = f"{Path(fallback_artifact.path).name}.zst"
+
+                if isinstance(fallback_artifact.path, (tuple, list)):
+                    fallback_paths = fallback_artifact.path
+                else:
+                    fallback_paths = [fallback_artifact.path]
+
+                for fallback_path in fallback_paths:
+                    recursive = False
+                    include_pattern = ""
+                    if "*" in fallback_path:
+                        s3_path = f"{Settings.S3_ARTIFACT_PATH}/{fallback_prefix}/{Utils.normalize_string(fallback_artifact._provided_by)}/"
+                        recursive = True
+                        include_pattern = Path(fallback_path).name
+                        assert "*" in include_pattern
+                    else:
+                        s3_path = f"{Settings.S3_ARTIFACT_PATH}/{fallback_prefix}/{Utils.normalize_string(fallback_artifact._provided_by)}/{Path(fallback_path).name}"
+                    S3.copy_file_from_s3(
+                        s3_path=s3_path,
+                        local_path=Settings.INPUT_DIR,
+                        recursive=recursive,
+                        include_pattern=include_pattern,
+                    )
+
+                    if fallback_artifact.compress_zst:
+                        Utils.decompress_file(Path(Settings.INPUT_DIR) / fallback_path)
         if not local_run and job.needs_submodules and Settings.ENABLE_SUBMODULE_CACHE:
             self._restore_submodule_cache()
 

--- a/ci/praktika/validator.py
+++ b/ci/praktika/validator.py
@@ -212,8 +212,8 @@ class Validator:
             if workflow.enable_cache:
                 for artifact in workflow.artifacts or []:
                     assert (
-                        artifact.is_s3_artifact()
-                    ), f"All artifacts must be of S3 type if enable_cache|enable_html=True, artifact [{artifact.name}], type [{artifact.type}], workflow [{workflow.name}]"
+                        artifact.is_s3_artifact() or artifact.type == Artifact.Type.GH
+                    ), f"Artifacts must be S3 or GH type if enable_cache|enable_html=True, artifact [{artifact.name}], type [{artifact.type}], workflow [{workflow.name}]"
 
             if workflow.dockers and not workflow.disable_dockers_build:
                 assert (

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -221,7 +221,21 @@ jobs:
 
         TEMPLATE_GH_UPLOAD = """
       - name: Upload artifact {NAME}
-        uses: actions/upload-artifact@v4
+        id: upload_{NAME}
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: {NAME}
+          path: {PATH}
+          retention-days: 1
+      - name: Warn on failed upload of {NAME}
+        if: steps.upload_{NAME}.outcome == 'failure'
+        run: echo "::warning title=GH artifact upload failed::Failed to upload [{NAME}] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
+"""
+
+        TEMPLATE_GH_UPLOAD_NO_RETENTION = """
+      - name: Upload artifact {NAME}
+        uses: actions/upload-artifact@v7
         with:
           name: {NAME}
           path: {PATH}
@@ -229,7 +243,16 @@ jobs:
 
         TEMPLATE_GH_DOWNLOAD = """
       - name: Download artifact {NAME}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: {NAME}
+          path: {PATH}
+"""
+
+        TEMPLATE_GH_DOWNLOAD_STRICT = """
+      - name: Download artifact {NAME}
+        uses: actions/download-artifact@v8
         with:
           name: {NAME}
           path: {PATH}
@@ -323,16 +346,26 @@ class PullRequestPushYamlGen:
                     )
             uploads_github = []
             for artifact in job.artifacts_gh_provides:
+                upload_template = YamlGenerator.Templates.TEMPLATE_GH_UPLOAD
+                if self.workflow_config.name == "Community PR":
+                    upload_template = (
+                        YamlGenerator.Templates.TEMPLATE_GH_UPLOAD_NO_RETENTION
+                    )
                 uploads_github.append(
-                    YamlGenerator.Templates.TEMPLATE_GH_UPLOAD.format(
+                    upload_template.format(
                         NAME=artifact.name,
                         PATH=os.path.relpath(artifact.path, os.getcwd()),
                     )
                 )
             downloads_github = []
             for artifact in job.artifacts_gh_requires:
+                download_template = YamlGenerator.Templates.TEMPLATE_GH_DOWNLOAD
+                if self.workflow_config.name == "Community PR":
+                    download_template = (
+                        YamlGenerator.Templates.TEMPLATE_GH_DOWNLOAD_STRICT
+                    )
                 downloads_github.append(
-                    YamlGenerator.Templates.TEMPLATE_GH_DOWNLOAD.format(
+                    download_template.format(
                         NAME=artifact.name, PATH=Settings.INPUT_DIR
                     )
                 )
@@ -345,7 +378,7 @@ class PullRequestPushYamlGen:
             # NOTE (strtgbb): We still want the cache logic, we use it for skipping based on PR config
             if (
                 # self.workflow_config.config.enable_cache
-                # and 
+                # and
                 job_name_normalized != config_job_name_normalized
             ):
                 if_expression = YamlGenerator.Templates.TEMPLATE_IF_EXPRESSION.format(

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -73,6 +73,7 @@ workflow = Workflow.Config(
     artifacts=[
         *ArtifactConfigs.unittests_binaries,
         *clickhouse_binaries_with_tags,
+        *ArtifactConfigs.clickhouse_binaries_gh,
         *ArtifactConfigs.clickhouse_debians,
         *ArtifactConfigs.clickhouse_rpms,
         *ArtifactConfigs.clickhouse_tgzs,

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -147,6 +147,7 @@ workflow = Workflow.Config(
     artifacts=[
         *ArtifactConfigs.unittests_binaries,
         *ArtifactConfigs.clickhouse_binaries,
+        *ArtifactConfigs.clickhouse_binaries_gh,
         *ArtifactConfigs.clickhouse_stripped_binaries,
         *ArtifactConfigs.clickhouse_debians,
         *ArtifactConfigs.clickhouse_rpms,

--- a/ci/workflows/pull_request_community.py
+++ b/ci/workflows/pull_request_community.py
@@ -27,6 +27,19 @@ PLAIN_FUNCTIONAL_TEST_JOB = [
     j for j in JobConfigs.functional_tests_jobs if "amd_debug, parallel" in j.name
 ][0]
 
+def _normalize_gh_aliases(items):
+    if not items:
+        return items
+    normalized = []
+    seen = set()
+    for item in items:
+        base = item[:-3] if item.endswith("_GH") else item
+        if base not in seen:
+            normalized.append(base)
+            seen.add(base)
+    return normalized
+
+
 workflow = Workflow.Config(
     name="Community PR",
     event=Workflow.Event.PULL_REQUEST,
@@ -135,6 +148,8 @@ workflow = Workflow.Config(
 for i, job in enumerate(workflow.jobs):
     workflow.jobs[i] = copy.deepcopy(job)
     workflow.jobs[i].enable_commit_status = False
+    workflow.jobs[i].provides = _normalize_gh_aliases(workflow.jobs[i].provides)
+    workflow.jobs[i].requires = _normalize_gh_aliases(workflow.jobs[i].requires)
 
 for i, artifact in enumerate(workflow.artifacts):
     workflow.artifacts[i] = copy.deepcopy(artifact)

--- a/ci/workflows/release_branches.py
+++ b/ci/workflows/release_branches.py
@@ -51,6 +51,7 @@ workflow = Workflow.Config(
     ],
     artifacts=[
         *clickhouse_binaries_with_tags,
+        *ArtifactConfigs.clickhouse_binaries_gh,
         *ArtifactConfigs.clickhouse_debians,
         *ArtifactConfigs.clickhouse_rpms,
         *ArtifactConfigs.clickhouse_tgzs,

--- a/ci/workflows/release_builds.py
+++ b/ci/workflows/release_builds.py
@@ -49,6 +49,7 @@ workflow = Workflow.Config(
     additional_jobs=["GrypeScan", "SignRelease", "CIReport", "SourceUpload"],
     artifacts=[
         *clickhouse_binaries_with_tags,
+        *ArtifactConfigs.clickhouse_binaries_gh,
         *ArtifactConfigs.clickhouse_debians,
         *ArtifactConfigs.clickhouse_rpms,
         *ArtifactConfigs.clickhouse_tgzs,


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- use gh artifacts without aws when possible

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
