### PR TITLE
Preserve a few settings to partition export

### DIFF
--- a/src/Storages/ExportReplicatedMergeTreePartitionManifest.h
+++ b/src/Storages/ExportReplicatedMergeTreePartitionManifest.h
@@ -176,8 +176,9 @@ struct ExportReplicatedMergeTreePartitionManifest
     bool allow_lossy_cast = false;
     String iceberg_metadata_json;
     String parquet_compression_method;
-    UInt64 output_format_compression_level = 3;
-    UInt64 parquet_row_group_size = 1000000;
+    UInt64 output_format_compression_level;
+    UInt64 parquet_row_group_size;
+    UInt64 parquet_row_group_size_bytes;
 
     std::string toJsonString() const
     {
@@ -214,6 +215,7 @@ struct ExportReplicatedMergeTreePartitionManifest
         json.set("parquet_compression_method", parquet_compression_method);
         json.set("output_format_compression_level", output_format_compression_level);
         json.set("parquet_row_group_size", parquet_row_group_size);
+        json.set("parquet_row_group_size_bytes", parquet_row_group_size_bytes);
         std::ostringstream oss;     // STYLE_CHECK_ALLOW_STD_STRING_STREAM
         oss.exceptions(std::ios::failbit);
         Poco::JSON::Stringifier::stringify(json, oss);
@@ -272,9 +274,10 @@ struct ExportReplicatedMergeTreePartitionManifest
         /// on upgrade. New tasks always persist the initiator's actual choice.
         manifest.allow_lossy_cast = json->has("allow_lossy_cast") ? json->getValue<bool>("allow_lossy_cast") : true;
 
-        manifest.parquet_compression_method = json->has("parquet_compression_method") ? json->getValue<String>("parquet_compression_method") : "zstd";
-        manifest.output_format_compression_level = json->has("output_format_compression_level") ? json->getValue<UInt64>("output_format_compression_level") : 3;
-        manifest.parquet_row_group_size = json->has("parquet_row_group_size") ? json->getValue<UInt64>("parquet_row_group_size") : 1000000;
+        manifest.parquet_compression_method = json->getValue<String>("parquet_compression_method");
+        manifest.output_format_compression_level = json->getValue<UInt64>("output_format_compression_level");
+        manifest.parquet_row_group_size = json->getValue<UInt64>("parquet_row_group_size");
+        manifest.parquet_row_group_size_bytes = json->getValue<UInt64>("parquet_row_group_size_bytes");
 
         return manifest;
     }

--- a/src/Storages/ExportReplicatedMergeTreePartitionManifest.h
+++ b/src/Storages/ExportReplicatedMergeTreePartitionManifest.h
@@ -175,6 +175,9 @@ struct ExportReplicatedMergeTreePartitionManifest
     bool write_full_path_in_iceberg_metadata = false;
     bool allow_lossy_cast = false;
     String iceberg_metadata_json;
+    String parquet_compression_method;
+    UInt64 output_format_compression_level = 3;
+    UInt64 parquet_row_group_size = 1000000;
 
     std::string toJsonString() const
     {
@@ -208,6 +211,9 @@ struct ExportReplicatedMergeTreePartitionManifest
         json.set("task_timeout_seconds", task_timeout_seconds);
         json.set("write_full_path_in_iceberg_metadata", write_full_path_in_iceberg_metadata);
         json.set("allow_lossy_cast", allow_lossy_cast);
+        json.set("parquet_compression_method", parquet_compression_method);
+        json.set("output_format_compression_level", output_format_compression_level);
+        json.set("parquet_row_group_size", parquet_row_group_size);
         std::ostringstream oss;     // STYLE_CHECK_ALLOW_STD_STRING_STREAM
         oss.exceptions(std::ios::failbit);
         Poco::JSON::Stringifier::stringify(json, oss);
@@ -265,6 +271,10 @@ struct ExportReplicatedMergeTreePartitionManifest
         /// export scheduled with the old permissive worker behavior is not wrongly rejected
         /// on upgrade. New tasks always persist the initiator's actual choice.
         manifest.allow_lossy_cast = json->has("allow_lossy_cast") ? json->getValue<bool>("allow_lossy_cast") : true;
+
+        manifest.parquet_compression_method = json->has("parquet_compression_method") ? json->getValue<String>("parquet_compression_method") : "zstd";
+        manifest.output_format_compression_level = json->has("output_format_compression_level") ? json->getValue<UInt64>("output_format_compression_level") : 3;
+        manifest.parquet_row_group_size = json->has("parquet_row_group_size") ? json->getValue<UInt64>("parquet_row_group_size") : 1000000;
 
         return manifest;
     }

--- a/src/Storages/MergeTree/ExportPartitionUtils.cpp
+++ b/src/Storages/MergeTree/ExportPartitionUtils.cpp
@@ -81,6 +81,9 @@ namespace ExportPartitionUtils
         context_copy->setCurrentQueryId(manifest.query_id);
         context_copy->setSetting("output_format_parallel_formatting", manifest.parallel_formatting);
         context_copy->setSetting("output_format_parquet_parallel_encoding", manifest.parquet_parallel_encoding);
