### PR TITLE
Change export partition log levels

### DIFF
--- a/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.cpp
+++ b/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.cpp
@@ -63,7 +63,7 @@ namespace
         ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperGetChildren);
         if (Coordination::Error::ZOK != zk->tryGetChildren(container_path, children))
         {
-            LOG_INFO(log, "ExportPartition Manifest Updating Task: failed to list last_exception leaves for {}, leaving in-memory copy untouched", log_key);
+            LOG_WARNING(log, "ExportPartition Manifest Updating Task: failed to list last_exception leaves for {}, leaving in-memory copy untouched", log_key);
             return out;
         }
 
@@ -140,7 +140,7 @@ namespace
                 fs::path(entry_path) / "commit_lock", *zk, storage.getReplicaName());
             if (!commit_lock)
             {
-                LOG_INFO(log, "ExportPartition Manifest Updating Task: commit in progress for {}, skipping timeout kill", entry_path);
+                LOG_DEBUG(log, "ExportPartition Manifest Updating Task: commit in progress for {}, skipping timeout kill", entry_path);
                 return;
             }
 
@@ -153,14 +153,14 @@ namespace
             ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperGet);
             if (!zk->tryGet(status_path, status_string, &status_stat))
             {
-                LOG_INFO(log, "ExportPartition Manifest Updating Task: Failed to read status for {} while enforcing task timeout, skipping", entry_path);
+                LOG_WARNING(log, "ExportPartition Manifest Updating Task: Failed to read status for {} while enforcing task timeout, skipping", entry_path);
                 return;
             }
 
             const auto current_status = magic_enum::enum_cast<ExportReplicatedMergeTreePartitionTaskEntry::Status>(status_string);
             if (!current_status || *current_status != ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING)
             {
-                LOG_INFO(log, "ExportPartition Manifest Updating Task: Task {} is not PENDING, can't set to KILLED, skipping", entry_path);
+                LOG_DEBUG(log, "ExportPartition Manifest Updating Task: Task {} is not PENDING, can't set to KILLED, skipping", entry_path);
                 return;
             }
 
@@ -195,7 +195,7 @@ namespace
                 /// ZBADVERSION (status changed), ZNODEEXISTS (lazy-create race with the scheduler),
                 /// counter race, or ZNONODE (entry concurrently removed). In all cases the batch
                 /// was rolled back atomically and the task will be re-evaluated on the next poll.
-                LOG_INFO(log,
+                LOG_DEBUG(log,
                     "ExportPartition Manifest Updating Task: atomic kill for {} failed (rc={}); "
                     "status was concurrently updated or a ZK op conflicted, will retry on next poll",
                     entry_path, rc);
@@ -215,19 +215,19 @@ namespace
             if (Coordination::Error::ZOK != zk->tryGetChildren(fs::path(entry_path) / "processing", parts_in_processing_or_pending))
             {
 
-                LOG_INFO(log, "ExportPartition Manifest Updating Task: Failed to get parts in processing or pending, skipping");
+                LOG_WARNING(log, "ExportPartition Manifest Updating Task: Failed to get parts in processing or pending, skipping");
                 return;
             }
 
             if (parts_in_processing_or_pending.empty())
             {
-                LOG_INFO(log, "ExportPartition Manifest Updating Task: Cleanup found PENDING for {} with all parts exported, deferring commit recovery to post-lock phase", entry_path);
+                LOG_DEBUG(log, "ExportPartition Manifest Updating Task: Cleanup found PENDING for {} with all parts exported, deferring commit recovery to post-lock phase", entry_path);
 
                 const auto destination_storage_id = StorageID(QualifiedTableName {metadata.destination_database, metadata.destination_table});
                 const auto destination_storage = DatabaseCatalog::instance().tryGetTable(destination_storage_id, context);
                 if (!destination_storage)
                 {
-                    LOG_INFO(log, "ExportPartition Manifest Updating Task: Failed to reconstruct destination storage: {}, skipping", destination_storage_id.getNameForLogs());
+                    LOG_WARNING(log, "ExportPartition Manifest Updating Task: Failed to reconstruct destination storage: {}, skipping", destination_storage_id.getNameForLogs());
                     return;
                 }
 
@@ -312,7 +312,7 @@ void ExportPartitionManifestUpdatingTask::poll()
     auto cleanup_lock = zkutil::EphemeralNodeHolder::tryCreate(cleanup_lock_path, *zk, storage.replica_name);
     if (cleanup_lock)
     {
-        LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Cleanup lock acquired, will remove stale entries");
+        LOG_DEBUG(storage.log, "ExportPartition Manifest Updating Task: Cleanup lock acquired, will remove stale entries");
     }
 
     {
@@ -329,7 +329,7 @@ void ExportPartitionManifestUpdatingTask::poll()
 
         auto & entries_by_key = working_model->get<ExportPartitionTaskEntryTagByCompositeKey>();
 
-        LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Polling for new entries for table {}. Current number of entries: {}", storage.getStorageID().getNameForLogs(), entries_by_key.size());
+        LOG_DEBUG(storage.log, "ExportPartition Manifest Updating Task: Polling for new entries for table {}. Current number of entries: {}", storage.getStorageID().getNameForLogs(), entries_by_key.size());
 
         ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperRequests);
         ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperGetChildrenWatch);
@@ -352,7 +352,7 @@ void ExportPartitionManifestUpdatingTask::poll()
             std::string metadata_json;
             if (!zk->tryGet(fs::path(entry_path) / "metadata.json", metadata_json))
             {
-                LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing metadata.json", key);
+                LOG_DEBUG(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing metadata.json", key);
                 continue;
             }
 
@@ -402,14 +402,14 @@ void ExportPartitionManifestUpdatingTask::poll()
 
             if (status_string.empty())
             {
-                LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing status", key);
+                LOG_DEBUG(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing status", key);
                 continue;
             }
 
             const auto status = magic_enum::enum_cast<ExportReplicatedMergeTreePartitionTaskEntry::Status>(status_string);
             if (!status)
             {
-                LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Invalid status {} for task {}, skipping", status_string, key);
+                LOG_WARNING(storage.log, "ExportPartition Manifest Updating Task: Invalid status {} for task {}, skipping", status_string, key);
                 continue;
             }
 
@@ -458,7 +458,7 @@ void ExportPartitionManifestUpdatingTask::poll()
                     }
                 }
             }
