### PR TITLE
24.8.14 Backport of #79147 - Remove guard pages from fibers and alternative stack for signals in threads

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -1,6 +1,7 @@
 #include "Keeper.h"
 
 #include <Common/ClickHouseRevision.h>
+#include <Common/formatReadable.h>
 #include <Common/getMultipleKeysFromConfig.h>
 #include <Common/DNSResolver.h>
 #include <Interpreters/DNSCacheUpdater.h>

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -11,6 +11,7 @@
 #include <Core/Protocol.h>
 #include <Common/DateLUT.h>
 #include <Common/MemoryTracker.h>
+#include <Common/formatReadable.h>
 #include <Common/scope_guard_safe.h>
 #include <Common/Exception.h>
 #include <Common/getNumberOfPhysicalCPUCores.h>

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -22,6 +22,7 @@
 #include <Common/DNSResolver.h>
 #include <Common/StringUtils.h>
 #include <Common/OpenSSLHelpers.h>
+#include <Common/formatReadable.h>
 #include <Common/randomSeed.h>
 #include <Core/Block.h>
 #include <Core/ProtocolDefines.h>

--- a/src/Common/AsyncTaskExecutor.cpp
+++ b/src/Common/AsyncTaskExecutor.cpp
@@ -1,5 +1,6 @@
 #include <Common/AsyncTaskExecutor.h>
 #include <base/scope_guard.h>
+#include <fmt/format.h>
 
 
 namespace DB
@@ -129,4 +130,3 @@ String getSocketTimeoutExceededMessageByTimeoutType(AsyncEventTimeoutType type, 
 }
 
 }
-

--- a/src/Common/AsyncTaskExecutor.h
+++ b/src/Common/AsyncTaskExecutor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <base/types.h>
 #include <Common/Epoll.h>
 #include <Common/Fiber.h>
 #include <Common/FiberStack.h>

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -1,0 +1,101 @@
+#include <base/defines.h>
+#include <Common/formatReadable.h>
+#include <Common/CurrentMemoryTracker.h>
+#include <Common/Exception.h>
+#include <Common/memory.h>
+#include <base/getPageSize.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/mman.h>
+#include <Common/FiberStack.h>
+
+#if defined(BOOST_USE_VALGRIND)
+#include <valgrind/valgrind.h>
+#endif
+
+/// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
+#ifndef MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+namespace
+{
+constexpr bool guardPagesEnabled()
+{
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    return true;
+#else
+    return false;
+#endif
+}
+}
+
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_ALLOCATE_MEMORY;
+}
+
+FiberStack::FiberStack(size_t stack_size_)
+    : stack_size(stack_size_)
+    , page_size(getPageSize())
+{
+}
+
+boost::context::stack_context FiberStack::allocate() const
+{
+    size_t num_pages = 1 + (stack_size - 1) / page_size;
+
+    if constexpr (guardPagesEnabled())
+        /// Add one page at bottom that will be used as guard-page
+        num_pages += 1;
+
+    size_t num_bytes = num_pages * page_size;
+
+    void * data = aligned_alloc(page_size, num_bytes);
+
+    if (!data)
+        throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate FiberStack");
+
+    if constexpr (guardPagesEnabled())
+    {
+        /// TODO: make reports on illegal guard page access more clear.
+        /// Currently we will see segfault and almost random stacktrace.
+        try
+        {
+            memoryGuardInstall(data, page_size);
+        }
+        catch (...)
+        {
+            free(data);
+            throw;
+        }
+    }
+
+    auto trace = CurrentMemoryTracker::alloc(num_bytes);
+    trace.onAlloc(data, num_bytes);
+
+    boost::context::stack_context sctx;
+    sctx.size = num_bytes;
+    sctx.sp = static_cast< char * >(data) + sctx.size;
+#if defined(BOOST_USE_VALGRIND)
+    sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, data);
+#endif
+    return sctx;
+}
+
+void FiberStack::deallocate(boost::context::stack_context & sctx) const
+{
+#if defined(BOOST_USE_VALGRIND)
+    VALGRIND_STACK_DEREGISTER(sctx.valgrind_stack_id);
+#endif
+    void * data = static_cast< char * >(sctx.sp) - sctx.size;
+
+    if constexpr (guardPagesEnabled())
+        memoryGuardRemove(data, page_size);
+
+    free(data);
+
+    /// Do not count guard page in memory usage.
+    auto trace = CurrentMemoryTracker::free(sctx.size);
+    trace.onFree(data, sctx.size - page_size);
+}

