### PR TITLE
Antalya 26.3: Update broken tests

### DIFF
--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -29,6 +29,9 @@
 - name: 03441_deltalake_clickhouse_virtual_columns
   reason: INVESTIGATE - S3 sometimes unreachable
   message: 'Error interacting with object store: Generic S3 error: Error performing GET'
+- name: 00157_cache_dictionary
+  reason: 'KNOWN: Timeout on slow Altinity runners (passes upstream)'
+  message: 'DB::Exception: Timeout exceeded' 
 - name: 00167_read_bytes_from_fs
   reason: INVESTIGATE - Memory limit exceeded
   message: 'DB::Exception: (total) memory limit exceeded:'
@@ -149,6 +152,12 @@
   - tsan
   - asan
 - name: test_scheduler_cpu_preemptive/test.py::test_cpu_time_fairness[fixed_longer_prd]
+  reason: INVESTIGATE - Unstable on tsan, msan
+  message: 'Failed: Timeout (>900.0s)'
+  check_types:
+  - tsan
+  - msan
+- name: test_scheduler_cpu_preemptive/test.py::test_cpu_time_fairness[random_longer_prd]
   reason: INVESTIGATE - Unstable on tsan, msan
   message: 'Failed: Timeout (>900.0s)'
   check_types:

--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -133,6 +133,11 @@
   message: 'curl: (28) Operation timed out'
   check_types:
   - debug
+- name: 03443_shared_storage_snapshots
+  reason: KNOWN - Unstable on asan
+  message: 'All iterations has been failed. Unable to test snapshot sharing disabled'
+  check_types:
+  - asan
 - name: test_storage_s3_queue/test_5.py::test_migration[1-s3queue_]
   reason: KNOWN - Sometimes fails due to test order
   message: 'Failed: Timeout >900.0s'

--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -138,6 +138,11 @@
   message: 'All iterations has been failed. Unable to test snapshot sharing disabled'
   check_types:
   - asan
+- name: 03572_export_merge_tree_part_limits_and_table_functions
+  reason: 'INVESTIGATE - Unstable on tsan'
+  message: 'timeout: 60s'
+  check_types:
+  - tsan
 - name: test_storage_s3_queue/test_5.py::test_migration[1-s3queue_]
   reason: KNOWN - Sometimes fails due to test order
   message: 'Failed: Timeout >900.0s'


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_oauth--> OAuth (5m)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