+        context_copy->setSetting("output_format_parquet_compression_method", manifest.parquet_compression_method);
+        context_copy->setSetting("output_format_compression_level", manifest.output_format_compression_level);
+        context_copy->setSetting("output_format_parquet_row_group_size", manifest.parquet_row_group_size);
         context_copy->setSetting("max_threads", manifest.max_threads);
         context_copy->setSetting("export_merge_tree_part_file_already_exists_policy", String(magic_enum::enum_name(manifest.file_already_exists_policy)));
         context_copy->setSetting("export_merge_tree_part_max_bytes_per_file", manifest.max_bytes_per_file);

--- a/src/Storages/MergeTree/ExportPartitionUtils.cpp
+++ b/src/Storages/MergeTree/ExportPartitionUtils.cpp
@@ -84,6 +84,7 @@ namespace ExportPartitionUtils
         context_copy->setSetting("output_format_parquet_compression_method", manifest.parquet_compression_method);
         context_copy->setSetting("output_format_compression_level", manifest.output_format_compression_level);
         context_copy->setSetting("output_format_parquet_row_group_size", manifest.parquet_row_group_size);
+        context_copy->setSetting("output_format_parquet_row_group_size_bytes", manifest.parquet_row_group_size_bytes);
         context_copy->setSetting("max_threads", manifest.max_threads);
         context_copy->setSetting("export_merge_tree_part_file_already_exists_policy", String(magic_enum::enum_name(manifest.file_already_exists_policy)));
         context_copy->setSetting("export_merge_tree_part_max_bytes_per_file", manifest.max_bytes_per_file);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -218,6 +218,9 @@ namespace Setting
     extern const SettingsUInt64 export_merge_tree_partition_task_timeout_seconds;
     extern const SettingsBool output_format_parallel_formatting;
     extern const SettingsBool output_format_parquet_parallel_encoding;
+    extern const SettingsParquetCompression output_format_parquet_compression_method;
+    extern const SettingsUInt64 output_format_compression_level;
+    extern const SettingsUInt64 output_format_parquet_row_group_size;
     extern const SettingsMaxThreads max_threads;
     extern const SettingsMergeTreePartExportFileAlreadyExistsPolicy export_merge_tree_part_file_already_exists_policy;
     extern const SettingsUInt64 export_merge_tree_part_max_bytes_per_file;
@@ -8505,6 +8508,9 @@ void StorageReplicatedMergeTree::exportPartitionToTable(const PartitionCommand &
     manifest.max_threads = query_context->getSettingsRef()[Setting::max_threads];
     manifest.parallel_formatting = query_context->getSettingsRef()[Setting::output_format_parallel_formatting];
     manifest.parquet_parallel_encoding = query_context->getSettingsRef()[Setting::output_format_parquet_parallel_encoding];
+    manifest.parquet_compression_method = query_context->getSettingsRef()[Setting::output_format_parquet_compression_method].toString();
+    manifest.output_format_compression_level = query_context->getSettingsRef()[Setting::output_format_compression_level];
+    manifest.parquet_row_group_size = query_context->getSettingsRef()[Setting::output_format_parquet_row_group_size];
     manifest.max_bytes_per_file = query_context->getSettingsRef()[Setting::export_merge_tree_part_max_bytes_per_file];
     manifest.max_rows_per_file = query_context->getSettingsRef()[Setting::export_merge_tree_part_max_rows_per_file];
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -221,6 +221,7 @@ namespace Setting
     extern const SettingsParquetCompression output_format_parquet_compression_method;
     extern const SettingsUInt64 output_format_compression_level;
     extern const SettingsUInt64 output_format_parquet_row_group_size;
+    extern const SettingsUInt64 output_format_parquet_row_group_size_bytes;
     extern const SettingsMaxThreads max_threads;
     extern const SettingsMergeTreePartExportFileAlreadyExistsPolicy export_merge_tree_part_file_already_exists_policy;
     extern const SettingsUInt64 export_merge_tree_part_max_bytes_per_file;
@@ -8511,6 +8512,7 @@ void StorageReplicatedMergeTree::exportPartitionToTable(const PartitionCommand &
     manifest.parquet_compression_method = query_context->getSettingsRef()[Setting::output_format_parquet_compression_method].toString();
     manifest.output_format_compression_level = query_context->getSettingsRef()[Setting::output_format_compression_level];
     manifest.parquet_row_group_size = query_context->getSettingsRef()[Setting::output_format_parquet_row_group_size];
+    manifest.parquet_row_group_size_bytes = query_context->getSettingsRef()[Setting::output_format_parquet_row_group_size_bytes];
     manifest.max_bytes_per_file = query_context->getSettingsRef()[Setting::export_merge_tree_part_max_bytes_per_file];
     manifest.max_rows_per_file = query_context->getSettingsRef()[Setting::export_merge_tree_part_max_rows_per_file];
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Route a few more settings through export partition to export part: `output_format_parquet_compression_method`, `output_format_compression_level`, `output_format_parquet_row_group_size` and `output_format_parquet_row_group_size_bytes`.

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
