### PR TITLE
Datalake catalog auth token profile events

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1431,6 +1431,10 @@ The server successfully detected this situation and will download merged part fr
     M(DataLakeRestCatalogGetCredentialsMicroseconds, "Total time of 'get credentials' requests to Iceberg REST catalog.", ValueType::Microseconds) \
     M(DataLakeRestCatalogCredentialsVended, "Number of table metadata requests to Iceberg REST catalog that asked the catalog to vend storage credentials (i.e. cache miss).", ValueType::Number) \
     M(DataLakeRestCatalogCredentialsCacheHits, "Number of table metadata requests to Iceberg REST catalog that reused cached storage credentials and did not ask the catalog to vend new ones.", ValueType::Number) \
+    M(DataLakeRestCatalogAuthTokenCacheHits, "Number of requests to Iceberg REST catalog that reused a cached access token and did not fetch a new one.", ValueType::Number) \
+    M(DataLakeRestCatalogAuthTokenRefreshed, "Number of new access tokens fetched for Iceberg REST catalog (OAuth client-credentials or GCP metadata/ADC).", ValueType::Number) \
+    M(DataLakeRestCatalogAuthTokenRefreshedMicroseconds, "Total time spent fetching access tokens for Iceberg REST catalog.", ValueType::Microseconds) \
+    M(DataLakeRestCatalogAuthTokenRefreshedOnUnauthorized, "Number of Iceberg REST catalog HTTP requests retried with a new access token after HTTP 401 or 403.", ValueType::Number) \
     M(DataLakeRestCatalogCreateNamespace, "Number of 'create namespace' requests to Iceberg REST catalog.", ValueType::Number) \
     M(DataLakeRestCatalogCreateNamespaceMicroseconds, "Total time of 'create namespace' requests to Iceberg REST catalog.", ValueType::Microseconds) \
     M(DataLakeRestCatalogCreateTable, "Number of 'create table' requests to Iceberg REST catalog.", ValueType::Number) \
@@ -1465,6 +1469,8 @@ The server successfully detected this situation and will download merged part fr
     M(DataLakeUnityCatalogGetSchemasMicroseconds, "Total time of 'get schemas' requests to Iceberg Unity catalog.", ValueType::Microseconds) \
     M(DataLakeUnityCatalogGetCredentials, "Number of 'get credentials' requests to Iceberg Unity catalog.", ValueType::Number) \
     M(DataLakeUnityCatalogGetCredentialsMicroseconds, "Total time of 'get credentials' requests to Iceberg Unity catalog.", ValueType::Microseconds) \
+    \
+    M(DataLakePaimonRestCatalogAuthTokenRefreshedOnUnauthorized, "Number of Paimon REST catalog DLF HTTP requests retried with a new authorization signature after HTTP 401.", ValueType::Number) \
 
 
 #ifdef APPLY_FOR_EXTERNAL_EVENTS

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1469,8 +1469,6 @@ The server successfully detected this situation and will download merged part fr
     M(DataLakeUnityCatalogGetSchemasMicroseconds, "Total time of 'get schemas' requests to Iceberg Unity catalog.", ValueType::Microseconds) \
     M(DataLakeUnityCatalogGetCredentials, "Number of 'get credentials' requests to Iceberg Unity catalog.", ValueType::Number) \
     M(DataLakeUnityCatalogGetCredentialsMicroseconds, "Total time of 'get credentials' requests to Iceberg Unity catalog.", ValueType::Microseconds) \
-    \
-    M(DataLakePaimonRestCatalogAuthTokenRefreshedOnUnauthorized, "Number of Paimon REST catalog DLF HTTP requests retried with a new authorization signature after HTTP 401.", ValueType::Number) \
 
 
 #ifdef APPLY_FOR_EXTERNAL_EVENTS

--- a/src/Databases/DataLake/PaimonRestCatalog.cpp
+++ b/src/Databases/DataLake/PaimonRestCatalog.cpp
@@ -37,10 +37,16 @@
 #include <Poco/MD5Engine.h>
 #include <Poco/String.h>
 #include <Common/Base64.h>
+#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Common/OpenSSLHelpers.h>
 #include <Common/logger_useful.h>
+
+namespace ProfileEvents
+{
+    extern const Event DataLakePaimonRestCatalogAuthTokenRefreshedOnUnauthorized;
+}
 
 
 namespace DB::ErrorCodes
