### PR TITLE
Fix: DataLakes JSON parser depth limit for Delta/Iceberg metadata (stable-25.8)

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -2,6 +2,7 @@
 #include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h>
 #include <Storages/ObjectStorage/Utils.h>
 #include <base/JSON.h>
+#include <Core/Defines.h>
 #include "config.h"
 
 #if USE_PARQUET
@@ -260,6 +261,9 @@ struct DeltaLakeMetadataImpl
                 continue;
 
             Poco::JSON::Parser parser;
+            /// Bound the parser depth so a deeply nested metadata/schema JSON is rejected cleanly
+            /// instead of overflowing the native stack in Poco's recursive parser.
+            parser.setDepth(DBMS_DEFAULT_MAX_PARSER_DEPTH);
             Poco::Dynamic::Var json = parser.parse(json_str);
             const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
 
@@ -540,6 +544,7 @@ struct DeltaLakeMetadataImpl
             if (!metadata.empty())
             {
                 Poco::JSON::Parser parser;
+                parser.setDepth(DBMS_DEFAULT_MAX_PARSER_DEPTH);
                 Poco::Dynamic::Var json = parser.parse(metadata);
                 const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.cpp
@@ -14,6 +14,7 @@
 
 #include <Core/TypeId.h>
 #include <DataTypes/DataTypesDecimal.h>
+#include <Core/Defines.h>
 #include <Poco/JSON/Parser.h>
 #include <Storages/ColumnsDescription.h>
 #include <Parsers/ASTFunction.h>
@@ -175,6 +176,9 @@ ManifestFileContent::ManifestFileContent(
             ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION, "Required columns are not found in manifest file: {}", f_sequence_number);
 
     Poco::JSON::Parser parser;
+    /// Bound the parser depth so deeply nested partition-spec/schema JSON is rejected cleanly
+    /// instead of overflowing the native stack in Poco's recursive parser.
+    parser.setDepth(DBMS_DEFAULT_MAX_PARSER_DEPTH);
 
     auto partition_spec_json_string = manifest_file_deserializer.tryGetAvroMetadataValue("partition-spec");
     if (!partition_spec_json_string.has_value())

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -22,6 +22,7 @@
 #include <Storages/ColumnsDescription.h>
 #include <base/types.h>
 #include <Core/ColumnsWithTypeAndName.h>
+#include <Core/Defines.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h>
 #include <config.h>
 
@@ -300,6 +301,9 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
         metadata_json_str = create_fn();
 
     Poco::JSON::Parser parser; /// For some reason base/base/JSON.h can not parse this json file
+    /// Bound the parser depth so a deeply nested (attacker-controlled) metadata JSON is rejected
+    /// cleanly instead of overflowing the native stack in Poco's recursive parser.
+    parser.setDepth(DBMS_DEFAULT_MAX_PARSER_DEPTH);
     Poco::Dynamic::Var json = parser.parse(metadata_json_str);
     return json.extract<Poco::JSON::Object::Ptr>();
 }


### PR DESCRIPTION
Cherry-pick of upstream commit **46ae3fed9df** (*DataLakes: bound JSON parser depth for Delta/Iceberg metadata*) adapted for stable-25.8.

## Problem

The earlier backport (commit `0ceb8764bcc`, upstream PR #108278) wired the depth check into Poco's `handleArray`/`handleObject` but did **not** add the `setDepth()` call in the DataLakes metadata parsers. As a result, the parsers parse metadata/schema JSON with unlimited depth despite the Poco enforcement code being present — causing the test `04340_datalake_schema_deep_recursion` to fail since the error is never thrown.

## Changes

| File | Change |
|------|--------|
| `DeltaLakeMetadata.cpp` | `parser.setDepth(DBMS_DEFAULT_MAX_PARSER_DEPTH)` in two `Poco::JSON::Parser` usages |
| `Iceberg/Utils.cpp` | `parser.setDepth(DBMS_DEFAULT_MAX_PARSER_DEPTH)` in `getMetadataJSONObject()` |
| `Iceberg/ManifestFile.cpp` | `parser.setDepth(DBMS_DEFAULT_MAX_PARSER_DEPTH)` for the partition-spec/schema parser |

**Conflict resolution:** Upstream applied the Iceberg manifest fix to `ManifestFileIterator.cpp`, which does not exist in stable-25.8. The equivalent code lives in `ManifestFile.cpp` — the `setDepth` call was applied there instead.

**Not needed:** The Poco `ParserImpl` depth-enforcement code (`_currentDepth`, `handleArray`/`handleObject` checks) is already in stable-25.8 from the prior backport. The test `04340_datalake_schema_deep_recursion` is also already in place.

## Related

- Upstream commit: https://github.com/ClickHouse/ClickHouse/commit/46ae3fed9df8942fdfd3341a68f17238ad97b8b6
- Earlier partial backport: upstream PR #108278 / Altinity PR #2024
- Identified in triage of: Altinity/ClickHouse#2043

Correctness validated by CI on this PR, not locally (no local build available).

---

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
Fix stack overflow on deeply nested Iceberg/DeltaLake metadata JSON (`04340_datalake_schema_deep_recursion`): wire `setDepth(DBMS_DEFAULT_MAX_PARSER_DEPTH)` into all DataLakes `Poco::JSON::Parser` usages.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_aarch64|arm--> All with Aarch64
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)