--- a/src/Common/FiberStack.h
+++ b/src/Common/FiberStack.h
@@ -1,36 +1,12 @@
 #pragma once
-#include <base/defines.h>
 #include <boost/context/stack_context.hpp>
-#include <Common/formatReadable.h>
-#include <Common/CurrentMemoryTracker.h>
-#include <Common/Exception.h>
-#include <base/getPageSize.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/mman.h>
 
-#if defined(BOOST_USE_VALGRIND)
-#include <valgrind/valgrind.h>
-#endif
-
-/// Required for older Darwin builds, that lack definition of MAP_ANONYMOUS
-#ifndef MAP_ANONYMOUS
-#define MAP_ANONYMOUS MAP_ANON
-#endif
-
-namespace DB::ErrorCodes
-{
-    extern const int CANNOT_ALLOCATE_MEMORY;
-}
 
 /// This is an implementation of allocator for fiber stack.
 /// The reference implementation is protected_fixedsize_stack from boost::context.
 /// This implementation additionally track memory usage. It is the main reason why it is needed.
 class FiberStack
 {
-private:
-    size_t stack_size;
-    size_t page_size = 0;
 public:
     /// NOTE: If you see random segfaults in CI and stack starts from boost::context::...fiber...
     /// probably it worth to try to increase stack size for coroutines.
@@ -39,51 +15,12 @@ public:
     /// way. We will have 80 pages with 4KB page size.
     static constexpr size_t default_stack_size = 320 * 1024; /// 64KB was not enough for tests
 
-    explicit FiberStack(size_t stack_size_ = default_stack_size) : stack_size(stack_size_)
-    {
-        page_size = getPageSize();
-    }
+    explicit FiberStack(size_t stack_size_ = default_stack_size);
 
-    boost::context::stack_context allocate() const
-    {
-        size_t num_pages = 1 + (stack_size - 1) / page_size;
-        size_t num_bytes = (num_pages + 1) * page_size; /// Add one page at bottom that will be used as guard-page
+    boost::context::stack_context allocate() const;
+    void deallocate(boost::context::stack_context & sctx) const;
 
-        void * vp = ::mmap(nullptr, num_bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (MAP_FAILED == vp)
-            throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: Cannot mmap {}.", ReadableSize(num_bytes));
-
-        /// TODO: make reports on illegal guard page access more clear.
-        /// Currently we will see segfault and almost random stacktrace.
-        if (-1 == ::mprotect(vp, page_size, PROT_NONE))
-        {
-            ::munmap(vp, num_bytes);
-            throw DB::ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "FiberStack: cannot protect guard page");
-        }
-
-        /// Do not count guard page in memory usage.
-        auto trace = CurrentMemoryTracker::alloc(num_pages * page_size);
-        trace.onAlloc(vp, num_pages * page_size);
-
-        boost::context::stack_context sctx;
-        sctx.size = num_bytes;
-        sctx.sp = static_cast< char * >(vp) + sctx.size;
-#if defined(BOOST_USE_VALGRIND)
-        sctx.valgrind_stack_id = VALGRIND_STACK_REGISTER(sctx.sp, vp);
-#endif
-        return sctx;
-    }
-
-    void deallocate(boost::context::stack_context & sctx) const
-    {
-#if defined(BOOST_USE_VALGRIND)
-        VALGRIND_STACK_DEREGISTER(sctx.valgrind_stack_id);
-#endif
-        void * vp = static_cast< char * >(sctx.sp) - sctx.size;
-        ::munmap(vp, sctx.size);
-
-        /// Do not count guard page in memory usage.
-        auto trace = CurrentMemoryTracker::free(sctx.size - page_size);
-        trace.onFree(vp, sctx.size - page_size);
-    }
+ private:
+    size_t stack_size;
+    size_t page_size;
 };

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -4,6 +4,7 @@
 #include <Common/ThreadStatus.h>
 #include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>