@@ -311,6 +317,7 @@ DB::ReadWriteBufferFromHTTPPtr PaimonRestCatalog::createReadBuffer(
     {
         if (e.code() == Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED && refresh_token && token->token_provider == "dlf")
         {
+            ProfileEvents::increment(ProfileEvents::DataLakePaimonRestCatalogAuthTokenRefreshedOnUnauthorized);
             refresh_token = false;
             token->dlf_generated_authorization = "";
             return create_buffer();

--- a/src/Databases/DataLake/PaimonRestCatalog.cpp
+++ b/src/Databases/DataLake/PaimonRestCatalog.cpp
@@ -37,16 +37,10 @@
 #include <Poco/MD5Engine.h>
 #include <Poco/String.h>
 #include <Common/Base64.h>
-#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Common/OpenSSLHelpers.h>
 #include <Common/logger_useful.h>
-
-namespace ProfileEvents
-{
-    extern const Event DataLakePaimonRestCatalogAuthTokenRefreshedOnUnauthorized;
-}
 
 
 namespace DB::ErrorCodes
@@ -317,7 +311,6 @@ DB::ReadWriteBufferFromHTTPPtr PaimonRestCatalog::createReadBuffer(
     {
         if (e.code() == Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED && refresh_token && token->token_provider == "dlf")
         {
-            ProfileEvents::increment(ProfileEvents::DataLakePaimonRestCatalogAuthTokenRefreshedOnUnauthorized);
             refresh_token = false;
             token->dlf_generated_authorization = "";
             return create_buffer();

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -73,6 +73,10 @@ namespace ProfileEvents
     extern const Event DataLakeRestCatalogGetCredentialsMicroseconds;
     extern const Event DataLakeRestCatalogCredentialsVended;
     extern const Event DataLakeRestCatalogCredentialsCacheHits;
+    extern const Event DataLakeRestCatalogAuthTokenCacheHits;
+    extern const Event DataLakeRestCatalogAuthTokenRefreshed;
+    extern const Event DataLakeRestCatalogAuthTokenRefreshedMicroseconds;
+    extern const Event DataLakeRestCatalogAuthTokenRefreshedOnUnauthorized;
     extern const Event DataLakeRestCatalogCreateNamespace;
     extern const Event DataLakeRestCatalogCreateNamespaceMicroseconds;
     extern const Event DataLakeRestCatalogCreateTable;
@@ -278,6 +282,10 @@ DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(
         {
             access_token = retrieveAccessToken();
         }
+        else
+        {
+            ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenCacheHits);
+        }
 
         DB::HTTPHeaderEntries headers;
         headers.emplace_back("Authorization", "Bearer " + access_token.value().token);
@@ -313,6 +321,9 @@ OneLakeCatalog::OneLakeCatalog(
 
 AccessToken RestCatalog::retrieveAccessToken() const
 {
+    ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshed);
+    auto timer = DB::CurrentThread::getProfileEvents().timer(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedMicroseconds);
+
     static constexpr auto oauth_tokens_endpoint = "oauth/tokens";
 
     /// TODO:
@@ -444,6 +455,10 @@ DB::HTTPHeaderEntries BigLakeCatalog::getAuthHeaders(
         {
             access_token = retrieveGoogleCloudAccessToken();
         }
+        else
+        {
+            ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenCacheHits);
+        }
 
         DB::HTTPHeaderEntries headers;
         headers.emplace_back("Authorization", "Bearer " + access_token->token);
@@ -467,6 +482,9 @@ DB::HTTPHeaderEntries BigLakeCatalog::getAuthHeaders(
 
 AccessToken BigLakeCatalog::retrieveGoogleCloudAccessTokenFromRefreshToken() const
 {
+    ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshed);
+    auto timer = DB::CurrentThread::getProfileEvents().timer(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedMicroseconds);
+
     if (google_adc_client_id.empty() || google_adc_client_secret.empty() || google_adc_refresh_token.empty())
         throw DB::Exception(
             DB::ErrorCodes::BAD_ARGUMENTS,
@@ -498,6 +516,9 @@ AccessToken BigLakeCatalog::retrieveGoogleCloudAccessToken() const
 
     /// Fallback to GCP metadata service (works inside GCP infrastructure)
     /// https://cloud.google.com/compute/docs/metadata/overview
+    ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshed);
+    auto timer = DB::CurrentThread::getProfileEvents().timer(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedMicroseconds);
+
     static constexpr auto DEFAULT_REQUEST_TOKEN_PATH = "/computeMetadata/v1/instance/service-accounts";
 
     Poco::URI url;
@@ -614,6 +635,7 @@ DB::ReadWriteBufferFromHTTPPtr RestCatalog::createReadBuffer(
             (status == Poco::Net::HTTPResponse::HTTPStatus::HTTP_UNAUTHORIZED
              || status == Poco::Net::HTTPResponse::HTTPStatus::HTTP_FORBIDDEN))
         {
+            ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedOnUnauthorized);
             return create_buffer(true);
         }
         throw;
@@ -1077,24 +1099,53 @@ void RestCatalog::sendRequest(const String & endpoint, Poco::JSON::Object::Ptr r
     DB::HTTPHeaderEntries extra_headers;
     extra_headers.emplace_back("Content-Type", "application/json");
 
-    DB::HTTPHeaderEntries headers = getAuthHeaders(/* update_token = */ true, method, url, extra_headers, body_str);
-    headers.emplace_back("Content-Type", "application/json");
-    auto wb = DB::BuilderRWBufferFromHTTP(url)
-        .withConnectionGroup(DB::HTTPConnectionGroupType::HTTP)
-        .withMethod(method)
-        .withSettings(context->getReadSettings())
-        .withTimeouts(DB::ConnectionTimeouts::getHTTPTimeouts(context->getSettingsRef(), context->getServerSettings()))
-        .withHostFilter(&context->getRemoteHostFilter())
-        .withHeaders(headers)
-        .withOutCallback(out_stream_callback)
-        .withSkipNotFound(false)
-        .create(credentials);
+    auto create_buffer = [&](bool update_token)
+    {
+        DB::HTTPHeaderEntries headers = getAuthHeaders(update_token, method, url, extra_headers, body_str);
+        headers.emplace_back("Content-Type", "application/json");
+        return DB::BuilderRWBufferFromHTTP(url)
+            .withConnectionGroup(DB::HTTPConnectionGroupType::HTTP)
+            .withMethod(method)
+            .withSettings(context->getReadSettings())
+            .withTimeouts(DB::ConnectionTimeouts::getHTTPTimeouts(context->getSettingsRef(), context->getServerSettings()))
+            .withHostFilter(&context->getRemoteHostFilter())
+            .withHeaders(headers)
+            .withOutCallback(out_stream_callback)
+            .withSkipNotFound(false)
+            .create(credentials);
+    };
 
-    String response_str;
-    if (!ignore_result)
-        readJSONObjectPossiblyInvalid(response_str, *wb);
-    else
-        wb->ignoreAll();
+    try
+    {
+        auto wb = create_buffer(false);
+
+        String response_str;
+        if (!ignore_result)
+            readJSONObjectPossiblyInvalid(response_str, *wb);
+        else
+            wb->ignoreAll();
+    }
+    catch (const DB::HTTPException & e)
+    {
+        const auto status = e.getHTTPStatus();
+        if (update_token_if_expired &&
+            (status == Poco::Net::HTTPResponse::HTTPStatus::HTTP_UNAUTHORIZED
+             || status == Poco::Net::HTTPResponse::HTTPStatus::HTTP_FORBIDDEN))
+        {
+            ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedOnUnauthorized);
+            auto wb = create_buffer(true);
+
+            String response_str;
+            if (!ignore_result)
+                readJSONObjectPossiblyInvalid(response_str, *wb);
+            else
+                wb->ignoreAll();
+        }
+        else
+        {
+            throw;
+        }
+    }
 }
 
 void RestCatalog::createNamespaceIfNotExists(const String & namespace_name, const String & location) const

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -264,8 +264,12 @@ DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(
     const String & /*method*/,
     const Poco::URI & /*url*/,
     const DB::HTTPHeaderEntries & /*extra_headers*/,
-    const String & /*body*/) const
+    const String & /*body*/,
+    bool * used_cached_oauth_token) const
 {
+    if (used_cached_oauth_token)
+        *used_cached_oauth_token = false;
+
     /// Option 1: user specified auth header manually.
     /// Header has format: 'Authorization: <scheme> <token>'.
     if (auth_header.has_value())
@@ -282,9 +286,9 @@ DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(
         {
             access_token = retrieveAccessToken();
         }
-        else
+        else if (used_cached_oauth_token)
         {
-            ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenCacheHits);
+            *used_cached_oauth_token = true;
         }
 
         DB::HTTPHeaderEntries headers;
@@ -440,10 +444,11 @@ BigLakeCatalog::BigLakeCatalog(
 
 DB::HTTPHeaderEntries BigLakeCatalog::getAuthHeaders(
     bool update_token,
-    const String & /*method*/,
-    const Poco::URI & /*url*/,
-    const DB::HTTPHeaderEntries & /*extra_headers*/,
-    const String & /*body*/) const
+    const String & method,
+    const Poco::URI & url,
+    const DB::HTTPHeaderEntries & extra_headers,
+    const String & body,
+    bool * used_cached_oauth_token) const
 {
     /// Google Cloud OAuth2 for BigLake.
     /// Uses GCP metadata service or Application Default Credentials to get access token.
@@ -451,13 +456,16 @@ DB::HTTPHeaderEntries BigLakeCatalog::getAuthHeaders(
     /// https://developers.google.com/identity/protocols/oauth2
     if (!google_project_id.empty() || !google_adc_client_id.empty())
     {
+        if (used_cached_oauth_token)
+            *used_cached_oauth_token = false;
+
         if (!access_token.has_value() || update_token || access_token->isExpired())
         {
             access_token = retrieveGoogleCloudAccessToken();
         }
-        else
+        else if (used_cached_oauth_token)
         {
-            ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenCacheHits);
+            *used_cached_oauth_token = true;
         }
 
         DB::HTTPHeaderEntries headers;
@@ -477,7 +485,7 @@ DB::HTTPHeaderEntries BigLakeCatalog::getAuthHeaders(
         return headers;
     }
 
-    return RestCatalog::getAuthHeaders(update_token);
+    return RestCatalog::getAuthHeaders(update_token, method, url, extra_headers, body, used_cached_oauth_token);
 }
 
 AccessToken BigLakeCatalog::retrieveGoogleCloudAccessTokenFromRefreshToken() const
@@ -603,9 +611,9 @@ DB::ReadWriteBufferFromHTTPPtr RestCatalog::createReadBuffer(
     if (!params.empty())
         url.setQueryParameters(params);
 
-    auto create_buffer = [&](bool update_token)
+    auto create_buffer = [&](bool update_token, bool & used_cached_oauth_token)
     {
-        auto result_headers = getAuthHeaders(update_token, Poco::Net::HTTPRequest::HTTP_GET, url, headers, {});
+        auto result_headers = getAuthHeaders(update_token, Poco::Net::HTTPRequest::HTTP_GET, url, headers, {}, &used_cached_oauth_token);
         std::move(headers.begin(), headers.end(), std::back_inserter(result_headers));
 
         return DB::BuilderRWBufferFromHTTP(url)
@@ -623,7 +631,11 @@ DB::ReadWriteBufferFromHTTPPtr RestCatalog::createReadBuffer(
 
     try
     {
-        return create_buffer(false);
+        bool used_cached_oauth_token = false;
+        auto buf = create_buffer(false, used_cached_oauth_token);
+        if (used_cached_oauth_token)
+            ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenCacheHits);
+        return buf;
     }
     catch (const DB::HTTPException & e)
     {
@@ -633,7 +645,8 @@ DB::ReadWriteBufferFromHTTPPtr RestCatalog::createReadBuffer(
              || status == Poco::Net::HTTPResponse::HTTPStatus::HTTP_FORBIDDEN))
         {
             ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedOnUnauthorized);
-            return create_buffer(true);
+            bool used_cached_oauth_token_on_retry = false;
+            return create_buffer(true, used_cached_oauth_token_on_retry);
         }
         throw;
     }
@@ -1096,9 +1109,9 @@ void RestCatalog::sendRequest(const String & endpoint, Poco::JSON::Object::Ptr r
     DB::HTTPHeaderEntries extra_headers;
     extra_headers.emplace_back("Content-Type", "application/json");
 
-    auto create_buffer = [&](bool update_token)
+    auto create_buffer = [&](bool update_token, bool & used_cached_oauth_token)
     {
-        DB::HTTPHeaderEntries headers = getAuthHeaders(update_token, method, url, extra_headers, body_str);
+        DB::HTTPHeaderEntries headers = getAuthHeaders(update_token, method, url, extra_headers, body_str, &used_cached_oauth_token);
         headers.emplace_back("Content-Type", "application/json");
         return DB::BuilderRWBufferFromHTTP(url)
             .withConnectionGroup(DB::HTTPConnectionGroupType::HTTP)
@@ -1114,13 +1127,17 @@ void RestCatalog::sendRequest(const String & endpoint, Poco::JSON::Object::Ptr r
 
     try
     {
-        auto wb = create_buffer(false);
+        bool used_cached_oauth_token = false;
+        auto wb = create_buffer(false, used_cached_oauth_token);
 
         String response_str;
         if (!ignore_result)
             readJSONObjectPossiblyInvalid(response_str, *wb);
         else
             wb->ignoreAll();
+
+        if (used_cached_oauth_token)
+            ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenCacheHits);
     }
     catch (const DB::HTTPException & e)
     {
@@ -1130,7 +1147,8 @@ void RestCatalog::sendRequest(const String & endpoint, Poco::JSON::Object::Ptr r
              || status == Poco::Net::HTTPResponse::HTTPStatus::HTTP_FORBIDDEN))
         {
             ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedOnUnauthorized);
-            auto wb = create_buffer(true);
+            bool used_cached_oauth_token_on_retry = false;
+            auto wb = create_buffer(true, used_cached_oauth_token_on_retry);
 
             String response_str;
             if (!ignore_result)

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -278,7 +278,7 @@ DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(
     /// https://github.com/apache/iceberg/blob/3badfe0c1fcf0c0adfc7aa4a10f0b50365c48cf9/open-api/rest-catalog-open-api.yaml#L3498C5-L3498C34
     if (!client_id.empty())
     {
-        if (!access_token.has_value() || update_token)
+        if (!access_token.has_value() || update_token || access_token->isExpired())
         {
             access_token = retrieveAccessToken();
         }
@@ -482,9 +482,6 @@ DB::HTTPHeaderEntries BigLakeCatalog::getAuthHeaders(
 
 AccessToken BigLakeCatalog::retrieveGoogleCloudAccessTokenFromRefreshToken() const
 {
-    ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshed);
-    auto timer = DB::CurrentThread::getProfileEvents().timer(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedMicroseconds);
-
     if (google_adc_client_id.empty() || google_adc_client_secret.empty() || google_adc_refresh_token.empty())
         throw DB::Exception(
             DB::ErrorCodes::BAD_ARGUMENTS,
@@ -502,6 +499,9 @@ AccessToken BigLakeCatalog::retrieveGoogleCloudAccessTokenFromRefreshToken() con
 
 AccessToken BigLakeCatalog::retrieveGoogleCloudAccessToken() const
 {
+    ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshed);
+    auto timer = DB::CurrentThread::getProfileEvents().timer(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedMicroseconds);
+
     if (!google_adc_client_id.empty() && !google_adc_client_secret.empty() && !google_adc_refresh_token.empty())
     {
         try
@@ -516,9 +516,6 @@ AccessToken BigLakeCatalog::retrieveGoogleCloudAccessToken() const
 
     /// Fallback to GCP metadata service (works inside GCP infrastructure)
     /// https://cloud.google.com/compute/docs/metadata/overview
-    ProfileEvents::increment(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshed);
-    auto timer = DB::CurrentThread::getProfileEvents().timer(ProfileEvents::DataLakeRestCatalogAuthTokenRefreshedMicroseconds);
-
     static constexpr auto DEFAULT_REQUEST_TOKEN_PATH = "/computeMetadata/v1/instance/service-accounts";
 
     Poco::URI url;

--- a/src/Databases/DataLake/RestCatalog.h
+++ b/src/Databases/DataLake/RestCatalog.h
@@ -210,7 +210,8 @@ protected:
         const String & method = {},
         const Poco::URI & url = {},
         const DB::HTTPHeaderEntries & extra_headers = {},
-        const String & body = {}) const;
+        const String & body = {},
+        bool * used_cached_oauth_token = nullptr) const;
     static void parseCatalogConfigurationSettings(const Poco::JSON::Object::Ptr & object, Config & result);
 
     void sendRequest(
@@ -283,7 +284,8 @@ public:
         const String & method = {},
         const Poco::URI & url = {},
         const DB::HTTPHeaderEntries & extra_headers = {},
-        const String & body = {}) const override;
+        const String & body = {},
+        bool * used_cached_oauth_token = nullptr) const override;
 
     const std::string & getGoogleADCClientId() const { return google_adc_client_id; }
     const std::string & getGoogleADCClientSecret() const { return google_adc_client_secret; }

--- a/src/Databases/DataLake/S3TablesCatalog.cpp
+++ b/src/Databases/DataLake/S3TablesCatalog.cpp
@@ -250,7 +250,8 @@ DB::HTTPHeaderEntries S3TablesCatalog::getAuthHeaders(
     const String & method,
     const Poco::URI & url,
     const DB::HTTPHeaderEntries & extra_headers,
-    const String & body) const
+    const String & body,
+    bool * /*used_cached_oauth_token*/) const
 {
     DB::HTTPHeaderEntries all_signed;
     signRequestWithAWSV4(method, url, extra_headers, body, *signer, region, "s3tables", all_signed);

--- a/src/Databases/DataLake/S3TablesCatalog.h
+++ b/src/Databases/DataLake/S3TablesCatalog.h
@@ -52,7 +52,8 @@ protected:
         const String & method = {},
         const Poco::URI & url = {},
         const DB::HTTPHeaderEntries & extra_headers = {},
-        const String & body = {}) const override;
+        const String & body = {},
+        bool * used_cached_oauth_token = nullptr) const override;
 
 private:
     const String region;

--- a/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
@@ -104,3 +104,27 @@ services:
       /usr/bin/mc policy set public minio/warehouse-rest;
       " # FIX 3: Removed 'tail -f /dev/null' to make this a one-shot setup task.
     cpus: 3
+
+  mock-oauth:
+    image: python:3.12-alpine
+    command:
+      - python
+      - -c
+      - |
+        from http.server import HTTPServer, BaseHTTPRequestHandler
+        import json
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_token()
+            def do_POST(self):
+                self.send_token()
+            def send_token(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                payload = {"access_token": "test-token", "expires_in": 3600, "token_type": "Bearer"}
+                self.wfile.write(json.dumps(payload).encode())
+            def log_message(self, format, *args):
+                pass
+        HTTPServer(("0.0.0.0", 9999), Handler).serve_forever()
+    cpus: 1

--- a/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
+++ b/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
@@ -23,6 +23,7 @@ from helpers.test_tools import TSV, csv_compare
 
 BASE_URL_LOCAL = "http://localhost:8181/catalog"
 BASE_URL = "http://lakekeeper:8181/catalog"
+MOCK_OAUTH_URL = "http://mock-oauth:9999/token"
 CATALOG_NAME = "demo"
 WAREHOUSE_NAME = "demo"
 
@@ -409,11 +410,7 @@ def get_auth_token_profile_events(node, query_id):
         f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenCacheHits'] "
         f"FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
     ))
-    refreshed_on_unauthorized = int(node.query(
-        f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenRefreshedOnUnauthorized'] "
-        f"FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
-    ))
-    return refreshed, cache_hits, refreshed_on_unauthorized
+    return refreshed, cache_hits
 
 
 def test_auth_token_profile_events(started_cluster):
@@ -438,33 +435,28 @@ def test_auth_token_profile_events(started_cluster):
         properties={"write.metadata.compression-codec": "none"},
     )
 
-    create_qid = f"{test_ref}-create-{uuid.uuid4()}"
-    settings = {
-        "catalog_type": "rest",
-        "warehouse": "demo",
-        "storage_endpoint": "http://minio:9000/warehouse-rest",
-        "catalog_credential": "SECRET_1",
-    }
-    node.query(
-        f"""
-DROP DATABASE IF EXISTS {db_name};
-SET allow_experimental_database_iceberg=true;
-CREATE DATABASE {db_name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
-SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
-        """,
-        query_id=create_qid,
+    # The catalog client is initialized lazily on the first database access,
+    # not during CREATE DATABASE. OAuth credentials must use client_id:client_secret
+    # format; oauth_server_uri points to a mock token endpoint in docker compose.
+    create_clickhouse_iceberg_database(
+        started_cluster,
+        node,
+        db_name,
+        additional_settings={
+            "catalog_credential": "test:secret",
+            "oauth_server_uri": MOCK_OAUTH_URL,
+        },
     )
-    refreshed, _, _ = get_auth_token_profile_events(node, create_qid)
-    assert refreshed >= 1
 
     qid1 = f"{test_ref}-show-1-{uuid.uuid4()}"
     node.query(f"SHOW TABLES FROM {db_name}", query_id=qid1)
-    refreshed, cache_hits, _ = get_auth_token_profile_events(node, qid1)
-    assert refreshed == 0 and cache_hits >= 1
+    assert table_name in node.query(f"SHOW TABLES FROM {db_name}")
+    refreshed, cache_hits = get_auth_token_profile_events(node, qid1)
+    assert refreshed >= 1
 
     qid2 = f"{test_ref}-show-2-{uuid.uuid4()}"
     node.query(f"SHOW TABLES FROM {db_name}", query_id=qid2)
-    refreshed, cache_hits, _ = get_auth_token_profile_events(node, qid2)
+    refreshed, cache_hits = get_auth_token_profile_events(node, qid2)
     assert refreshed == 0 and cache_hits >= 1
 
 

--- a/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
+++ b/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
@@ -399,6 +399,75 @@ def get_credentials_profile_events(node, query_id):
     return vended, hits
 
 
+def get_auth_token_profile_events(node, query_id):
+    node.query("SYSTEM FLUSH LOGS")
+    refreshed = int(node.query(
+        f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenRefreshed'] "
+        f"FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
+    ))
+    cache_hits = int(node.query(
+        f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenCacheHits'] "
+        f"FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
+    ))
+    refreshed_on_unauthorized = int(node.query(
+        f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenRefreshedOnUnauthorized'] "
+        f"FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
+    ))
+    return refreshed, cache_hits, refreshed_on_unauthorized
+
+
+def test_auth_token_profile_events(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_auth_token_profile_events_{uuid.uuid4().hex[:8]}"
+    db_name = f"{test_ref}_database"
+    namespace = (f"{test_ref}_namespace",)
+    table_name = f"{test_ref}_table"
+
+    catalog = load_catalog_impl(started_cluster)
+    if namespace not in catalog.list_namespaces():
+        catalog.create_namespace(namespace)
+
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=IntegerType(), required=False),
+        NestedField(field_id=2, name="data", field_type=StringType(), required=False),
+    )
+    catalog.create_table(
+        namespace + (table_name,),
+        schema=schema,
+        properties={"write.metadata.compression-codec": "none"},
+    )
+
+    create_qid = f"{test_ref}-create-{uuid.uuid4()}"
+    settings = {
+        "catalog_type": "rest",
+        "warehouse": "demo",
+        "storage_endpoint": "http://minio:9000/warehouse-rest",
+        "catalog_credential": "SECRET_1",
+    }
+    node.query(
+        f"""
+DROP DATABASE IF EXISTS {db_name};
+SET allow_experimental_database_iceberg=true;
+CREATE DATABASE {db_name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
+SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
+        """,
+        query_id=create_qid,
+    )
+    refreshed, _, _ = get_auth_token_profile_events(node, create_qid)
+    assert refreshed >= 1
+
+    qid1 = f"{test_ref}-show-1-{uuid.uuid4()}"
+    node.query(f"SHOW TABLES FROM {db_name}", query_id=qid1)
+    refreshed, cache_hits, _ = get_auth_token_profile_events(node, qid1)
+    assert refreshed == 0 and cache_hits >= 1
+
+    qid2 = f"{test_ref}-show-2-{uuid.uuid4()}"
+    node.query(f"SHOW TABLES FROM {db_name}", query_id=qid2)
+    refreshed, cache_hits, _ = get_auth_token_profile_events(node, qid2)
+    assert refreshed == 0 and cache_hits >= 1
+
+
 def test_vended_credentials_cache(started_cluster):
     node = started_cluster.instances["node1"]
     catalog = load_catalog_impl(started_cluster)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Datalake catalog auth token profile events

### Documentation entry for user-facing changes
New profile events for requests to catalog token, REST only.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
