### PR TITLE
Test builders with less ram

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -230,7 +230,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -287,7 +287,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -344,7 +344,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -401,7 +401,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -458,7 +458,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -515,7 +515,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -629,7 +629,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -686,7 +686,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_coverage:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9jb3ZlcmFnZSk=') }}
     name: "Build (amd_coverage)"
@@ -731,7 +731,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -776,7 +776,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -230,7 +230,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -287,7 +287,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -344,7 +344,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -401,7 +401,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -458,7 +458,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -515,7 +515,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -629,7 +629,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -686,7 +686,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_coverage:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9jb3ZlcmFnZSk=') }}
     name: "Build (amd_coverage)"
@@ -731,7 +731,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -776,7 +776,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -230,7 +230,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -287,7 +287,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -344,7 +344,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -401,7 +401,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -458,7 +458,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -515,7 +515,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -629,7 +629,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -686,7 +686,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_coverage:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9jb3ZlcmFnZSk=') }}
     name: "Build (amd_coverage)"
@@ -731,7 +731,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -776,7 +776,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -230,7 +230,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -287,7 +287,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -344,7 +344,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -401,7 +401,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -458,7 +458,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -515,7 +515,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -629,7 +629,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -686,7 +686,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_coverage:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9jb3ZlcmFnZSk=') }}
     name: "Build (amd_coverage)"