-            LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: already exists", key);
+            LOG_DEBUG(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: already exists", key);
             
         }
 
@@ -470,7 +470,7 @@ void ExportPartitionManifestUpdatingTask::poll()
         /// `entries_by_key` (a reference into it) must not be used afterwards.
         storage.export_partition_manifests.set(std::move(working_model));
 
-        LOG_INFO(storage.log, "ExportPartition Manifest Updating task: finished polling for new entries. Number of entries: {}", entries_count);
+        LOG_DEBUG(storage.log, "ExportPartition Manifest Updating task: finished polling for new entries. Number of entries: {}", entries_count);
     }
 
     const auto log_ptr = storage.log.load();
@@ -603,7 +603,7 @@ void ExportPartitionManifestUpdatingTask::handleStatusChanges()
 
         const bool had_changes = !local_status_changes.empty();
 
-        LOG_INFO(storage.log, "ExportPartition Manifest Updating task: handling status changes. Number of status changes: {}", local_status_changes.size());
+        LOG_DEBUG(storage.log, "ExportPartition Manifest Updating task: handling status changes. Number of status changes: {}", local_status_changes.size());
 
         const auto current_model = storage.export_partition_manifests.get();
         auto working_model = current_model
@@ -635,7 +635,7 @@ void ExportPartitionManifestUpdatingTask::handleStatusChanges()
             std::string new_status_string;
             if (!zk->tryGet(fs::path(storage.zookeeper_path) / "exports" / key / "status", new_status_string))
             {
-                LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Failed to get new status for task {}, skipping", key);
+                LOG_WARNING(storage.log, "ExportPartition Manifest Updating Task: Failed to get new status for task {}, skipping", key);
                 local_status_changes.pop();
                 continue;
             }
@@ -643,7 +643,7 @@ void ExportPartitionManifestUpdatingTask::handleStatusChanges()
             const auto new_status = magic_enum::enum_cast<ExportReplicatedMergeTreePartitionTaskEntry::Status>(new_status_string);
             if (!new_status)
             {
-                LOG_INFO(storage.log, "ExportPartition Manifest Updating Task: Invalid status {} for task {}, skipping", new_status_string, key);
+                LOG_WARNING(storage.log, "ExportPartition Manifest Updating Task: Invalid status {} for task {}, skipping", new_status_string, key);
                 local_status_changes.pop();
                 continue;
             }
