### PR TITLE
Antalya 26.3 - Fix PRs in Release table

### DIFF
--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -311,12 +311,15 @@ def _find_rebase_baseline(branch_ref: str, cwd: str | None) -> str | None:
             "git",
             "log",
             branch_ref,
-            "--reverse",
+            "--first-parent",
+            "-n",
+            "1",
             "-i",
             "-E",
             "--grep=^Rebase CICD",
             "--grep=Merge pull request .*rebase-cicd",
             "--grep=Merge pull request .*from Altinity/rebase/",
+            "--grep=Merge pull request .*from Altinity/bump/",
             "--format=%H",
         ],
         cwd=cwd,
@@ -339,7 +342,7 @@ def get_prs_in_release_dataframe(
 ) -> pd.DataFrame:
     f"""
     PRs merged into branch_ref that belong in the next release notes: after the latest GitHub
-    Release tag on this history, or after the oldest rebase bootstrap if no such tag exists.
+    Release tag on this history, or after the latest bootstrap merge if no such tag exists.
     Only merge commits whose subject has from <repo_owner>/ (e.g. from Altinity/) are included.
     Columns: pr_number, pr_name, labels. Omits PRs labeled cicd.
     """
@@ -356,11 +359,11 @@ def get_prs_in_release_dataframe(
         check=False,
     )
 
-    baseline_ref, baseline_sha = _find_release_baseline(branch_ref, repo, cwd)
+    _, baseline_sha = _find_release_baseline(branch_ref, repo, cwd)
     if not baseline_sha:
-        # If no release tag, try to find rebase commit 200 commits back.
+        # If no release tag, search recent history for the latest branch bootstrap merge.
         subprocess.run(
-            ["git", "fetch", "--deepen=200", "origin", branch_ref],
+            ["git", "fetch", "--deepen=500", "origin", branch_ref],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -1066,6 +1069,7 @@ def create_workflow_report(
         "regression_fails": get_regression_fails(db_client, actions_run_url),
         "docker_images_cves": [],
     }
+    known_fails = {}
 
     if pr_number == 0 and not mark_preview:
         try:


### PR DESCRIPTION
When no release tag exists, choose the latest bootstrap merge from first-parent history and match `Altinity/bump` subjects, and initialize `known_fails` to avoid an `UnboundLocalError` in report rendering.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