@@ -731,7 +731,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -776,7 +776,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -278,7 +278,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -335,7 +335,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -392,7 +392,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -449,7 +449,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -506,7 +506,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -563,7 +563,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -677,7 +677,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -791,7 +791,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -836,7 +836,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -278,7 +278,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -335,7 +335,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -392,7 +392,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -449,7 +449,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -506,7 +506,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -563,7 +563,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -677,7 +677,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -791,7 +791,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -836,7 +836,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -278,7 +278,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -335,7 +335,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -392,7 +392,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -449,7 +449,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -506,7 +506,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -563,7 +563,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -677,7 +677,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -791,7 +791,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -836,7 +836,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -278,7 +278,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -335,7 +335,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -392,7 +392,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -449,7 +449,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -506,7 +506,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -563,7 +563,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -677,7 +677,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -791,7 +791,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -836,7 +836,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -130,7 +130,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -188,7 +188,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -253,7 +253,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -318,7 +318,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -383,7 +383,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -448,7 +448,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -557,7 +557,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -666,7 +666,7 @@ jobs:
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -745,7 +745,7 @@ jobs:
           path: ci/tmp/*64.tgz*
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -130,7 +130,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -188,7 +188,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -253,7 +253,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -318,7 +318,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -383,7 +383,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -448,7 +448,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -557,7 +557,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -666,7 +666,7 @@ jobs:
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -745,7 +745,7 @@ jobs:
           path: ci/tmp/*64.tgz*
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -130,7 +130,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -188,7 +188,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -253,7 +253,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -318,7 +318,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -383,7 +383,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -448,7 +448,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -557,7 +557,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -666,7 +666,7 @@ jobs:
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -745,7 +745,7 @@ jobs:
           path: ci/tmp/*64.tgz*
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -130,7 +130,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -188,7 +188,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -253,7 +253,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -318,7 +318,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -383,7 +383,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -448,7 +448,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -557,7 +557,7 @@ jobs:
           path: ci/tmp/*.deb
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -666,7 +666,7 @@ jobs:
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -745,7 +745,7 @@ jobs:
           path: ci/tmp/*64.tgz*
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, fast_test]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -229,7 +229,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -288,7 +288,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -347,7 +347,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -406,7 +406,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -465,7 +465,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -524,7 +524,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -642,7 +642,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -701,7 +701,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -748,7 +748,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-cx53, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -229,7 +229,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -288,7 +288,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -347,7 +347,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -406,7 +406,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -465,7 +465,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -524,7 +524,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -642,7 +642,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -701,7 +701,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -748,7 +748,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-builder, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -229,7 +229,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -288,7 +288,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -347,7 +347,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -406,7 +406,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -465,7 +465,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -524,7 +524,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -642,7 +642,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -701,7 +701,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -748,7 +748,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-builder]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -229,7 +229,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_amd_debug:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9kZWJ1Zyk=') }}
     name: "Build (amd_debug)"
@@ -288,7 +288,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_DEBUG_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_asan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9hc2FuKQ==') }}
     name: "Build (amd_asan)"
@@ -347,7 +347,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_tsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF90c2FuKQ==') }}
     name: "Build (amd_tsan)"
@@ -406,7 +406,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_TSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_msan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9tc2FuKQ==') }}
     name: "Build (amd_msan)"
@@ -465,7 +465,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_MSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_ubsan:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [build_amd_binary, build_arm_binary, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF91YnNhbik=') }}
     name: "Build (amd_ubsan)"
@@ -524,7 +524,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_AMD_UBSAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9iaW5hcnkp') }}
     name: "Build (amd_binary)"
@@ -642,7 +642,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_ASAN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_arm_binary:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9iaW5hcnkp') }}
     name: "Build (arm_binary)"
@@ -701,7 +701,7 @@ jobs:
         run: echo "::warning title=GH artifact upload failed::Failed to upload [CH_ARM_BIN_GH] to GitHub artifacts (e.g. quota/rate limit). Downstream consumers will fall back to S3."
 
   build_amd_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFtZF9yZWxlYXNlKQ==') }}
     name: "Build (amd_release)"
@@ -748,7 +748,7 @@ jobs:
           for line in sys.stdin: sys.stdout.write(prefix() + " " + line); sys.stdout.flush()' | tee ./ci/tmp/job.log
 
   build_arm_release:
-    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx53, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
+    runs-on: [self-hosted, altinity-on-demand, altinity-type-ccx43, altinity-setup-create_snapshot, altinity-image-x86-system-ubuntu-22.04]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'QnVpbGQgKGFybV9yZWxlYXNlKQ==') }}
     name: "Build (arm_release)"

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -16,8 +16,8 @@ S3_REPORT_BUCKET_HTTP_ENDPOINT = altinity_overrides.S3_REPORT_BUCKET_HTTP_ENDPOI
 class RunnerLabels:
     CI_SERVICES = "ci_services"
     CI_SERVICES_EBS = "ci_services_ebs"
-    BUILDER_AMD = ["self-hosted", "altinity-on-demand", "altinity-type-ccx43", "altinity-setup-builder", "altinity-image-x86-system-ubuntu-22.04"]
-    BUILDER_ARM = ["self-hosted", "altinity-on-demand", "altinity-type-ccx43", "altinity-setup-builder", "altinity-image-x86-system-ubuntu-22.04"]
+    BUILDER_AMD = ["self-hosted", "altinity-on-demand", "altinity-type-cx53", "altinity-setup-builder", "altinity-image-x86-system-ubuntu-22.04"]
+    BUILDER_ARM = ["self-hosted", "altinity-on-demand", "altinity-type-cx53", "altinity-setup-builder", "altinity-image-x86-system-ubuntu-22.04"]
     FUNC_TESTER_AMD = ["self-hosted", "altinity-on-demand", "altinity-func-tester"]
     FUNC_TESTER_ARM = [
         "self-hosted",

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -16,8 +16,8 @@ S3_REPORT_BUCKET_HTTP_ENDPOINT = altinity_overrides.S3_REPORT_BUCKET_HTTP_ENDPOI
 class RunnerLabels:
     CI_SERVICES = "ci_services"
     CI_SERVICES_EBS = "ci_services_ebs"
-    BUILDER_AMD = ["self-hosted", "altinity-on-demand", "altinity-type-ccx43", "altinity-setup-create_snapshot", "altinity-image-x86-system-ubuntu-22.04"]
-    BUILDER_ARM = ["self-hosted", "altinity-on-demand", "altinity-type-ccx43", "altinity-setup-create_snapshot", "altinity-image-x86-system-ubuntu-22.04"]
+    BUILDER_AMD = ["self-hosted", "altinity-on-demand", "altinity-type-ccx43", "altinity-setup-builder", "altinity-image-x86-system-ubuntu-22.04"]
+    BUILDER_ARM = ["self-hosted", "altinity-on-demand", "altinity-type-ccx43", "altinity-setup-builder", "altinity-image-x86-system-ubuntu-22.04"]
     FUNC_TESTER_AMD = ["self-hosted", "altinity-on-demand", "altinity-func-tester"]
     FUNC_TESTER_ARM = [
         "self-hosted",

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -16,8 +16,8 @@ S3_REPORT_BUCKET_HTTP_ENDPOINT = altinity_overrides.S3_REPORT_BUCKET_HTTP_ENDPOI
 class RunnerLabels:
     CI_SERVICES = "ci_services"
     CI_SERVICES_EBS = "ci_services_ebs"
-    BUILDER_AMD = ["self-hosted", "altinity-on-demand", "altinity-builder"]
-    BUILDER_ARM = ["self-hosted", "altinity-on-demand", "altinity-builder"]
+    BUILDER_AMD = ["self-hosted", "altinity-on-demand", "altinity-type-ccx43", "altinity-setup-create_snapshot", "altinity-image-x86-system-ubuntu-22.04"]
+    BUILDER_ARM = ["self-hosted", "altinity-on-demand", "altinity-type-ccx43", "altinity-setup-create_snapshot", "altinity-image-x86-system-ubuntu-22.04"]
     FUNC_TESTER_AMD = ["self-hosted", "altinity-on-demand", "altinity-func-tester"]
     FUNC_TESTER_ARM = [
         "self-hosted",


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [ ] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
