### PR TITLE
25.8: Fix crash merging _part_offset projection on row-combining engines

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -532,13 +532,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         !patch_parts.empty() ||
         global_ctx->cleanup ||
         global_ctx->deduplicate ||
-        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Collapsing ||
-        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Replacing ||
-        global_ctx->merging_params.mode == MergeTreeData::MergingParams::VersionedCollapsing ||
-        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Summing ||
-        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Aggregating ||
-        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Graphite ||
-        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Coalescing;
+        global_ctx->merging_params.mode != MergeTreeData::MergingParams::Ordinary;
 
     prepareProjectionsToMergeAndRebuild();
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -534,7 +534,11 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         global_ctx->deduplicate ||
         global_ctx->merging_params.mode == MergeTreeData::MergingParams::Collapsing ||
         global_ctx->merging_params.mode == MergeTreeData::MergingParams::Replacing ||
-        global_ctx->merging_params.mode == MergeTreeData::MergingParams::VersionedCollapsing;
+        global_ctx->merging_params.mode == MergeTreeData::MergingParams::VersionedCollapsing ||
+        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Summing ||
+        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Aggregating ||
+        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Graphite ||
+        global_ctx->merging_params.mode == MergeTreeData::MergingParams::Coalescing;
 
     prepareProjectionsToMergeAndRebuild();
 

--- a/tests/queries/0_stateless/03786_projection_part_offset_reducing_merge.reference
+++ b/tests/queries/0_stateless/03786_projection_part_offset_reducing_merge.reference
@@ -1,0 +1,3 @@
+coalescing	1
+summing	1
+aggregating	1

--- a/tests/queries/0_stateless/03786_projection_part_offset_reducing_merge.sql
+++ b/tests/queries/0_stateless/03786_projection_part_offset_reducing_merge.sql
@@ -1,0 +1,67 @@
+-- Regression test for a crash (Logical error: 'page_pos < pages.size()') that happened when
+-- OPTIMIZE-ing a table whose engine combines rows (Coalescing/Summing/Aggregating/...) and that
+-- has a projection carrying the parent _part_offset.
+--
+-- Such merges reduce rows, so the source-to-merged offset mapping is incomplete and the projection
+-- must be rebuilt rather than merged. Before the fix these engines were missing from
+-- merge_may_reduce_rows, so the projection was merged and the offset remap read out of bounds.
+--
+-- The self-join below checks that every rebuilt projection row points back to the base row with the
+-- same key, i.e. its stored _parent_part_offset equals the base _part_offset.
+
+DROP TABLE IF EXISTS t_coalescing;
+CREATE TABLE t_coalescing
+(
+    a Int32,
+    v Nullable(Int64),
+    PROJECTION p (SELECT a, _part_offset ORDER BY a)
+)
+ENGINE = CoalescingMergeTree
+ORDER BY a
+SETTINGS deduplicate_merge_projection_mode = 'rebuild';
+
+INSERT INTO t_coalescing SELECT number, number FROM numbers(1000);
+INSERT INTO t_coalescing SELECT number, NULL FROM numbers(1000);
+OPTIMIZE TABLE t_coalescing FINAL;
+SELECT 'coalescing', count() = sum(l._part_offset = r._parent_part_offset)
+FROM t_coalescing l JOIN mergeTreeProjection(currentDatabase(), t_coalescing, p) r USING (a)
+SETTINGS enable_analyzer = 1;
+DROP TABLE t_coalescing;
+
+DROP TABLE IF EXISTS t_summing;
+CREATE TABLE t_summing
+(
+    a Int32,
+    v Int64,
+    PROJECTION p (SELECT a, _part_offset ORDER BY a)
+)
+ENGINE = SummingMergeTree
+ORDER BY a
+SETTINGS deduplicate_merge_projection_mode = 'rebuild';
+
+INSERT INTO t_summing SELECT number, 1 FROM numbers(1000);
+INSERT INTO t_summing SELECT number, 10 FROM numbers(1000);
+OPTIMIZE TABLE t_summing FINAL;
+SELECT 'summing', count() = sum(l._part_offset = r._parent_part_offset)
+FROM t_summing l JOIN mergeTreeProjection(currentDatabase(), t_summing, p) r USING (a)
+SETTINGS enable_analyzer = 1;
+DROP TABLE t_summing;
+
+DROP TABLE IF EXISTS t_aggregating;
+CREATE TABLE t_aggregating
+(
+    a Int32,
+    v SimpleAggregateFunction(sum, Int64),
+    PROJECTION p (SELECT a, _part_offset ORDER BY a)
+)
+ENGINE = AggregatingMergeTree
+ORDER BY a
+SETTINGS deduplicate_merge_projection_mode = 'rebuild';
+
+INSERT INTO t_aggregating SELECT number, 1 FROM numbers(1000);
+INSERT INTO t_aggregating SELECT number, 10 FROM numbers(1000);
+OPTIMIZE TABLE t_aggregating FINAL;
+SELECT 'aggregating', count() = sum(l._part_offset = r._parent_part_offset)
+FROM t_aggregating l JOIN mergeTreeProjection(currentDatabase(), t_aggregating, p) r USING (a)
+SETTINGS enable_analyzer = 1;
+DROP TABLE t_aggregating;


### PR DESCRIPTION
A projection that carries the parent _part_offset can only be safely merged when the parent merge preserves rows 1:1. Row-combining engines (Summing/Aggregating/Graphite/Coalescing) collapse rows with equal sorting keys, so the source-to-merged offset mapping becomes incomplete and the projection must be rebuilt instead.

These modes were missing from merge_may_reduce_rows, so such projections took the merge path and remapped offsets through a mapping that had no entry for the collapsed rows, reading out of bounds and aborting with "Logical error: 'page_pos < pages.size()'" (e.g. OPTIMIZE FINAL on a CoalescingMergeTree table with a _part_offset projection and deduplicate_merge_projection_mode = 'rebuild').

Add the four row-combining modes to merge_may_reduce_rows so these projections are rebuilt, and add a regression test.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixes a bug where `OPTIMIZE FINAL` on row-combining engines could crash the server (https://github.com/ClickHouse/ClickHouse/issues/106929)

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [x] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [x] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [x] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [x] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [x] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
