### PR TITLE
Antalya-26.3 - Try smaller runners for regression [CI Cost Reduction]

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -5708,7 +5708,6 @@ jobs:
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
-      runner_type: altinity-regression-tester
       commit: release
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -5720,7 +5719,6 @@ jobs:
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
-      runner_type: altinity-regression-tester-aarch64
       commit: release
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5519,7 +5519,6 @@ jobs:
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
-      runner_type: altinity-regression-tester
       commit: release
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -5531,7 +5530,6 @@ jobs:
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
-      runner_type: altinity-regression-tester-aarch64
       commit: release
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -133,7 +133,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: ${{ matrix.SUITE }}
@@ -157,7 +157,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -187,7 +187,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       storage_path: /${{ matrix.ONLY }}_partition
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
@@ -214,7 +214,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       storage_path: /${{ matrix.STORAGE }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -241,7 +241,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       storage_path: /${{ matrix.SSL }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
@@ -268,7 +268,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -293,7 +293,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: ldap_${{ matrix.SUITE }}
@@ -313,7 +313,7 @@ jobs:
       flags: --with-analyzer --identity-provider keycloak
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: oauth
@@ -333,7 +333,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: parquet
@@ -357,7 +357,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       storage_path: ${{ matrix.STORAGE }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -383,7 +383,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -408,7 +408,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -438,7 +438,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       storage_path: /${{ matrix.STORAGE }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
@@ -466,7 +466,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       storage_path: /minio
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
@@ -490,7 +490,7 @@ jobs:
         flags: --with-analyzer
         timeout_minutes: ${{ inputs.timeout_minutes }}
         runner_arch: ${{ inputs.arch }}
-        runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+        runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
         build_sha: ${{ inputs.build_sha }}
         set_commit_status: true
         job_name: swarms
@@ -514,7 +514,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-style-checker-aarch64' || 'altinity-style-checker' }}
       storage_path: /${{ matrix.STORAGE }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -2,10 +2,6 @@ name: Regression test workflow - Release
 'on':
   workflow_call:
     inputs:
-      runner_type:
-        description: the (meta-)label of runner to use
-        required: true
-        type: string
       commit:
         description: commit hash of the regression tests.
         required: true
@@ -137,7 +133,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: ${{ matrix.SUITE }}
@@ -161,7 +157,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -191,7 +187,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       storage_path: /${{ matrix.ONLY }}_partition
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
@@ -218,7 +214,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       storage_path: /${{ matrix.STORAGE }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -245,7 +241,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       storage_path: /${{ matrix.SSL }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
@@ -272,7 +268,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -297,7 +293,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: ldap_${{ matrix.SUITE }}
@@ -317,7 +313,7 @@ jobs:
       flags: --with-analyzer --identity-provider keycloak
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: oauth
@@ -337,7 +333,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: parquet
@@ -361,7 +357,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       storage_path: ${{ matrix.STORAGE }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -387,7 +383,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -412,7 +408,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
@@ -442,7 +438,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       storage_path: /${{ matrix.STORAGE }}
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
@@ -470,7 +466,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       storage_path: /minio
       part: ${{ matrix.PART }}
       build_sha: ${{ inputs.build_sha }}
@@ -494,7 +490,7 @@ jobs:
         flags: --with-analyzer
         timeout_minutes: ${{ inputs.timeout_minutes }}
         runner_arch: ${{ inputs.arch }}
-        runner_type: ${{ inputs.runner_type }}
+        runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
         build_sha: ${{ inputs.build_sha }}
         set_commit_status: true
         job_name: swarms
@@ -518,7 +514,7 @@ jobs:
       flags: --with-analyzer
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner_arch: ${{ inputs.arch }}
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.arch == 'aarch64' && 'altinity-regression-tester-aarch64' || 'altinity-regression-tester' }}
       storage_path: /${{ matrix.STORAGE }}
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -67,7 +67,6 @@ class AltinityWorkflowTemplates:
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
-      runner_type: altinity-regression-tester
       commit: {REGRESSION_HASH}
       arch: release
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -79,7 +78,6 @@ class AltinityWorkflowTemplates:
     uses: ./.github/workflows/regression.yml
     secrets: inherit
     with:
-      runner_type: altinity-regression-tester-aarch64
       commit: {REGRESSION_HASH}
       arch: aarch64
       build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Testing what suites can tolerate tiny runners.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_oauth--> OAuth (5m)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
