### PR TITLE
[WIP] Allow global join for right table in distributed queries

### DIFF
--- a/src/Storages/IStorageCluster.cpp
+++ b/src/Storages/IStorageCluster.cpp
@@ -332,7 +332,7 @@ void IStorageCluster::updateQueryWithJoinToSendIfNeeded(
             modified_query_tree = buildQueryTreeForShard(
                 query_info.planner_context,
                 modified_query_tree,
-                /*allow_global_join_for_right_table*/ false,
+                /*allow_global_join_for_right_table*/ true,
                 /*find_cross_join*/ true);
             query_to_send = queryNodeToDistributedSelectQuery(modified_query_tree);
         }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Solved #1664

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix right outer join in cluster requests
