### PR TITLE
Antalya 26.5: Antalya 26.3 Backport - Added test cases for s3 encoding fix

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_path_resolver.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_path_resolver.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+
+#include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
+
+using namespace DB::Iceberg;
+
+TEST(GetProperFilePathFromMetadataInfo, S3SchemePreservesPercentEncodedSlash)
+{
+    auto result = getProperFilePathFromMetadataInfo(
+        "s3://bucket/warehouse/data/partition=us%2Fwest/file.parquet",
+        "warehouse",
+        "s3://bucket/warehouse");
+    ASSERT_EQ(result, "warehouse/data/partition=us%2Fwest/file.parquet");
+}
+
+TEST(GetProperFilePathFromMetadataInfo, SimpleKeyWithoutEncoding)
+{
+    auto result = getProperFilePathFromMetadataInfo(
+        "s3://bucket/warehouse/data/file.parquet",
+        "warehouse",
+        "s3://bucket/warehouse");
+    ASSERT_EQ(result, "warehouse/data/file.parquet");
+}
+
+TEST(GetProperFilePathFromMetadataInfo, MultiplePercentEncodedSegments)
+{
+    auto result = getProperFilePathFromMetadataInfo(
+        "s3://bucket/warehouse/data/region=us%2Fwest/city=san%20francisco/file.parquet",
+        "warehouse",
+        "s3://bucket/warehouse");
+    ASSERT_EQ(result, "warehouse/data/region=us%2Fwest/city=san%20francisco/file.parquet");
+}
+
+TEST(GetProperFilePathFromMetadataInfo, HttpSchemePreservesPercentEncodedSlash)
+{
+    auto result = getProperFilePathFromMetadataInfo(
+        "http://minio:9000/bucket/warehouse/data/partition=us%2Fwest/file.parquet",
+        "warehouse",
+        "http://minio:9000/bucket/warehouse");
+    ASSERT_EQ(result, "warehouse/data/partition=us%2Fwest/file.parquet");
+}

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -795,6 +795,50 @@ def test_table_with_slash(started_cluster):
     assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_encoded_name}`") == "\\N\tAAPL\t193.24\t193.31\t('bot')\n"
 
 
+def test_partition_value_with_slash(started_cluster):
+    """Partition value containing '/' produces object keys with %2F; reading must preserve encoding."""
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_partition_slash_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    partition_spec = PartitionSpec(
+        PartitionField(
+            source_id=2, field_id=1000, transform=IdentityTransform(), name="symbol"
+        )
+    )
+    schema = DEFAULT_SCHEMA
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(root_namespace)
+
+    table = create_table(
+        catalog,
+        root_namespace,
+        table_name,
+        schema,
+        partition_spec=partition_spec,
+        sort_order=DEFAULT_SORT_ORDER,
+    )
+
+    data = [
+        {
+            "datetime": datetime.now(),
+            "symbol": "us/west",
+            "bid": 100.0,
+            "ask": 101.0,
+            "details": {"created_by": "test"},
+        }
+    ]
+    df = pa.Table.from_pylist(data)
+    table.append(df)
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+    assert 1 == int(node.query(f"SELECT count() FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`"))
+    assert "us/west" in node.query(f"SELECT symbol FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`")
+
+
 def test_cluster_select(started_cluster):
     node1 = started_cluster.instances["node1"]
     node2 = started_cluster.instances["node2"]


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Backport of https://github.com/Altinity/ClickHouse/pull/1516, unit/integration tests added.  The original fix was in the `resolveObjectStorageForPath` function(Utils.cpp) which was renamed/rewritten to `getProperFilePathFromMetadataInfo`. The tests are to make sure % encoded URLs still work in iceberg. closes https://github.com/Altinity/ClickHouse/issues/1348 (https://github.com/Altinity/ClickHouse/pull/1781 by @subkanthi).

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)

Cherry-picked from #1781.

---

### Documentation entry for user-facing changes
Backport of https://github.com/Altinity/ClickHouse/pull/1516, unit tests added.