### PR TITLE
25.8 - Run ARM builds when aarch64 tests are disabled

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -48,6 +48,22 @@ FUNCTIONAL_TEST_FLAKY_CHECK_JOBS = [
 
 _info_cache = None
 
+DOCKER_REQUIRED_ARM_JOBS = {
+    "Build (arm_release)",
+    Settings.DOCKER_BUILD_ARM_LINUX_JOB_NAME,
+    Settings.DOCKER_BUILD_MANIFEST_JOB_NAME,
+}
+
+
+def is_ci_excluded_by_tag(job_name, tag):
+    if tag in ("aarch64", "arm") and job_name in DOCKER_REQUIRED_ARM_JOBS:
+        return False
+
+    return tag in job_name.lower()
+
+
+# Must match ci.workflows.pull_request.KEEPER_STRESS_PR_NAME
+KEEPER_STRESS_PR_NAME = "Keeper Stress Tests (PR)"
 
 def should_skip_job(job_name):
     global _info_cache

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -6,6 +6,7 @@ from ci.jobs.scripts.workflow_hooks.new_tests_check import (
 )
 from ci.jobs.scripts.workflow_hooks.pr_description import Labels
 from ci.praktika.info import Info
+from ci.praktika.settings import Settings
 
 
 def only_docs(changed_files):

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -63,9 +63,6 @@ def is_ci_excluded_by_tag(job_name, tag):
     return tag in job_name.lower()
 
 
-# Must match ci.workflows.pull_request.KEEPER_STRESS_PR_NAME
-KEEPER_STRESS_PR_NAME = "Keeper Stress Tests (PR)"
-
 def should_skip_job(job_name):
     global _info_cache
     if _info_cache is None:
@@ -195,7 +192,7 @@ def should_skip_job(job_name):
 
     ci_exclude_tags = _info_cache.get_kv_data("ci_exclude_tags") or []
     for tag in ci_exclude_tags:
-        if tag in job_name:
+        if is_ci_excluded_by_tag(job_name, tag):
             return True, f"Skipped, job name includes excluded tag '{tag}'"
 
     return False, ""


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