+#include <Common/memory.h>
 #include <base/getPageSize.h>
 #include <base/errnoToString.h>
 #include <Interpreters/Context.h>
@@ -16,12 +17,25 @@
 
 namespace DB
 {
-
 thread_local ThreadStatus constinit * current_thread = nullptr;
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_ALLOCATE_MEMORY;
+}
 
 #if !defined(SANITIZER)
 namespace
 {
+
+constexpr bool guardPagesEnabled()
+{
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    return true;
+#else
+    return false;
+#endif
+}
 
 /// For aarch64 16K is not enough (likely due to tons of registers)
 constexpr size_t UNWIND_MINSIGSTKSZ = 32 << 10;
@@ -41,19 +55,43 @@ constexpr size_t UNWIND_MINSIGSTKSZ = 32 << 10;
 struct ThreadStack
 {
     ThreadStack()
-        : data(aligned_alloc(getPageSize(), getSize()))
     {
-        /// Add a guard page
-        /// (and since the stack grows downward, we need to protect the first page).
-        mprotect(data, getPageSize(), PROT_NONE);
+        auto page_size = getPageSize();
+        data = aligned_alloc(page_size, getSize());
+        if (!data)
+            throw ErrnoException(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate ThreadStack");
+
+        if constexpr (guardPagesEnabled())
+        {
+            try
+            {
+                /// Since the stack grows downward, we need to protect the first page
+                memoryGuardInstall(data, page_size);
+            }
+            catch (...)
+            {
+                free(data);
+                throw;
+            }
+        }
     }
     ~ThreadStack()
     {
-        mprotect(data, getPageSize(), PROT_WRITE|PROT_READ);
+        if constexpr (guardPagesEnabled())
+            memoryGuardRemove(data, getPageSize());
+
         free(data);
     }
 
-    static size_t getSize() { return std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ); }
+    static size_t getSize()
+    {
+        auto size = std::max<size_t>(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ);
+
+        if constexpr (guardPagesEnabled())
+            size += 1;
+
+        return size;
+    }
     void * getData() const { return data; }
 
 private:

--- a/src/Common/memory.cpp
+++ b/src/Common/memory.cpp
@@ -1,0 +1,62 @@
+#include <sys/mman.h>
+#include <Poco/Environment.h>
+#include <Common/Exception.h>
+#include <Common/VersionNumber.h>
+#include <Common/memory.h>
+
+#ifdef OS_LINUX
+#if !defined(MADV_GUARD_INSTALL)
+#define MADV_GUARD_INSTALL 102
+#endif
+
+#if !defined(MADV_GUARD_REMOVE)
+#define MADV_GUARD_REMOVE 103
+#endif
+
+static bool supportsGuardPages()
+{
+    DB::VersionNumber madv_guard_minimal_version(6, 13, 0);
+    DB::VersionNumber linux_version(Poco::Environment::osVersion());
+    return (linux_version >= madv_guard_minimal_version);
+}
+static bool supports_guard_pages = supportsGuardPages();
+#endif // OS_LINUX
+
+namespace DB::ErrorCodes
+{
+    extern const int SYSTEM_ERROR;
+}
+
+/// Uses MADV_GUARD_INSTALL if available, or mprotect() if not
+void memoryGuardInstall(void *addr, size_t len)
+{
+#ifdef OS_LINUX
+    if (supports_guard_pages)
+    {
+        if (madvise(addr, len, MADV_GUARD_INSTALL))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot madvise(MADV_GUARD_INSTALL)");
+    }
+    else
+#endif
+    {
+        if (mprotect(addr, len, PROT_NONE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot mprotect(PROT_NONE)");
+    }
+}
+
+/// Uses MADV_GUARD_REMOVE if available, or mprotect() if not
+void memoryGuardRemove(void *addr, size_t len)
+{
+#ifdef OS_LINUX
+    if (supports_guard_pages)
+    {
+        if (madvise(addr, len, MADV_GUARD_REMOVE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot madvise(MADV_GUARD_INSTALL)");
+    }
+    else
+#endif
+    {
+        if (mprotect(addr, len, PROT_READ|PROT_WRITE))
+            throw DB::ErrnoException(DB::ErrorCodes::SYSTEM_ERROR, "Cannot mprotect(PROT_NONE)");
+    }
+}

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -24,6 +24,16 @@ namespace ProfileEvents
     extern const Event GWPAsanFree;
 }
 
+/// Guard pages interface.
+///
+/// Uses MADV_GUARD_INSTALL/MADV_GUARD_REMOVE (since Linux 6.13+) which does
+/// not splits VMA (unlike mprotect()), or fallback to mprotect()
+///
+/// Uses MADV_GUARD_INSTALL if available, or mprotect() if not
+void memoryGuardInstall(void *addr, size_t len);
+/// Uses MADV_GUARD_REMOVE if available, or mprotect() if not
+void memoryGuardRemove(void *addr, size_t len);
+
 namespace Memory
 {
 

--- a/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
+++ b/src/Storages/Distributed/DistributedAsyncInsertBatch.cpp
@@ -5,6 +5,7 @@
 #include <Storages/StorageDistributed.h>
 #include <QueryPipeline/RemoteInserter.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/formatReadable.h>
 #include <base/defines.h>
 #include <IO/Operators.h>
 #include <IO/WriteBufferFromFile.h>


### PR DESCRIPTION
### Note for the reviewer

This PR originally changed two files and I had conflicts in both of them. One of them, `FiberStack.cpp`, was missing from the original 24.8 branch because it was added later.

Initially I landed the changes on `FiberStack.h` itself and introduced the missing `memoryGuardInstall` / `memoryGuardRemove` functions to `Common/memory.h`, creating `Common/memory.cpp` as well. This, however, broke the build for a missing `jemalloc.h` because `FiberStack.h` got an include for `Common/memory.h`:

```
In file included from /home/mk/git/altinity-clickhouse-24.8-79147/src/Core/ExternalTable.cpp:18:
In file included from /home/mk/git/altinity-clickhouse-24.8-79147/src/Core/ExternalTable.h:3:
In file included from /home/mk/git/altinity-clickhouse-24.8-79147/src/Client/Connection.h:11:
In file included from /home/mk/git/altinity-clickhouse-24.8-79147/src/IO/ReadBufferFromPocoSocketChunked.h:4:
In file included from /home/mk/git/altinity-clickhouse-24.8-79147/src/IO/ReadBufferFromPocoSocket.h:5:
In file included from /home/mk/git/altinity-clickhouse-24.8-79147/src/Common/AsyncTaskExecutor.h:5:
In file included from /home/mk/git/altinity-clickhouse-24.8-79147/src/Common/FiberStack.h:7:
/home/mk/git/altinity-clickhouse-24.8-79147/src/Common/memory.h:13:14: fatal error: 'jemalloc/jemalloc.h' file not found
   13 | #    include <jemalloc/jemalloc.h>
      |              ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Because of that, I decided to split `FiberStack` to a header and implementation file as it is in the upstream. When I did that, I got multiple compiler errors about missing `fmt` and `formatReadable*` functions because the files using those functions previously got those from transitive includes by `FiberStack.h`. After I moved most of inclusions to `FiberStack.cpp`, the functions became undefined.

Before adding the extra includes to `Keeper.cpp`, `ClientBase.cpp`, `Connection.cpp` and `AsyncTaskExecutor.cpp` I verified those includes existed in the upstream's versions of those files at the moment of the original PR.

Unfortunately all of this led to the situation where the PR got quite large in comparison to the original one.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove guard pages for threads and async_socket_for_remote/use_hedge_requests. Change the allocation method in `FiberStack` from `mmap` to `aligned_alloc`. Since this splits VMAs and under heavy load vm.max_map_count can be reached (https://github.com/ClickHouse/ClickHouse/pull/79147 by @CheSema)

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_oauth--> OAuth (5m)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
