### PR TITLE
Validate ClickHouseVersion format with explicit suffix parsing

### DIFF
--- a/src/Common/ClickHouseVersion.cpp
+++ b/src/Common/ClickHouseVersion.cpp
@@ -4,7 +4,6 @@
 #include <IO/ReadHelpers.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/join.hpp>
 
 #include <fmt/ranges.h>
 
@@ -20,24 +19,38 @@ ClickHouseVersion::ClickHouseVersion(std::string_view version)
 {
     Strings split;
     boost::split(split, version, [](char c){ return c == '.'; });
-    components.reserve(split.size());
     if (split.empty())
-        throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version here: {}", version};
+        throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version: {}", version};
 
-    for (size_t i = 0; i < split.size(); ++i)
+    size_t last_component;
+    bool last_is_numeric = !split.back().empty();
+    if (last_is_numeric)
+    {
+        ReadBufferFromString buf(split.back());
+        last_is_numeric = tryReadIntText(last_component, buf) && buf.eof();
+    }
+
+    if (!last_is_numeric)
+    {
+        /// A trailing non-numeric token is a build suffix (e.g. "26.1.3.20001.altinityantalya").
+        /// Only that exact suffix, preceded by exactly 4 numeric components, is accepted
+        suffix = split.back();
+        split.pop_back();
+        if (suffix != "altinityantalya" || split.size() != 4)
+            throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version: {}", version};
+    }
+    else if (split.size() < 2 || split.size() > 4)
+    {
+        throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version: {}", version};
+    }
+
+    components.reserve(split.size());
+    for (const auto & token : split)
     {
         size_t component;
-        ReadBufferFromString buf(split[i]);
-        if (!tryReadIntText(component, buf) || !buf.eof())
-        {
-            /// Non-numeric component (e.g. "altinityantalya"): treat this and remaining parts as suffix.
-            /// Valid version must have at least one numeric component (e.g. "26.1.3.20001.altinityantalya").
-            if (components.empty())
-                throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version here: {}", version};
-            Strings suffix_parts(split.begin() + i, split.end());
-            suffix = boost::algorithm::join(suffix_parts, ".");
-            break;
-        }
+        ReadBufferFromString buf(token);
+        if (token.empty() || !tryReadIntText(component, buf) || !buf.eof())
+            throw Exception{ErrorCodes::BAD_ARGUMENTS, "Cannot parse ClickHouse version: {}", version};
         components.push_back(component);
     }
 }

--- a/src/Common/tests/gtest_ch_version.cpp
+++ b/src/Common/tests/gtest_ch_version.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+#include <compare>
+#include <Common/ClickHouseVersion.h>
+#include <Common/Exception.h>
+
+using namespace DB;
+
+TEST(ClickHouseVersion, AcceptsValidFormats)
+{
+    EXPECT_EQ(ClickHouseVersion("26.3").toString(), "26.3");
+    EXPECT_EQ(ClickHouseVersion("25.8").toString(), "25.8");
+    EXPECT_EQ(ClickHouseVersion("18.12.17").toString(), "18.12.17");
+    EXPECT_EQ(ClickHouseVersion("26.3.1.20001").toString(), "26.3.1.20001");
+    EXPECT_EQ(ClickHouseVersion("26.1.3.20001.altinityantalya").toString(), "26.1.3.20001.altinityantalya");
+    EXPECT_EQ(ClickHouseVersion("25.8.16.20001.altinityantalya").toString(), "25.8.16.20001.altinityantalya");
+}
+
+TEST(ClickHouseVersion, RejectsMalformedComponents)
+{
+    EXPECT_THROW(ClickHouseVersion("26..1"), Exception);  /// empty middle component
+    EXPECT_THROW(ClickHouseVersion("26.1."), Exception);  /// trailing dot
+    EXPECT_THROW(ClickHouseVersion("26.x.1"), Exception); /// non-numeric token that is not the last token
+    EXPECT_THROW(ClickHouseVersion(".26"), Exception);    /// leading dot
+    EXPECT_THROW(ClickHouseVersion(""), Exception);       /// empty string
+    EXPECT_THROW(ClickHouseVersion("       "), Exception);  /// whitespace-only token
+    EXPECT_THROW(ClickHouseVersion("v26.1"), Exception);  /// alphabetic prefix where a number is required
+    EXPECT_THROW(ClickHouseVersion("."), Exception);      /// lone separator, no numeric component
+    EXPECT_THROW(ClickHouseVersion("26.."), Exception);   /// two empty trailing tokens
+    EXPECT_THROW(ClickHouseVersion("26.3.1.20001."), Exception); /// trailing dot after a full version
+}
+
+TEST(ClickHouseVersion, RejectsInvalidSuffix)
+{
+    EXPECT_THROW(ClickHouseVersion("26.3.1.20001.altinityantalya.1"), Exception);
+    EXPECT_THROW(ClickHouseVersion("26.altinityantalya"), Exception);
+    EXPECT_THROW(ClickHouseVersion("26.1.altinityantalya"), Exception);
+    EXPECT_THROW(ClickHouseVersion("26.3.1.20001.altinitystable"), Exception);
+    EXPECT_THROW(ClickHouseVersion("altinityantalya"), Exception);
+}
+
+TEST(ClickHouseVersion, RejectsWrongGroupCount)
+{
+    EXPECT_THROW(ClickHouseVersion("26"), Exception);              /// 1 group
+    EXPECT_THROW(ClickHouseVersion("26.3.1.20001.1"), Exception);  /// 5 groups, no suffix
+}
+
+TEST(ClickHouseVersion, ComparesGroupVersion)
+{
+    EXPECT_TRUE(ClickHouseVersion("26.1") < ClickHouseVersion("26.1.0"));
+}


### PR DESCRIPTION
Fixes #1831.

The `ClickHouseVersion` parser introduced in #1653 stopped at the first non-numeric token and treated the rest of the string as a build suffix.  However, it missed to check the suffix text, the number of numeric groups, or empty tokens, so malformed strings like `26..1`, `26.1.`, `26.x.1` and `26.altinityantalya` were accepted instead of rejected with `BAD_ARGUMENTS`.

This replaces the previous scan with an explicit format check. The last token is classified first, so a trailing suffix is distinguished from a malformed middle token.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
