### PR TITLE
Antalya 26.5 - fix ci self-tests

### DIFF
--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -36,6 +36,7 @@ class CIDB:
         Result.Status.DROPPED: "dropped",
         Result.Status.UNKNOWN: "failure",
         Result.Status.XFAIL: "success",
+        Result.Status.BROKEN: "success",
         Result.Status.XPASS: "failure",
     }
 

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -871,6 +871,7 @@ class GH:
         Result.Status.DROPPED: Result.GHStatus.ERROR,
         Result.Status.UNKNOWN: Result.GHStatus.FAILURE,
         Result.Status.XFAIL: Result.GHStatus.SUCCESS,
+        Result.Status.BROKEN: Result.GHStatus.SUCCESS,
         Result.Status.XPASS: Result.GHStatus.FAILURE,
     }
 

--- a/ci/tests/test_result.py
+++ b/ci/tests/test_result.py
@@ -29,6 +29,7 @@ ALL_STATUSES = {
     Result.Status.PENDING,
     Result.Status.RUNNING,
     Result.Status.DROPPED,
+    Result.Status.BROKEN,
 }
 
 
@@ -64,7 +65,7 @@ def test_status_values_are_unique():
 # --- is_ok / is_success / is_failure / is_error ---
 
 def test_is_ok():
-    ok_statuses = {Result.Status.OK, Result.Status.SKIPPED, Result.Status.XFAIL}
+    ok_statuses = {Result.Status.OK, Result.Status.SKIPPED, Result.Status.BROKEN, Result.Status.XFAIL}
     not_ok = ALL_STATUSES - ok_statuses
     for s in ok_statuses:
         assert Result("t", s).is_ok(), f"{s} should be ok"
@@ -73,7 +74,7 @@ def test_is_ok():
 
 
 def test_is_success():
-    success_statuses = {Result.Status.OK, Result.Status.XFAIL}
+    success_statuses = {Result.Status.OK, Result.Status.BROKEN, Result.Status.XFAIL}
     for s in success_statuses:
         assert Result("t", s).is_success(), f"{s} should be success"
     for s in ALL_STATUSES - success_statuses:


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