@@ -691,7 +691,7 @@ void ExportPartitionManifestUpdatingTask::handleStatusChanges()
     {
         tryLogCurrentException(storage.log, __PRETTY_FUNCTION__);
 
-        LOG_INFO(storage.log, "ExportPartition Manifest Updating task: exception thrown while handling status changes; nothing was published, requeuing the whole batch. Batch size: {}", batch.size());
+        LOG_WARNING(storage.log, "ExportPartition Manifest Updating task: exception thrown while handling status changes; nothing was published, requeuing the whole batch. Batch size: {}", batch.size());
 
         std::lock_guard lock(status_changes_mutex);
 
@@ -708,7 +708,7 @@ void ExportPartitionManifestUpdatingTask::handleStatusChanges()
             std::swap(status_changes, requeued);
         }
 
-        LOG_INFO(storage.log, "ExportPartition Manifest Updating task: pending status changes after requeue: {}", status_changes.size());
+        LOG_DEBUG(storage.log, "ExportPartition Manifest Updating task: pending status changes after requeue: {}", status_changes.size());
 
         throw;
     }

--- a/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.cpp
+++ b/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.cpp
@@ -352,7 +352,7 @@ void ExportPartitionManifestUpdatingTask::poll()
             std::string metadata_json;
             if (!zk->tryGet(fs::path(entry_path) / "metadata.json", metadata_json))
             {
-                LOG_DEBUG(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing metadata.json", key);
+                LOG_WARNING(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing metadata.json", key);
                 continue;
             }
 

--- a/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.cpp
+++ b/src/Storages/MergeTree/ExportPartitionManifestUpdatingTask.cpp
@@ -402,7 +402,7 @@ void ExportPartitionManifestUpdatingTask::poll()
 
             if (status_string.empty())
             {
-                LOG_DEBUG(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing status", key);
+                LOG_WARNING(storage.log, "ExportPartition Manifest Updating Task: Skipping {}: missing status", key);
                 continue;
             }
 

--- a/src/Storages/MergeTree/ExportPartitionTaskScheduler.cpp
+++ b/src/Storages/MergeTree/ExportPartitionTaskScheduler.cpp
@@ -52,7 +52,7 @@ void ExportPartitionTaskScheduler::run()
     /// this is subject to TOCTOU - but for now we choose to live with it.
     if (available_move_executors == 0)
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: No available move executors, skipping");
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: No available move executors, skipping");
         return;
     }
 
@@ -70,7 +70,7 @@ void ExportPartitionTaskScheduler::run()
         return;
     }
 
-    LOG_INFO(storage.log, "ExportPartition scheduler task: Available move executors: {}", available_move_executors);
+    LOG_DEBUG(storage.log, "ExportPartition scheduler task: Available move executors: {}", available_move_executors);
 
     std::size_t scheduled_exports_count = 0;
 
@@ -91,14 +91,14 @@ void ExportPartitionTaskScheduler::run()
     {
         if (scheduled_exports_count >= available_move_executors)
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: Scheduled exports count is greater than available move executors, skipping");
+            LOG_DEBUG(storage.log, "ExportPartition scheduler task: Scheduled exports count is greater than available move executors, skipping");
             break;
         }
 
         /// No need to query zk for status if the local one is not PENDING
         if (entry.status != ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING)
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: Skipping... Local status is {}", magic_enum::enum_name(entry.status).data());
+            LOG_DEBUG(storage.log, "ExportPartition scheduler task: Skipping... Local status is {}", magic_enum::enum_name(entry.status).data());
             continue;
         }
 
@@ -113,7 +113,7 @@ void ExportPartitionTaskScheduler::run()
 
         if (!destination_storage)
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to reconstruct destination storage: {}, skipping", destination_storage_id.getNameForLogs());
+            LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to reconstruct destination storage: {}, skipping", destination_storage_id.getNameForLogs());
             continue;
         }
 
@@ -122,7 +122,7 @@ void ExportPartitionTaskScheduler::run()
         std::string status_in_zk_string;
         if (!zk->tryGet(fs::path(storage.zookeeper_path) / "exports" / key / "status", status_in_zk_string))
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to get status, skipping");
+            LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to get status, skipping");
             continue;
         }
 
@@ -130,13 +130,13 @@ void ExportPartitionTaskScheduler::run()
 
         if (!status_in_zk)
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to get status from zk, skipping");
+            LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to get status from zk, skipping");
             continue;
         }
 
         if (status_in_zk.value() != ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING)
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: Skipping {}... Status from zk is {}", key, magic_enum::enum_name(status_in_zk.value()).data());
+            LOG_DEBUG(storage.log, "ExportPartition scheduler task: Skipping {}... Status from zk is {}", key, magic_enum::enum_name(status_in_zk.value()).data());
             continue;
         }
 
@@ -146,14 +146,14 @@ void ExportPartitionTaskScheduler::run()
 
         if (Coordination::Error::ZOK != zk->tryGetChildren(fs::path(storage.zookeeper_path) / "exports" / key / "processing", parts_in_processing_or_pending))
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to get parts in processing or pending, skipping");
+            LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to get parts in processing or pending, skipping");
             continue;
         }
 
 
         if (parts_in_processing_or_pending.empty())
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: No parts in processing or pending, skipping");
+            LOG_DEBUG(storage.log, "ExportPartition scheduler task: No parts in processing or pending, skipping");
             continue;
         }
 
@@ -166,7 +166,7 @@ void ExportPartitionTaskScheduler::run()
 
         if (Coordination::Error::ZOK != zk->tryGetChildren(fs::path(storage.zookeeper_path) / "exports" / key / "locks", locked_parts))
         {
-            LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to get locked parts, skipping");
+            LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to get locked parts, skipping");
             continue;
         }
 
@@ -176,20 +176,20 @@ void ExportPartitionTaskScheduler::run()
         {
             if (scheduled_exports_count >= available_move_executors)
             {
-                LOG_INFO(storage.log, "ExportPartition scheduler task: Scheduled exports count is greater than available move executors, skipping");
+                LOG_DEBUG(storage.log, "ExportPartition scheduler task: Scheduled exports count is greater than available move executors, skipping");
                 break;
             }
 
             if (locked_parts_set.contains(zk_part_name))
             {
-                LOG_INFO(storage.log, "ExportPartition scheduler task: Part {} is locked, skipping", zk_part_name);
+                LOG_DEBUG(storage.log, "ExportPartition scheduler task: Part {} is locked, skipping", zk_part_name);
                 continue;
             }
 
             const auto part = storage.getPartIfExists(zk_part_name, {MergeTreeDataPartState::Active, MergeTreeDataPartState::Outdated});
             if (!part)
             {
-                LOG_INFO(storage.log, "ExportPartition scheduler task: Part {} not found locally, skipping", zk_part_name);
+                LOG_DEBUG(storage.log, "ExportPartition scheduler task: Part {} not found locally, skipping", zk_part_name);
                 continue;
             }
 
@@ -199,7 +199,7 @@ void ExportPartitionTaskScheduler::run()
 
             try
             {
-                LOG_INFO(storage.log, "ExportPartition scheduler task: Exporting part to table");
+                LOG_DEBUG(storage.log, "ExportPartition scheduler task: Exporting part to table");
 
                 LOG_INFO(storage.log, "ExportPartition scheduler task: Attempting to lock part: {}", zk_part_name);
 
@@ -280,12 +280,12 @@ void ExportPartitionTaskScheduler::handlePartExportSuccess(
 
     for (const auto & relative_path_in_destination_storage : relative_paths_in_destination_storage)
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: {}", relative_path_in_destination_storage);
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: {}", relative_path_in_destination_storage);
     }
 
     if (!tryToMovePartToProcessed(export_path, processing_parts_path, processed_part_path, part_name, relative_paths_in_destination_storage, zk))
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to move part to processed, will not commit export partition");
+        LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to move part to processed, will not commit export partition");
         return;
     }
 
@@ -352,13 +352,13 @@ void ExportPartitionTaskScheduler::handlePartExportFailure(
     ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperGet);
     if (!zk->tryGet(export_path / "locks" / part_name, locked_by, &locked_by_stat))
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Part {} is not locked by any replica, will not increment error counts", part_name);
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: Part {} is not locked by any replica, will not increment error counts", part_name);
         return;
     }
 
     if (locked_by != storage.replica_name)
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Part {} is locked by another replica, will not increment error counts", part_name);
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: Part {} is locked by another replica, will not increment error counts", part_name);
         return;
     }
 
@@ -385,7 +385,7 @@ void ExportPartitionTaskScheduler::handlePartExportFailure(
 
             if (Coordination::Error::ZBADVERSION == removal_code)
             {
-                LOG_INFO(storage.log, "ExportPartition scheduler task: Part {} lock version mismatch, will not increment error counts", part_name);
+                LOG_DEBUG(storage.log, "ExportPartition scheduler task: Part {} lock version mismatch, will not increment error counts", part_name);
                 break;
             }
 
@@ -404,14 +404,14 @@ void ExportPartitionTaskScheduler::handlePartExportFailure(
     ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperGet);
     if (!zk->tryGet(status_path, current_status, &status_stat))
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: /status missing for {}, skipping failure bookkeeping", export_path.string());
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: /status missing for {}, skipping failure bookkeeping", export_path.string());
         return;
     }
 
     const auto status = magic_enum::enum_cast<ExportReplicatedMergeTreePartitionTaskEntry::Status>(current_status);
     if (!status || *status != ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING)
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: /status for {} is {} (not PENDING), skipping failure bookkeeping", export_path.string(), current_status);
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: /status for {} is {} (not PENDING), skipping failure bookkeeping", export_path.string(), current_status);
         return;
     }
 
@@ -425,7 +425,7 @@ void ExportPartitionTaskScheduler::handlePartExportFailure(
 
     if (!zk->tryGet(processing_part_path, processing_part_string))
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to get processing part, will not increment error counts");
+        LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to get processing part, will not increment error counts");
         return;
     }
 
@@ -446,11 +446,11 @@ void ExportPartitionTaskScheduler::handlePartExportFailure(
         processing_part_entry.finished_by = storage.replica_name;
 
         ops.emplace_back(zkutil::makeSetRequest(status_path, String(magic_enum::enum_name(ExportReplicatedMergeTreePartitionTaskEntry::Status::FAILED)).data(), status_stat.version));
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Retry count limit exceeded for part {}, will try to fail the entire task", part_name);
+        LOG_WARNING(storage.log, "ExportPartition scheduler task: Retry count limit exceeded for part {}, will try to fail the entire task", part_name);
     }
     else
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Retry count limit not exceeded for part {}, will increment retry count", part_name);
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: Retry count limit not exceeded for part {}, will increment retry count", part_name);
     }
 
     ExportPartitionUtils::appendExceptionOps(
@@ -462,7 +462,7 @@ void ExportPartitionTaskScheduler::handlePartExportFailure(
     Coordination::Responses responses;
     if (Coordination::Error::ZOK != zk->tryMulti(ops, responses))
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: All failure mechanism failed, will not try to update it");
+        LOG_WARNING(storage.log, "ExportPartition scheduler task: All failure mechanism failed, will not try to update it");
         return;
     }
 
@@ -485,7 +485,7 @@ bool ExportPartitionTaskScheduler::tryToMovePartToProcessed(
     ProfileEvents::increment(ProfileEvents::ExportPartitionZooKeeperGet);
     if (!zk->tryGet(export_path / "locks" / part_name, locked_by, &locked_by_stat))
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Part {} is not locked by any replica, will not commit or set it as completed", part_name);
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: Part {} is not locked by any replica, will not commit or set it as completed", part_name);
         return false;
     }
 
@@ -493,7 +493,7 @@ bool ExportPartitionTaskScheduler::tryToMovePartToProcessed(
     /// I guess we should not throw if file already exists for export partition, hard coded.
     if (locked_by != storage.replica_name)
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Part {} is locked by another replica, will not commit or set it as completed", part_name);
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: Part {} is locked by another replica, will not commit or set it as completed", part_name);
         return false;
     }
 
@@ -515,7 +515,7 @@ bool ExportPartitionTaskScheduler::tryToMovePartToProcessed(
     {
 
         /// todo  arthur remember what to do here
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to update export path, skipping");
+        LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to update export path, skipping");
         return false;
     }
 
@@ -531,13 +531,13 @@ bool ExportPartitionTaskScheduler::areAllPartsProcessed(
     Strings parts_in_processing_or_pending;
     if (Coordination::Error::ZOK != zk->tryGetChildren(export_path / "processing", parts_in_processing_or_pending))
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: Failed to get parts in processing or pending, will not try to commit export partition");
+        LOG_WARNING(storage.log, "ExportPartition scheduler task: Failed to get parts in processing or pending, will not try to commit export partition");
         return false;
     }
 
     if (!parts_in_processing_or_pending.empty())
     {
-        LOG_INFO(storage.log, "ExportPartition scheduler task: There are still parts in processing or pending, will not try to commit export partition");
+        LOG_DEBUG(storage.log, "ExportPartition scheduler task: There are still parts in processing or pending, will not try to commit export partition");
         return false;
     }
 

--- a/src/Storages/MergeTree/ExportPartitionUtils.cpp
+++ b/src/Storages/MergeTree/ExportPartitionUtils.cpp
@@ -121,7 +121,7 @@ namespace ExportPartitionUtils
     {
         std::vector<std::string> exported_paths;
 
-        LOG_INFO(log, "ExportPartition: Getting exported paths for {}", export_path);
+        LOG_DEBUG(log, "ExportPartition: Getting exported paths for {}", export_path);
 
         const auto processed_parts_path = fs::path(export_path) / "processed";
 
@@ -131,7 +131,7 @@ namespace ExportPartitionUtils
         if (Coordination::Error::ZOK != zk->tryGetChildren(processed_parts_path, processed_parts))
         {
             /// todo arthur do something here
-            LOG_INFO(log, "ExportPartition: Failed to get parts children, exiting");
+            LOG_WARNING(log, "ExportPartition: Failed to get parts children, exiting");
             return {};
         }
 
@@ -155,7 +155,7 @@ namespace ExportPartitionUtils
                 /// todo arthur what to do in this case?
                 /// It could be that zk is corrupt, in that case we should fail the task
                 /// but it can also be some temporary network issue? not sure
-                LOG_INFO(log, "ExportPartition: Failed to get exported path, exiting");
+                LOG_WARNING(log, "ExportPartition: Failed to get exported path, exiting");
                 return {};
             }
 
@@ -199,7 +199,7 @@ namespace ExportPartitionUtils
         auto commit_lock = zkutil::EphemeralNodeHolder::tryCreate(commit_lock_path, *zk, replica_name);
         if (!commit_lock)
         {
-            LOG_INFO(log, "ExportPartition: commit_lock for {} is held by another replica, skipping commit on this replica", entry_path);
+            LOG_DEBUG(log, "ExportPartition: commit_lock for {} is held by another replica, skipping commit on this replica", entry_path);
             return;
         }
         LOG_INFO(log, "ExportPartition: commit_lock for {} acquired by replica {}", entry_path, replica_name);
@@ -212,7 +212,7 @@ namespace ExportPartitionUtils
         const auto status = magic_enum::enum_cast<ExportReplicatedMergeTreePartitionTaskEntry::Status>(status_str);
         if (!status || *status != ExportReplicatedMergeTreePartitionTaskEntry::Status::PENDING)
         {
-            LOG_INFO(log, "ExportPartition: {} not PENDING, skipping commit", entry_path);
+            LOG_DEBUG(log, "ExportPartition: {} not PENDING, skipping commit", entry_path);
             return;
         }
 
@@ -287,14 +287,14 @@ namespace ExportPartitionUtils
         if (!zk->tryGet(status_path, current_status, &status_stat))
         {
             /// Task was removed (TTL cleanup or force-overwrite). Nothing to do.
-            LOG_INFO(log, "ExportPartition: /status missing for {}, skipping commit-failure bookkeeping", entry_path);
+            LOG_DEBUG(log, "ExportPartition: /status missing for {}, skipping commit-failure bookkeeping", entry_path);
             return false;
         }
 
         const auto status = magic_enum::enum_cast<ExportReplicatedMergeTreePartitionTaskEntry::Status>(current_status);
         if (!status)
         {
-            LOG_INFO(log, "ExportPartition: Invalid status {} for task {}, skipping commit-failure bookkeeping", current_status, entry_path);
+            LOG_WARNING(log, "ExportPartition: Invalid status {} for task {}, skipping commit-failure bookkeeping", current_status, entry_path);
             return false;
         }
 
@@ -302,7 +302,7 @@ namespace ExportPartitionUtils
         {
             /// Another replica already reached a terminal state (COMPLETED or FAILED).
             /// Do NOT overwrite — a successful commit by a peer must win.
-            LOG_INFO(log,
+            LOG_DEBUG(log,
                 "ExportPartition: /status for {} is {} (not PENDING), skipping commit-failure bookkeeping",
                 entry_path, current_status);
             return false;
@@ -372,7 +372,7 @@ namespace ExportPartitionUtils
             /// non-fatal: the next attempt re-reads /status and either skips (terminal
             /// state won) or retries the bookkeeping. Worst case we delay FAILED by one
             /// poll cycle, which matches the best-effort property of the existing counters.
-            LOG_INFO(log, "ExportPartition: Failed to persist commit failure bookkeeping for {}: {}", entry_path, rc);
+            LOG_WARNING(log, "ExportPartition: Failed to persist commit failure bookkeeping for {}: {}", entry_path, rc);
             return false;
         }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Using `LOG_INFO` for all logs in export partition might flood the system. Replace it with DEBUG and WARNING.

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
