### PR TITLE
25.8 Altinity backport of #91574: Add cleanup thread to MergeTree to avoid cleanup starvation

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -29,8 +29,8 @@ static struct InitFiu
 /// We should define different types of failpoints here. There are four types of them:
 /// - ONCE: the failpoint will only be triggered once.
 /// - REGULAR: the failpoint will always be triggered until disableFailPoint is called.
-/// - PAUSEABLE_ONCE: the failpoint will be blocked one time when pauseFailPoint is called, util disableFailPoint is called.
-/// - PAUSEABLE: the failpoint will be blocked every time when pauseFailPoint is called, util disableFailPoint is called.
+/// - PAUSEABLE_ONCE: the failpoint will be blocked one time when pauseFailPoint is called, until disableFailPoint is called.
+/// - PAUSEABLE: the failpoint will be blocked every time when pauseFailPoint is called, until disableFailPoint is called.
 
 #define APPLY_FOR_FAILPOINTS(ONCE, REGULAR, PAUSEABLE_ONCE, PAUSEABLE) \
     ONCE(replicated_merge_tree_commit_zk_fail_after_op) \
@@ -133,9 +133,9 @@ static struct InitFiu
     REGULAR(patch_parts_reverse_column_order) \
     ONCE(smt_commit_exception_before_op) \
     ONCE(backup_add_empty_memory_table) \
+    REGULAR(storage_merge_tree_background_schedule_merge_fail) \
     REGULAR(refresh_task_stop_racing_for_running_refresh) \
     REGULAR(wide_part_writer_fail_in_add_streams)
-
 
 namespace FailPoints
 {

--- a/src/Storages/MergeTree/IMergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/IMergeTreeCleanupThread.cpp
@@ -1,0 +1,162 @@
+#include <Storages/MergeTree/IMergeTreeCleanupThread.h>
+
+#include <Interpreters/Context.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Common/ZooKeeper/KeeperException.h>
+
+namespace DB
+{
+
+namespace MergeTreeSetting
+{
+    extern const MergeTreeSettingsUInt64 cleanup_delay_period;
+    extern const MergeTreeSettingsUInt64 cleanup_delay_period_random_add;
+    extern const MergeTreeSettingsUInt64 cleanup_thread_preferred_points_per_iteration;
+    extern const MergeTreeSettingsUInt64 max_cleanup_delay_period;
+}
+
+IMergeTreeCleanupThread::IMergeTreeCleanupThread(MergeTreeData & data_)
+    : data(data_)
+    , log_name(data.getStorageID().getFullTableName() + " (CleanupThread)")
+    , log(getLogger(log_name))
+    , sleep_ms((*data.getSettings())[MergeTreeSetting::cleanup_delay_period] * 1000)
+{
+    task = data.getContext()->getSchedulePool().createTask(log_name, [this] { run(); });
+}
+
+IMergeTreeCleanupThread::~IMergeTreeCleanupThread() = default;
+
+void IMergeTreeCleanupThread::start()
+{
+    task->activateAndSchedule();
+}
+
+void IMergeTreeCleanupThread::wakeup()
+{
+    task->schedule();
+}
+
+void IMergeTreeCleanupThread::stop()
+{
+    task->deactivate();
+}
+
+void IMergeTreeCleanupThread::wakeupEarlierIfNeeded()
+{
+    /// It may happen that the tables was idle for a long time, but then a user started to aggressively insert (or mutate) data.
+    /// In this case, sleep_ms was set to the highest possible value, the task is not going to wake up soon,
+    /// but the number of objects to clean up is growing. We need to wakeup the task earlier.
+    auto storage_settings = data.getSettings();
+    if (!(*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration])
+        return;
+
+    /// The number of other objects (logs, blocks, etc) is usually correlated with the number of Outdated parts.
+    /// Do not wake up unless we have too many.
+    size_t number_of_outdated_objects = data.getOutdatedPartsCount();
+    if (number_of_outdated_objects < (*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration] * 2)
+        return;
+
+    /// A race condition is possible here, but it's okay
+    if (is_running.load(std::memory_order_relaxed))
+        return;
+
+    /// Do not re-check all parts too often (avoid constantly calling getNumberOfOutdatedPartsWithExpiredRemovalTime())
+    if (!wakeup_check_timer.compareAndRestart(static_cast<double>((*storage_settings)[MergeTreeSetting::cleanup_delay_period]) / 4.0))
+        return;
+
+    UInt64 prev_run_timestamp_ms = prev_cleanup_timestamp_ms.load(std::memory_order_relaxed);
+    UInt64 now_ms = clock_gettime_ns_adjusted(prev_run_timestamp_ms * 1'000'000) / 1'000'000;
+    if (!prev_run_timestamp_ms || now_ms <= prev_run_timestamp_ms)
+        return;
+
+    /// Don't run it more often than cleanup_delay_period
+    UInt64 seconds_passed = (now_ms - prev_run_timestamp_ms) / 1000;
+    if (seconds_passed < (*storage_settings)[MergeTreeSetting::cleanup_delay_period])
+        return;
+
+    /// Do not count parts that cannot be removed anyway. Do not wake up unless we have too many.
+    number_of_outdated_objects = data.getNumberOfOutdatedPartsWithExpiredRemovalTime();
+    if (number_of_outdated_objects < (*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration] * 2)
+        return;
+
+    LOG_TRACE(
+        log,
+        "Waking up cleanup thread because there are {} outdated objects and previous cleanup finished {}s ago",
+        number_of_outdated_objects,
+        seconds_passed);
+
+    wakeup();
+}
+
+void IMergeTreeCleanupThread::run()
+{
+    if (cleanup_blocker.isCancelled())
+    {
+        LOG_TRACE(LogFrequencyLimiter(log, 30), "Cleanup is cancelled, exiting");
+        return;
+    }
+
+    SCOPE_EXIT({ is_running.store(false, std::memory_order_relaxed); });
+    is_running.store(true, std::memory_order_relaxed);
+
+    auto storage_settings = data.getSettings();
+
+    Float32 cleanup_points = 0;
+    try
+    {
+        cleanup_points = iterate();
+    }
+    catch (const Coordination::Exception & e)
+    {
+        tryLogCurrentException(log, __PRETTY_FUNCTION__);
+
+        if (e.code == Coordination::Error::ZSESSIONEXPIRED)
+            return;
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, __PRETTY_FUNCTION__);
+    }
+
+    UInt64 prev_timestamp = prev_cleanup_timestamp_ms.load(std::memory_order_relaxed);
+    UInt64 now_ms = clock_gettime_ns_adjusted(prev_timestamp * 1'000'000) / 1'000'000;
+
+    /// Do not adjust sleep_ms on the first run after starting the server
+    if (prev_timestamp && (*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration])
+    {
+        /// We don't want to run the task too often when the table was barely changed and there's almost nothing to cleanup.
+        /// But we cannot simply sleep max_cleanup_delay_period (300s) when nothing was cleaned up and cleanup_delay_period (30s)
+        /// when we removed something, because inserting one part per 30s will lead to running cleanup each 30s just to remove one part.
+        /// So we need some interpolation based on preferred batch size.
+        auto expected_cleanup_points = (*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration];
+
+        /// How long should we sleep to remove cleanup_thread_preferred_points_per_iteration on the next iteration?
+        Float32 ratio = cleanup_points / static_cast<Float32>(expected_cleanup_points);
+        if (ratio == 0)
+            sleep_ms = (*storage_settings)[MergeTreeSetting::max_cleanup_delay_period] * 1000;
+        else
+            sleep_ms = static_cast<UInt64>(static_cast<Float32>(sleep_ms) / ratio);
+
+        sleep_ms = std::clamp(
+            sleep_ms,
+            (*storage_settings)[MergeTreeSetting::cleanup_delay_period] * 1000,
+            (*storage_settings)[MergeTreeSetting::max_cleanup_delay_period] * 1000);
+
+        UInt64 interval_ms = now_ms - prev_timestamp;
+        LOG_TRACE(
+            log,
+            "Scheduling next cleanup after {}ms (points: {}, interval: {}ms, ratio: {}, points per minute: {})",
+            sleep_ms,
+            cleanup_points,
+            interval_ms,
+            ratio,
+            cleanup_points / static_cast<Float32>(interval_ms * 60'000));
+    }
+    prev_cleanup_timestamp_ms.store(now_ms, std::memory_order_relaxed);
+
+    sleep_ms += std::uniform_int_distribution<UInt64>(0, (*storage_settings)[MergeTreeSetting::cleanup_delay_period_random_add] * 1000)(rng);
+    task->scheduleAfter(sleep_ms);
+}
+
+}

--- a/src/Storages/MergeTree/IMergeTreeCleanupThread.h
+++ b/src/Storages/MergeTree/IMergeTreeCleanupThread.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <Core/BackgroundSchedulePool.h>
+#include <Common/ActionBlocker.h>
+#include <Common/Stopwatch.h>
+#include <Common/randomSeed.h>
+
+#include <pcg_random.hpp>
+
+namespace DB
+{
+
+class MergeTreeData;
+
+/// Removes obsolete data from a table of type [Replicated]MergeTree.
+class IMergeTreeCleanupThread
+{
+public:
+    explicit IMergeTreeCleanupThread(MergeTreeData & data_);
+
+    virtual ~IMergeTreeCleanupThread();
+
+    void start();
+
+    void wakeup();
+
+    void stop();
+
+    void wakeupEarlierIfNeeded();
+
+    ActionLock getCleanupLock() { return cleanup_blocker.cancel(); }
+
+protected:
+    MergeTreeData & data;
+
+    String log_name;
+    LoggerPtr log;
+    BackgroundSchedulePoolTaskHolder task;
+    pcg64 rng{randomSeed()};
+
+    UInt64 sleep_ms;
+
+    std::atomic<UInt64> prev_cleanup_timestamp_ms = 0;
+    std::atomic<bool> is_running = false;
+
+    AtomicStopwatch wakeup_check_timer;
+
+    ActionBlocker cleanup_blocker;
+
+    void run();
+
+    /// Returns a number this is directly proportional to the number of cleaned up blocks
+    virtual Float32 iterate() = 0;
+};
+
+}

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -700,7 +700,7 @@ bool IMergeTreeDataPart::isMovingPart() const
     return part_directory_path.parent_path().filename() == "moving";
 }
 
-void IMergeTreeDataPart::clearCaches()
+void IMergeTreeDataPart::clearCaches() const
 {
     if (cleared_data_in_caches.exchange(true) || is_duplicate)
         return;

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -177,7 +177,7 @@ public:
     virtual void removeMarksFromCache(MarkCache * mark_cache) const = 0;
 
     /// Removes data related to data part from mark and primary index caches.
-    void clearCaches();
+    void clearCaches() const;
 
     /// Returns true if data related to data part may be stored in mark and primary index caches.
     bool mayStoreDataInCaches() const;

--- a/src/Storages/MergeTree/MergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/MergeTreeCleanupThread.cpp
@@ -1,0 +1,63 @@
+#include <Storages/MergeTree/MergeTreeCleanupThread.h>
+
+#include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Storages/StorageMergeTree.h>
+
+namespace DB
+{
+
+namespace MergeTreeSetting
+{
+    extern const MergeTreeSettingsSeconds lock_acquire_timeout_for_background_operations;
+    extern const MergeTreeSettingsUInt64 merge_tree_clear_old_parts_interval_seconds;
+    extern const MergeTreeSettingsUInt64 merge_tree_clear_old_temporary_directories_interval_seconds;
+    extern const MergeTreeSettingsSeconds temporary_directories_lifetime;
+}
+
+MergeTreeCleanupThread::MergeTreeCleanupThread(StorageMergeTree & storage_)
+    : IMergeTreeCleanupThread(storage_)
+    , storage(storage_)
+{
+}
+
+void MergeTreeCleanupThread::start()
+{
+    time_after_previous_cleanup_parts.restart();
+    time_after_previous_cleanup_temporary_directories.restart();
+    IMergeTreeCleanupThread::start();
+}
+
+Float32 MergeTreeCleanupThread::iterate()
+{
+    size_t cleaned_other = 0;
+    size_t cleaned_part_like = 0;
+    size_t cleaned_parts = 0;
+
+    auto storage_settings = storage.getSettings();
+
+    auto shared_lock
+        = storage.lockForShare(RWLockImpl::NO_QUERY, (*storage_settings)[MergeTreeSetting::lock_acquire_timeout_for_background_operations]);
+    if (auto lock = time_after_previous_cleanup_temporary_directories.compareAndRestartDeferred(
+            static_cast<double>((*storage_settings)[MergeTreeSetting::merge_tree_clear_old_temporary_directories_interval_seconds])))
+    {
+        /// Both use relative_data_path which changes during rename, so we do it under share lock
+        cleaned_part_like += storage.clearOldTemporaryDirectories(
+            (*storage.getSettings())[MergeTreeSetting::temporary_directories_lifetime].totalSeconds());
+    }
+
+    if (auto lock = time_after_previous_cleanup_parts.compareAndRestartDeferred(
+            static_cast<double>((*storage_settings)[MergeTreeSetting::merge_tree_clear_old_parts_interval_seconds])))
+    {
+        cleaned_parts += storage.clearOldPartsFromFilesystem(/* force */ false, /* with_pause_point */ true);
+        cleaned_other += storage.clearOldMutations();
+        cleaned_part_like += storage.clearEmptyParts();
+        cleaned_part_like += storage.clearUnusedPatchParts();
+        cleaned_part_like += storage.unloadPrimaryKeysAndClearCachesOfOutdatedParts();
+    }
+
+    constexpr Float32 parts_number_amplification = 1.3f; /// Assuming we merge 4-5 parts each time
+    Float32 cleaned_inserted_parts = static_cast<Float32>(cleaned_parts) / parts_number_amplification;
+    return cleaned_inserted_parts + static_cast<Float32>(cleaned_part_like) + static_cast<Float32>(cleaned_other);
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeCleanupThread.h
+++ b/src/Storages/MergeTree/MergeTreeCleanupThread.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Storages/MergeTree/IMergeTreeCleanupThread.h>
+#include <Common/Stopwatch.h>
+
+namespace DB
+{
+
+class StorageMergeTree;
+
+class MergeTreeCleanupThread : public IMergeTreeCleanupThread
+{
+public:
+    explicit MergeTreeCleanupThread(StorageMergeTree & storage_);
+
+    /// Shadows IMergeTreeCleanupThread::start() to restart cleanup timers
+    /// before activating the background task. This ensures the thread waits
+    /// a full interval after the manual cleanup done in startup().
+    void start();
+
+private:
+    StorageMergeTree & storage;
+
+    AtomicStopwatch time_after_previous_cleanup_parts;
+    AtomicStopwatch time_after_previous_cleanup_temporary_directories;
+
+    /// Returns a number that is directly proportional to the number of cleaned up objects
+    Float32 iterate() override;
+};
+
+}

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -3205,6 +3205,12 @@ MergeTreeData::DataPartsVector MergeTreeData::grabOldParts(bool force)
         {
             res.emplace_back(*it_to_delete);
             modifyPartState(it_to_delete, DataPartState::Deleting);
+
+            /// Clear caches while storage is definitely alive so deferred part destruction
+            /// does not have to access storage through a dangling reference.
+            (*it_to_delete)->clearCaches();
+            for (const auto & [_, proj_part] : (*it_to_delete)->getProjectionParts())
+                proj_part->clearCaches();
         }
     }
 
@@ -3747,6 +3753,9 @@ void MergeTreeData::dropAllData()
             continue;
         }
         modifyPartState(it, DataPartState::Deleting);
+        (*it)->clearCaches();
+        for (const auto & [_, proj_part] : (*it)->getProjectionParts())
+            proj_part->clearCaches();
         all_parts.push_back(*it);
     }
     if (skipped_parts > 0)
@@ -5641,6 +5650,9 @@ void MergeTreeData::swapActivePart(MergeTreeData::DataPartPtr part_copy, DataPar
             }
 
             modifyPartState(original_active_part, DataPartState::DeleteOnDestroy);
+            original_active_part->clearCaches();
+            for (const auto & [_, proj_part] : original_active_part->getProjectionParts())
+                proj_part->clearCaches();
             LOG_TEST(log, "swapActivePart: removing {} from data_parts_indexes", (*active_part_it)->getNameWithState());
             data_parts_indexes.erase(active_part_it);
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
@@ -1,28 +1,17 @@
-#include <Interpreters/Context.h>
-#include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/ReplicatedMergeTreeCleanupThread.h>
+
+#include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/StorageReplicatedMergeTree.h>
-#include <Core/BackgroundSchedulePool.h>
 #include <Common/ZooKeeper/KeeperException.h>
-
-#include <random>
-#include <unordered_set>
-
-#include <base/sort.h>
-#include <Poco/Timestamp.h>
-
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 
 namespace DB
 {
 
 namespace MergeTreeSetting
 {
-    extern const MergeTreeSettingsUInt64 cleanup_delay_period;
-    extern const MergeTreeSettingsUInt64 cleanup_delay_period_random_add;
-    extern const MergeTreeSettingsUInt64 cleanup_thread_preferred_points_per_iteration;
     extern const MergeTreeSettingsUInt64 finished_mutations_to_keep;
     extern const MergeTreeSettingsSeconds lock_acquire_timeout_for_background_operations;
-    extern const MergeTreeSettingsUInt64 max_cleanup_delay_period;
     extern const MergeTreeSettingsUInt64 max_replicated_logs_to_keep;
     extern const MergeTreeSettingsUInt64 min_replicated_logs_to_keep;
     extern const MergeTreeSettingsUInt64 replicated_deduplication_window;
@@ -41,132 +30,9 @@ namespace ErrorCodes
 
 
 ReplicatedMergeTreeCleanupThread::ReplicatedMergeTreeCleanupThread(StorageReplicatedMergeTree & storage_)
-    : storage(storage_)
-    , log_name(storage.getStorageID().getFullTableName() + " (ReplicatedMergeTreeCleanupThread)")
-    , log(getLogger(log_name))
-    , sleep_ms((*storage.getSettings())[MergeTreeSetting::cleanup_delay_period] * 1000)
+    : IMergeTreeCleanupThread(storage_)
+    , storage(storage_)
 {
-    task = storage.getContext()->getSchedulePool().createTask(log_name, [this]{ run(); });
-}
-
-void ReplicatedMergeTreeCleanupThread::run()
-{
-    if (cleanup_blocker.isCancelled())
-    {
-        LOG_TRACE(LogFrequencyLimiter(log, 30), "Cleanup is cancelled, exiting");
-        return;
-    }
-
-    SCOPE_EXIT({ is_running.store(false, std::memory_order_relaxed); });
-    is_running.store(true, std::memory_order_relaxed);
-
-    auto storage_settings = storage.getSettings();
-
-    Float32 cleanup_points = 0;
-    try
-    {
-        cleanup_points = iterate();
-    }
-    catch (const Coordination::Exception & e)
-    {
-        tryLogCurrentException(log, __PRETTY_FUNCTION__);
-
-        if (e.code == Coordination::Error::ZSESSIONEXPIRED)
-            return;
-    }
-    catch (...)
-    {
-        tryLogCurrentException(log, __PRETTY_FUNCTION__);
-    }
-
-    UInt64 prev_timestamp = prev_cleanup_timestamp_ms.load(std::memory_order_relaxed);
-    UInt64 now_ms = clock_gettime_ns_adjusted(prev_timestamp * 1'000'000) / 1'000'000;
-
-    /// Do not adjust sleep_ms on the first run after starting the server
-    if (prev_timestamp && (*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration])
-    {
-        /// We don't want to run the task too often when the table was barely changed and there's almost nothing to cleanup.
-        /// But we cannot simply sleep max_cleanup_delay_period (300s) when nothing was cleaned up and cleanup_delay_period (30s)
-        /// when we removed something, because inserting one part per 30s will lead to running cleanup each 30s just to remove one part.
-        /// So we need some interpolation based on preferred batch size.
-        auto expected_cleanup_points = (*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration];
-
-        /// How long should we sleep to remove cleanup_thread_preferred_points_per_iteration on the next iteration?
-        Float32 ratio = cleanup_points / expected_cleanup_points;
-        if (ratio == 0)
-            sleep_ms = (*storage_settings)[MergeTreeSetting::max_cleanup_delay_period] * 1000;
-        else
-            sleep_ms = static_cast<UInt64>(sleep_ms / ratio);
-
-        sleep_ms = std::clamp(sleep_ms, (*storage_settings)[MergeTreeSetting::cleanup_delay_period] * 1000, (*storage_settings)[MergeTreeSetting::max_cleanup_delay_period] * 1000);
-
-        UInt64 interval_ms = now_ms - prev_timestamp;
-        LOG_TRACE(log, "Scheduling next cleanup after {}ms (points: {}, interval: {}ms, ratio: {}, points per minute: {})",
-                  sleep_ms, cleanup_points, interval_ms, ratio, cleanup_points / interval_ms * 60'000);
-    }
-    prev_cleanup_timestamp_ms.store(now_ms, std::memory_order_relaxed);
-
-    sleep_ms += std::uniform_int_distribution<UInt64>(0, (*storage_settings)[MergeTreeSetting::cleanup_delay_period_random_add] * 1000)(rng);
-    task->scheduleAfter(sleep_ms);
-}
-
-void ReplicatedMergeTreeCleanupThread::wakeupEarlierIfNeeded()
-{
-    /// It may happen that the tables was idle for a long time, but then a user started to aggressively insert (or mutate) data.
-    /// In this case, sleep_ms was set to the highest possible value, the task is not going to wake up soon,
-    /// but the number of objects to clean up is growing. We need to wakeup the task earlier.
-    auto storage_settings = storage.getSettings();
-    if (!(*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration])
-        return;
-
-    /// The number of other objects (logs, blocks, etc) is usually correlated with the number of Outdated parts.
-    /// Do not wake up unless we have too many.
-    size_t number_of_outdated_objects = storage.getOutdatedPartsCount();
-    if (number_of_outdated_objects < (*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration] * 2)
-        return;
-
-    /// A race condition is possible here, but it's okay
-    if (is_running.load(std::memory_order_relaxed))
-        return;
-
-    /// Do not re-check all parts too often (avoid constantly calling getNumberOfOutdatedPartsWithExpiredRemovalTime())
-    if (!wakeup_check_timer.compareAndRestart((*storage_settings)[MergeTreeSetting::cleanup_delay_period] / 4.0))
-        return;
-
-    UInt64 prev_run_timestamp_ms = prev_cleanup_timestamp_ms.load(std::memory_order_relaxed);
-    UInt64 now_ms = clock_gettime_ns_adjusted(prev_run_timestamp_ms * 1'000'000) / 1'000'000;
-    if (!prev_run_timestamp_ms || now_ms <= prev_run_timestamp_ms)
-        return;
-
-    /// Don't run it more often than cleanup_delay_period
-    UInt64 seconds_passed = (now_ms - prev_run_timestamp_ms) / 1000;
-    if (seconds_passed < (*storage_settings)[MergeTreeSetting::cleanup_delay_period])
-        return;
-
-    /// Do not count parts that cannot be removed anyway. Do not wake up unless we have too many.
-    number_of_outdated_objects = storage.getNumberOfOutdatedPartsWithExpiredRemovalTime();
-    if (number_of_outdated_objects < (*storage_settings)[MergeTreeSetting::cleanup_thread_preferred_points_per_iteration] * 2)
-        return;
-
-    LOG_TRACE(log, "Waking up cleanup thread because there are {} outdated objects and previous cleanup finished {}s ago",
-              number_of_outdated_objects, seconds_passed);
-
-    wakeup();
-}
-
-void ReplicatedMergeTreeCleanupThread::start()
-{
-    task->activateAndSchedule();
-}
-
-void ReplicatedMergeTreeCleanupThread::wakeup()
-{
-    task->schedule();
-}
-
-void ReplicatedMergeTreeCleanupThread::stop()
-{
-    task->deactivate();
 }
 
 Float32 ReplicatedMergeTreeCleanupThread::iterate()
@@ -191,18 +57,25 @@ Float32 ReplicatedMergeTreeCleanupThread::iterate()
     if (storage.is_leader)
     {
         cleaned_logs = clearOldLogs();
-        size_t normal_blocks = clearOldBlocks("blocks", (*storage_settings)[MergeTreeSetting::replicated_deduplication_window_seconds],
-                                   (*storage_settings)[MergeTreeSetting::replicated_deduplication_window], cached_block_stats_for_sync_inserts);
 
-        size_t async_blocks = clearOldBlocks("async_blocks",
-                                   (*storage_settings)[MergeTreeSetting::replicated_deduplication_window_seconds_for_async_inserts],
-                                   (*storage_settings)[MergeTreeSetting::replicated_deduplication_window_for_async_inserts],
-                                   cached_block_stats_for_async_inserts);
+        auto zookeeper = storage.getZooKeeper();
+
+        size_t normal_blocks = clearOldBlocks(storage.zookeeper_path, "blocks", *zookeeper,
+            (*storage_settings)[MergeTreeSetting::replicated_deduplication_window_seconds],
+            (*storage_settings)[MergeTreeSetting::replicated_deduplication_window],
+            cached_block_stats_for_sync_inserts,
+            log);
+
+        size_t async_blocks = clearOldBlocks(storage.zookeeper_path, "async_blocks", *zookeeper,
+            (*storage_settings)[MergeTreeSetting::replicated_deduplication_window_seconds_for_async_inserts],
+            (*storage_settings)[MergeTreeSetting::replicated_deduplication_window_for_async_inserts],
+            cached_block_stats_for_async_inserts,
+            log);
 
         /// Many async blocks are transformed into one ordinary block
         Float32 async_blocks_per_block = static_cast<Float32>((*storage_settings)[MergeTreeSetting::replicated_deduplication_window]) /
-            ((*storage_settings)[MergeTreeSetting::replicated_deduplication_window_for_async_inserts] + 1);
-        cleaned_blocks = (normal_blocks + async_blocks * async_blocks_per_block) / 2;
+            static_cast<Float32>((*storage_settings)[MergeTreeSetting::replicated_deduplication_window_for_async_inserts] + 1);
+        cleaned_blocks = (static_cast<Float32>(normal_blocks) + static_cast<Float32>(async_blocks) * async_blocks_per_block) / 2;
 
         cleaned_other += clearOldMutations();
         cleaned_part_like += storage.clearEmptyParts();
@@ -222,8 +95,8 @@ Float32 ReplicatedMergeTreeCleanupThread::iterate()
     /// many Outdated parts, and WALs usually contain many parts too). We count then as one part for simplicity.
 
     constexpr Float32 parts_number_amplification = 1.3f;     /// Assuming we merge 4-5 parts each time
-    Float32 cleaned_inserted_parts = (cleaned_blocks + (cleaned_logs + cleaned_parts) / parts_number_amplification) / 3;
-    return cleaned_inserted_parts + cleaned_part_like + cleaned_other;
+    Float32 cleaned_inserted_parts = (cleaned_blocks + static_cast<Float32>(cleaned_logs + cleaned_parts) / parts_number_amplification) / 3;
+    return cleaned_inserted_parts + static_cast<Float32>(cleaned_part_like + cleaned_other);
 }
 
 
@@ -460,22 +333,31 @@ struct ReplicatedMergeTreeCleanupThread::NodeWithStat
 {
     String node;
     Int64 ctime = 0;
+    Int64 czxid = 0;
     Int32 version = 0;
 
-    NodeWithStat(String node_, Int64 ctime_, Int32 version_) : node(std::move(node_)), ctime(ctime_), version(version_) {}
+    NodeWithStat(String node_, Int64 ctime_, Int64 czxid_, Int32 version_) : node(std::move(node_)), ctime(ctime_), czxid(czxid_), version(version_) {}
 
+    /// Sort by (ctime, czxid) rather than (ctime, node_name) to ensure consistent ordering
+    /// across different deduplication directories that may contain entries created
+    /// by the same multi-op.
     static bool greaterByTime(const NodeWithStat & lhs, const NodeWithStat & rhs)
     {
-        return std::forward_as_tuple(lhs.ctime, lhs.node) > std::forward_as_tuple(rhs.ctime, rhs.node);
+        return std::forward_as_tuple(lhs.ctime, lhs.czxid) > std::forward_as_tuple(rhs.ctime, rhs.czxid);
     }
 };
 
-size_t ReplicatedMergeTreeCleanupThread::clearOldBlocks(const String & blocks_dir_name, UInt64 window_seconds, UInt64 window_size, NodeCTimeAndVersionCache & cached_block_stats)
+size_t ReplicatedMergeTreeCleanupThread::clearOldBlocks(
+    const String & zookeeper_path,
+    const String & blocks_dir_name,
+    zkutil::ZooKeeper & zookeeper,
+    UInt64 window_seconds,
+    UInt64 window_size,
+    NodeCTimeAndVersionCache & cached_block_stats,
+    LoggerPtr log_)
 {
-    auto zookeeper = storage.getZooKeeper();
-
     std::vector<NodeWithStat> timed_blocks;
-    getBlocksSortedByTime(blocks_dir_name, *zookeeper, timed_blocks, cached_block_stats);
+    getBlocksSortedByTime(zookeeper_path, blocks_dir_name, zookeeper, timed_blocks, cached_block_stats, log_);
 
     if (timed_blocks.empty())
         return 0;
@@ -487,7 +369,7 @@ size_t ReplicatedMergeTreeCleanupThread::clearOldBlocks(const String & blocks_di
         current_time - static_cast<Int64>(1000 * window_seconds));
 
     /// Virtual node, all nodes that are "greater" than this one will be deleted
-    NodeWithStat block_threshold{{}, time_threshold, 0};
+    NodeWithStat block_threshold{{}, time_threshold, 0, 0};
 
     size_t current_deduplication_window = std::min<size_t>(timed_blocks.size(), window_size);
     auto first_outdated_block_fixed_threshold = timed_blocks.begin() + current_deduplication_window;
@@ -500,15 +382,15 @@ size_t ReplicatedMergeTreeCleanupThread::clearOldBlocks(const String & blocks_di
         return 0;
 
     auto last_outdated_block = timed_blocks.end() - 1;
-    LOG_TRACE(log, "Will clear {} old blocks from {} (ctime {}) to {} (ctime {})", num_nodes_to_delete,
+    LOG_TRACE(log_, "Will clear {} old blocks from {} (ctime {}) to {} (ctime {})", num_nodes_to_delete,
               first_outdated_block->node, first_outdated_block->ctime,
               last_outdated_block->node, last_outdated_block->ctime);
 
     zkutil::AsyncResponses<Coordination::RemoveResponse> try_remove_futures;
     for (auto it = first_outdated_block; it != timed_blocks.end(); ++it)
     {
-        String path = storage.zookeeper_path + "/" + blocks_dir_name + "/" + it->node;
-        try_remove_futures.emplace_back(path, zookeeper->asyncTryRemove(path, it->version));
+        String path = zookeeper_path + "/" + blocks_dir_name + "/" + it->node;
+        try_remove_futures.emplace_back(path, zookeeper.asyncTryRemove(path, it->version));
     }
 
     for (auto & pair : try_remove_futures)
@@ -518,7 +400,7 @@ size_t ReplicatedMergeTreeCleanupThread::clearOldBlocks(const String & blocks_di
         if (rc == Coordination::Error::ZNOTEMPTY)
         {
             /// Can happen if there are leftover block nodes with children created by previous server versions.
-            zookeeper->removeRecursive(path);
+            zookeeper.removeRecursive(path);
             cached_block_stats.erase(first_outdated_block->node);
         }
         else if (rc == Coordination::Error::ZOK || rc == Coordination::Error::ZNONODE || rc == Coordination::Error::ZBADVERSION)
@@ -529,24 +411,30 @@ size_t ReplicatedMergeTreeCleanupThread::clearOldBlocks(const String & blocks_di
         }
         else
         {
-            LOG_WARNING(log, "Error while deleting ZooKeeper path `{}`: {}, ignoring.", path, rc);
+            LOG_WARNING(log_, "Error while deleting ZooKeeper path `{}`: {}, ignoring.", path, rc);
         }
         first_outdated_block++;
     }
 
-    LOG_TRACE(log, "Cleared {} old blocks from ZooKeeper", num_nodes_to_delete);
+    LOG_TRACE(log_, "Cleared {} old blocks from ZooKeeper", num_nodes_to_delete);
     return num_nodes_to_delete;
 }
 
 
-void ReplicatedMergeTreeCleanupThread::getBlocksSortedByTime(const String & blocks_dir_name, zkutil::ZooKeeper & zookeeper, std::vector<NodeWithStat> & timed_blocks, NodeCTimeAndVersionCache & cached_block_stats)
+void ReplicatedMergeTreeCleanupThread::getBlocksSortedByTime(
+    const String & zookeeper_path,
+    const String & blocks_dir_name,
+    zkutil::ZooKeeper & zookeeper,
+    std::vector<NodeWithStat> & timed_blocks,
+    NodeCTimeAndVersionCache & cached_block_stats,
+    LoggerPtr log_)
 {
     timed_blocks.clear();
 
     Strings blocks;
     Coordination::Stat stat;
-    if (Coordination::Error::ZOK != zookeeper.tryGetChildren(storage.zookeeper_path + "/" + blocks_dir_name, blocks, &stat))
-        throw Exception(ErrorCodes::NOT_FOUND_NODE, "{}/{} doesn't exist", storage.zookeeper_path, blocks_dir_name);
+    if (Coordination::Error::ZOK != zookeeper.tryGetChildren(zookeeper_path + "/" + blocks_dir_name, blocks, &stat))
+        throw Exception(ErrorCodes::NOT_FOUND_NODE, "{}/{} doesn't exist", zookeeper_path, blocks_dir_name);
 
     /// Seems like this code is obsolete, because we delete blocks from cache
     /// when they are deleted from zookeeper. But we don't know about all (maybe future) places in code
@@ -565,7 +453,7 @@ void ReplicatedMergeTreeCleanupThread::getBlocksSortedByTime(const String & bloc
     auto not_cached_blocks = stat.numChildren - cached_block_stats.size();
     if (not_cached_blocks)
     {
-        LOG_TRACE(log, "Checking {} {} ({} are not cached){}, path is {}", stat.numChildren, blocks_dir_name, not_cached_blocks, " to clear old ones from ZooKeeper.", storage.zookeeper_path + "/" + blocks_dir_name);
+        LOG_TRACE(log_, "Checking {} {} ({} are not cached) to clear old ones from ZooKeeper., path is {}/{}", stat.numChildren, blocks_dir_name, not_cached_blocks, zookeeper_path, blocks_dir_name);
     }
 
     std::vector<std::string> exists_paths;
@@ -575,13 +463,13 @@ void ReplicatedMergeTreeCleanupThread::getBlocksSortedByTime(const String & bloc
         if (it == cached_block_stats.end())
         {
             /// New block. Fetch its stat asynchronously.
-            exists_paths.emplace_back(storage.zookeeper_path + "/" + blocks_dir_name + "/" + block);
+            exists_paths.emplace_back(zookeeper_path + "/" + blocks_dir_name + "/" + block);
         }
         else
         {
             /// Cached block
-            const auto & ctime_and_version = it->second;
-            timed_blocks.emplace_back(block, ctime_and_version.first, ctime_and_version.second);
+            const auto & entry = it->second;
+            timed_blocks.emplace_back(block, entry.ctime, entry.czxid, entry.version);
         }
     }
 
@@ -595,8 +483,8 @@ void ReplicatedMergeTreeCleanupThread::getBlocksSortedByTime(const String & bloc
         if (status.error != Coordination::Error::ZNONODE)
         {
             auto node_name = fs::path(exists_paths[i]).filename();
-            cached_block_stats.emplace(node_name, std::make_pair(status.stat.ctime, status.stat.version));
-            timed_blocks.emplace_back(node_name, status.stat.ctime, status.stat.version);
+            cached_block_stats.emplace(node_name, NodeCacheEntry{status.stat.ctime, status.stat.czxid, status.stat.version});
+            timed_blocks.emplace_back(node_name, status.stat.ctime, status.stat.czxid, status.stat.version);
         }
     }
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.h
@@ -1,61 +1,48 @@
 #pragma once
 
-#include <base/types.h>
-#include <Common/ZooKeeper/Types.h>
-#include <Common/ZooKeeper/ZooKeeper.h>
-#include <Common/randomSeed.h>
-#include <Common/Stopwatch.h>
-#include <Common/ActionBlocker.h>
-#include <Core/BackgroundSchedulePoolTaskHolder.h>
+#include <Storages/MergeTree/IMergeTreeCleanupThread.h>
+#include <Common/Logger.h>
 
-#include <map>
-#include <unordered_map>
-#include <pcg_random.hpp>
+namespace zkutil
+{
 
+class ZooKeeper;
+using ZooKeeperPtr = std::shared_ptr<ZooKeeper>;
+
+}
 
 namespace DB
 {
 
 class StorageReplicatedMergeTree;
 
-
-/** Removes obsolete data from a table of type ReplicatedMergeTree.
-  */
-class ReplicatedMergeTreeCleanupThread
+class ReplicatedMergeTreeCleanupThread : public IMergeTreeCleanupThread
 {
 public:
     explicit ReplicatedMergeTreeCleanupThread(StorageReplicatedMergeTree & storage_);
 
-    void start();
-
-    void wakeup();
-
-    void stop();
-
-    void wakeupEarlierIfNeeded();
-
-    ActionLock getCleanupLock() { return cleanup_blocker.cancel(); }
+    struct NodeCacheEntry
+    {
+        Int64 ctime = 0;
+        Int64 czxid = 0;
+        Int32 version = 0;
+    };
+    using NodeCTimeAndVersionCache = std::map<String, NodeCacheEntry>;
+    /// Remove old block hashes from ZooKeeper. This is done by the leader replica. Returns the number of removed blocks
+    static size_t clearOldBlocks(
+        const String & zookeeper_path,
+        const String & blocks_dir_name,
+        zkutil::ZooKeeper & zookeeper,
+        UInt64 window_seconds,
+        UInt64 window_size,
+        NodeCTimeAndVersionCache & cached_block_stats,
+        LoggerPtr log_);
 
 private:
     StorageReplicatedMergeTree & storage;
-    String log_name;
-    LoggerPtr log;
-    BackgroundSchedulePoolTaskHolder task;
-    pcg64 rng{randomSeed()};
-
-    UInt64 sleep_ms;
-
-    std::atomic<UInt64> prev_cleanup_timestamp_ms = 0;
-    std::atomic<bool> is_running = false;
-
-    AtomicStopwatch wakeup_check_timer;
-
-    ActionBlocker cleanup_blocker;
-
-    void run();
 
     /// Returns a number this is directly proportional to the number of cleaned up blocks
-    Float32 iterate();
+    Float32 iterate() override;
 
     /// Remove old records from ZooKeeper. Returns the number of removed logs
     size_t clearOldLogs();
@@ -63,13 +50,11 @@ private:
     /// The replica is marked as "lost" if it is inactive and its log pointer
     ///  is far behind and we are not going to keep logs for it.
     /// Lost replicas will use different strategy for repair.
-    void markLostReplicas(const std::unordered_map<String, UInt32> & host_versions_lost_replicas,
-                          const std::unordered_map<String, String> & log_pointers_candidate_lost_replicas,
-                          size_t replicas_count, const zkutil::ZooKeeperPtr & zookeeper);
-
-    using NodeCTimeAndVersionCache = std::map<String, std::pair<Int64, Int32>>;
-    /// Remove old block hashes from ZooKeeper. This is done by the leader replica. Returns the number of removed blocks
-    size_t clearOldBlocks(const String & blocks_dir_name, UInt64 window_seconds, UInt64 window_size, NodeCTimeAndVersionCache & cached_block_stats);
+    void markLostReplicas(
+        const std::unordered_map<String, UInt32> & host_versions_lost_replicas,
+        const std::unordered_map<String, String> & log_pointers_candidate_lost_replicas,
+        size_t replicas_count,
+        const zkutil::ZooKeeperPtr & zookeeper);
 
     /// Remove old mutations that are done from ZooKeeper. This is done by the leader replica. Returns the number of removed mutations
     size_t clearOldMutations();
@@ -79,10 +64,15 @@ private:
 
     struct NodeWithStat;
     /// Returns list of blocks (with their stat) sorted by ctime in descending order.
-    void getBlocksSortedByTime(const String & blocks_dir_name, zkutil::ZooKeeper & zookeeper, std::vector<NodeWithStat> & timed_blocks, NodeCTimeAndVersionCache & cached_block_stats);
+    static void getBlocksSortedByTime(
+        const String & zookeeper_path,
+        const String & blocks_dir_name,
+        zkutil::ZooKeeper & zookeeper,
+        std::vector<NodeWithStat> & timed_blocks,
+        NodeCTimeAndVersionCache & cached_block_stats,
+        LoggerPtr log_);
 
     /// TODO Removing old quorum/failed_parts
 };
-
 
 }

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -65,6 +65,7 @@ namespace DB
 namespace FailPoints
 {
     extern const char storage_merge_tree_background_clear_old_parts_pause[];
+    extern const char storage_merge_tree_background_schedule_merge_fail[];
 }
 
 namespace Setting
@@ -129,6 +130,7 @@ namespace ActionLocks
     extern const StorageActionBlockType PartsMerge;
     extern const StorageActionBlockType PartsTTLMerge;
     extern const StorageActionBlockType PartsMove;
+    extern const StorageActionBlockType Cleanup;
 }
 
 static MergeTreeTransactionPtr tryGetTransactionForMutation(const MergeTreeMutationEntry & mutation, LoggerPtr log = nullptr)
@@ -181,6 +183,7 @@ StorageMergeTree::StorageMergeTree(
     , reader(*this)
     , writer(*this)
     , merger_mutator(*this)
+    , cleanup_thread(*this)
     , support_transaction(supportTransaction(getDisks(), log.load()))
 {
     initializeDirectoriesAndFormatVersion(relative_data_path_, LoadingStrictnessLevel::ATTACH <= mode, date_column_name);
@@ -216,11 +219,10 @@ void StorageMergeTree::startup()
     clearOldTemporaryDirectories(0, {"tmp_", "delete_tmp_", "tmp-fetch_"});
 
     /// NOTE background task will also do the above cleanups periodically.
-    time_after_previous_cleanup_parts.restart();
-    time_after_previous_cleanup_temporary_directories.restart();
 
     try
     {
+        cleanup_thread.start();
         background_operations_assignee.start();
         startBackgroundMoves();
         startOutdatedAndUnexpectedDataPartsLoadingTask();
@@ -244,6 +246,23 @@ void StorageMergeTree::startup()
     }
 }
 
+void StorageMergeTree::flushAndPrepareForShutdown()
+{
+    LOG_TRACE(log, "Start preparing for shutdown");
+
+    if (flush_called.exchange(true))
+        return;
+
+    merger_mutator.merges_blocker.cancelForever();
+    parts_mover.moves_blocker.cancelForever();
+
+    background_operations_assignee.finish();
+    background_moves_assignee.finish();
+
+    cleanup_thread.stop();
+
+    LOG_TRACE(log, "Finished preparing for shutdown");
+}
 void StorageMergeTree::shutdown(bool)
 {
     if (shutdown_called.exchange(true))
@@ -265,6 +284,7 @@ void StorageMergeTree::shutdown(bool)
 
     background_operations_assignee.finish();
     background_moves_assignee.finish();
+    cleanup_thread.stop();
 
     if (deduplication_log)
         deduplication_log->shutdown();
@@ -1523,6 +1543,7 @@ bool StorageMergeTree::scheduleDataProcessingJob(BackgroundJobsAssignee & assign
 
     assert(!isStaticStorage());
 
+    cleanup_thread.wakeupEarlierIfNeeded();
     auto metadata_snapshot = getInMemoryMetadataPtr();
     MergeMutateSelectedEntryPtr merge_entry;
     MergeMutateSelectedEntryPtr mutate_entry;
@@ -1589,6 +1610,12 @@ bool StorageMergeTree::scheduleDataProcessingJob(BackgroundJobsAssignee & assign
         /// in MergePlainMergeTreeTask. So, this slot will never be freed.
         if (!scheduled && isTTLMergeType(merge_entry->future_part->merge_type))
             getContext()->getMergeList().cancelMergeWithTTL();
+
+        fiu_do_on(FailPoints::storage_merge_tree_background_schedule_merge_fail,
+        {
+            scheduled = false;
+        });
+
         return scheduled;
     }
     if (mutate_entry)
@@ -1610,39 +1637,7 @@ bool StorageMergeTree::scheduleDataProcessingJob(BackgroundJobsAssignee & assign
         mutation_wait_event.notify_all();
     }
 
-    bool scheduled = false;
-    if (auto lock = time_after_previous_cleanup_temporary_directories.compareAndRestartDeferred(
-            (*getSettings())[MergeTreeSetting::merge_tree_clear_old_temporary_directories_interval_seconds]))
-    {
-        assignee.scheduleCommonTask(std::make_shared<ExecutableLambdaAdapter>(
-            [this, shared_lock] ()
-            {
-                return clearOldTemporaryDirectories((*getSettings())[MergeTreeSetting::temporary_directories_lifetime].totalSeconds());
-            }, common_assignee_trigger, getStorageID()), /* need_trigger */ false);
-        scheduled = true;
-    }
-
-    if (auto lock = time_after_previous_cleanup_parts.compareAndRestartDeferred(
-            (*getSettings())[MergeTreeSetting::merge_tree_clear_old_parts_interval_seconds]))
-    {
-        assignee.scheduleCommonTask(std::make_shared<ExecutableLambdaAdapter>(
-            [this, shared_lock] ()
-            {
-                /// All use relative_data_path which changes during rename
-                /// so execute under share lock.
-                size_t cleared_count = 0;
-                cleared_count += clearOldPartsFromFilesystem(/* force */ false, /* with_pause_point */true);
-                cleared_count += clearOldMutations();
-                cleared_count += clearEmptyParts();
-                cleared_count += clearUnusedPatchParts();
-                cleared_count += unloadPrimaryKeysAndClearCachesOfOutdatedParts();
-                return cleared_count;
-                /// TODO maybe take into account number of cleared objects when calculating backoff
-            }, common_assignee_trigger, getStorageID()), /* need_trigger */ false);
-        scheduled = true;
-    }
-
-    return scheduled;
+    return false;
 }
 
 UInt64 StorageMergeTree::getCurrentMutationVersion(UInt64 data_version, std::unique_lock<std::mutex> & /*currently_processing_in_background_mutex_lock*/) const
@@ -2616,6 +2611,8 @@ ActionLock StorageMergeTree::getActionLock(StorageActionBlockType action_type)
         return merger_mutator.ttl_merges_blocker.cancel();
     if (action_type == ActionLocks::PartsMove)
         return parts_mover.moves_blocker.cancel();
+    if (action_type == ActionLocks::Cleanup)
+        return cleanup_thread.getCleanupLock();
 
     return {};
 }
@@ -2626,6 +2623,8 @@ void StorageMergeTree::onActionLockRemove(StorageActionBlockType action_type)
         background_operations_assignee.trigger();
     else if (action_type == ActionLocks::PartsMove)
         background_moves_assignee.trigger();
+    else if (action_type == ActionLocks::Cleanup)
+        cleanup_thread.wakeup();
 }
 
 IStorage::DataValidationTasksPtr StorageMergeTree::getCheckTaskList(

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -3,6 +3,7 @@
 #include <Core/Names.h>
 #include <Storages/AlterCommands.h>
 #include <Storages/IStorage.h>
+#include <Storages/MergeTree/MergeTreeCleanupThread.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeDataSelectExecutor.h>
 #include <Storages/MergeTree/MergeTreeDataWriter.h>
@@ -49,6 +50,7 @@ public:
         std::unique_ptr<MergeTreeSettings> settings_);
 
     void startup() override;
+    void flushAndPrepareForShutdown() override;
     void shutdown(bool is_drop) override;
 
     ~StorageMergeTree() override;
@@ -131,16 +133,13 @@ private:
     MergeTreeDataSelectExecutor reader;
     MergeTreeDataWriter writer;
     MergeTreeDataMergerMutator merger_mutator;
+    MergeTreeCleanupThread cleanup_thread;
 
     std::unique_ptr<MergeTreeDeduplicationLog> deduplication_log;
 
     /// For block numbers.
     SimpleIncrement increment;
 
-    /// For clearOldParts
-    AtomicStopwatch time_after_previous_cleanup_parts;
-    /// For clearOldTemporaryDirectories.
-    AtomicStopwatch time_after_previous_cleanup_temporary_directories;
     /// For clearOldBrokenDetachedParts
     AtomicStopwatch time_after_previous_cleanup_broken_detached_parts;
 
@@ -304,6 +303,7 @@ private:
     friend class MergeTreeData;
     friend class MergePlainMergeTreeTask;
     friend class MutatePlainMergeTreeTask;
+    friend class MergeTreeCleanupThread;
 
     struct DataValidationTasks : public IStorage::DataValidationTasksBase
     {

--- a/tests/integration/helpers/corrupt_part_data_on_disk.py
+++ b/tests/integration/helpers/corrupt_part_data_on_disk.py
@@ -1,4 +1,5 @@
 def corrupt_part_data_on_disk(node, table, part_name, file_ext=".bin", database=None):
+    assert part_name
     part_path = node.query(
         "SELECT path FROM system.parts WHERE table = '{}' and name = '{}' {}".format(
             table,
@@ -6,6 +7,7 @@ def corrupt_part_data_on_disk(node, table, part_name, file_ext=".bin", database=
             f"AND database = '{database}'" if database is not None else "",
         )
     ).strip()
+    assert part_path
 
     corrupt_part_data_by_path(node, part_path, file_ext)
 

--- a/tests/integration/test_alter_moving_garbage/test.py
+++ b/tests/integration/test_alter_moving_garbage/test.py
@@ -232,7 +232,7 @@ def test_delete_race_leftovers(cluster):
     # and it can be race condition between removing from remote_data_paths and deleting blobs
     all_remote_paths = set()
     known_remote_paths = set()
-    for i in range(3):
+    for i in range(100):
         known_remote_paths = set(
             node.query(
                 f"SELECT remote_path FROM system.remote_data_paths WHERE disk_name = 's32'"

--- a/tests/integration/test_disk_configuration/test.py
+++ b/tests/integration/test_disk_configuration/test.py
@@ -2,14 +2,11 @@ import logging
 
 import pytest
 
-from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.config_cluster import minio_secret_key
-from minio.deleteobjects import DeleteObject
+from helpers.blobs import wait_blobs_count_synchronization
 
 cluster = ClickHouseCluster(__file__)
-
-TABLE_NAME = "test"
 
 
 @pytest.fixture(scope="module")
@@ -61,31 +58,16 @@ def start_cluster():
         cluster.shutdown()
 
 
-def remove_minio_objects(minio, path: str):
-    retry_count = 3
-    remaining_files = map(
-        lambda x: DeleteObject(x.object_name),
-        minio.list_objects(cluster.minio_bucket, path, recursive=True),
-    )
-    while len(list(remaining_files)) > 0 and retry_count > 0:
-        errors = minio.remove_objects(cluster.minio_bucket, remaining_files)
-        for error in errors:
-            logging.error(f"error occurred when deleting minio object: {error}")
-
-        remaining_files = map(
-            lambda x: DeleteObject(x.object_name),
-            minio.list_objects(cluster.minio_bucket, path, recursive=True),
-        )
-        retry_count -= 1
-    assert len(list(remaining_files)) == 0, remaining_files
-
-
 def test_merge_tree_disk_setting(start_cluster):
+    TABLE_NAME = "test_merge_tree_disk_setting"
     node1 = cluster.instances["node1"]
+    minio = cluster.minio_client
+
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
 
     node1.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME};
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -93,7 +75,6 @@ def test_merge_tree_disk_setting(start_cluster):
     """
     )
 
-    minio = cluster.minio_client
     count = len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True)))
 
     node1.query(f"INSERT INTO {TABLE_NAME} SELECT number FROM numbers(100)")
@@ -105,7 +86,6 @@ def test_merge_tree_disk_setting(start_cluster):
 
     node1.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME}_2;
         CREATE TABLE {TABLE_NAME}_2 (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -159,14 +139,19 @@ def test_merge_tree_disk_setting(start_cluster):
     node1.query(f"DROP TABLE {TABLE_NAME} SYNC")
     node1.query(f"DROP TABLE {TABLE_NAME}_2 SYNC")
 
-    remove_minio_objects(minio, "data/")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
 
 
 def test_merge_tree_custom_disk_setting(start_cluster):
+    TABLE_NAME = "test_merge_tree_custom_disk_setting"
     node1 = cluster.instances["node1"]
     node2 = cluster.instances["node2"]
-
+    minio = cluster.minio_client
     zk_client = start_cluster.get_kazoo_client("zoo1")
+
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
 
     if not zk_client.exists("/minio"):
         zk_client.create("/minio")
@@ -176,7 +161,6 @@ def test_merge_tree_custom_disk_setting(start_cluster):
     zk_client.set("/minio/access_key_id", b"minio")
     node1.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME};
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -191,7 +175,6 @@ def test_merge_tree_custom_disk_setting(start_cluster):
 
     # Check that data was indeed created on s3 with the needed path in s3
 
-    minio = cluster.minio_client
     count = len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True)))
 
     node1.query(f"INSERT INTO {TABLE_NAME} SELECT number FROM numbers(100)")
@@ -205,7 +188,6 @@ def test_merge_tree_custom_disk_setting(start_cluster):
 
     node1.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME}_2;
         CREATE TABLE {TABLE_NAME}_2 (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -228,11 +210,8 @@ def test_merge_tree_custom_disk_setting(start_cluster):
 
     # Check that data for a disk with a different path was created on the different path
 
-    remove_minio_objects(minio, "data2/")
-
     node1.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME}_3;
         CREATE TABLE {TABLE_NAME}_3 (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -292,7 +271,6 @@ def test_merge_tree_custom_disk_setting(start_cluster):
     replica = "{replica}"
     node1.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME}_4;
         CREATE TABLE {TABLE_NAME}_4 ON CLUSTER 'cluster' (a Int32)
         ENGINE=ReplicatedMergeTree('/clickhouse/tables/tbl/', '{replica}')
         ORDER BY tuple()
@@ -345,16 +323,20 @@ def test_merge_tree_custom_disk_setting(start_cluster):
     node1.query(f"DROP TABLE {TABLE_NAME}_4 SYNC")
     node2.query(f"DROP TABLE {TABLE_NAME}_4 SYNC")
 
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
 
 def test_merge_tree_nested_custom_disk_setting(start_cluster):
+    TABLE_NAME = "test_merge_tree_nested_custom_disk_setting"
     node = cluster.instances["node1"]
-
     minio = cluster.minio_client
-    remove_minio_objects(minio, "data/")
+
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
 
     node.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME} SYNC;
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree() order by tuple()
         SETTINGS disk = disk(
@@ -393,14 +375,22 @@ def test_merge_tree_nested_custom_disk_setting(start_cluster):
     assert expected.strip() in node.query(f"SHOW CREATE TABLE {TABLE_NAME}").strip()
     node.query(f"DROP TABLE {TABLE_NAME} SYNC")
 
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
 
 def test_merge_tree_setting_override(start_cluster):
+    TABLE_NAME = "test_merge_tree_setting_override"
     node = cluster.instances["node3"]
+    minio = cluster.minio_client
+
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
     assert (
         "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time"
         in node.query_and_get_error(
             f"""
-        DROP TABLE IF EXISTS {TABLE_NAME};
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -413,7 +403,6 @@ def test_merge_tree_setting_override(start_cluster):
         "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time"
         in node.query_and_get_error(
             f"""
-        DROP TABLE IF EXISTS {TABLE_NAME} SYNC;
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -423,11 +412,14 @@ def test_merge_tree_setting_override(start_cluster):
         )
     )
 
+    node.query(f"DROP TABLE {TABLE_NAME} SYNC")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
     assert (
         "MergeTree settings `storage_policy` and `disk` cannot be specified at the same time"
         in node.query_and_get_error(
             f"""
-        DROP TABLE IF EXISTS {TABLE_NAME} SYNC;
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -437,11 +429,14 @@ def test_merge_tree_setting_override(start_cluster):
         )
     )
 
+    node.query(f"DROP TABLE {TABLE_NAME} SYNC")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
     assert (
         "New storage policy `local` shall contain volumes of the old storage policy `s3`"
         in node.query_and_get_error(
             f"""
-        DROP TABLE IF EXISTS {TABLE_NAME};
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -451,12 +446,15 @@ def test_merge_tree_setting_override(start_cluster):
         )
     )
 
+    node.query(f"DROP TABLE {TABLE_NAME} SYNC")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
     # Using default policy so storage_policy and disk are not set at the same time
     assert (
         "New storage policy `__disk_local` shall contain disks of the old storage policy `hybrid`"
         in node.query_and_get_error(
             f"""
-        DROP TABLE IF EXISTS {TABLE_NAME};
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple();
@@ -465,9 +463,12 @@ def test_merge_tree_setting_override(start_cluster):
         )
     )
 
+    node.query(f"DROP TABLE {TABLE_NAME} SYNC")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
     assert "Unknown storage policy" in node.query_and_get_error(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME};
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -477,7 +478,6 @@ def test_merge_tree_setting_override(start_cluster):
 
     assert "Unknown disk" in node.query_and_get_error(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME};
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -487,7 +487,6 @@ def test_merge_tree_setting_override(start_cluster):
 
     node.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME} SYNC;
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -500,16 +499,18 @@ def test_merge_tree_setting_override(start_cluster):
     """
     )
 
-    minio = cluster.minio_client
     node.query(f"INSERT INTO {TABLE_NAME} SELECT number FROM numbers(100)")
     assert int(node.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
     assert (
         len(list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True))) > 0
     )
+    node.query(f"DROP TABLE {TABLE_NAME} SYNC")
+
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
 
     node.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME} SYNC;
         CREATE TABLE {TABLE_NAME} (a Int32)
         ENGINE = MergeTree()
         ORDER BY tuple()
@@ -525,6 +526,10 @@ def test_merge_tree_setting_override(start_cluster):
     )
     node.query(f"DROP TABLE {TABLE_NAME} SYNC")
 
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
+
+
 @pytest.mark.parametrize("use_node", ["node1", "node2"])
 def test_merge_tree_custom_encrypted_disk_include(start_cluster, use_node):
     """Test that encrypted disk configuration works with include parameter.
@@ -534,11 +539,15 @@ def test_merge_tree_custom_encrypted_disk_include(start_cluster, use_node):
     - The include mechanism correctly merges encryption keys into the disk config
     - Data can be successfully encrypted and decrypted using the included keys
     """
+    TABLE_NAME = f"test_merge_tree_custom_encrypted_disk_include_{use_node}"
     node = cluster.instances[use_node]
+    minio = cluster.minio_client
+
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")
 
     node.query(
         f"""
-        DROP TABLE IF EXISTS {TABLE_NAME}_encrypted;
         CREATE TABLE {TABLE_NAME}_encrypted (
             id Int32,
             data String
@@ -568,9 +577,10 @@ def test_merge_tree_custom_encrypted_disk_include(start_cluster, use_node):
     result = node.query(f"SELECT data FROM {TABLE_NAME}_encrypted WHERE id = 1")
     assert result.strip() == "test_data"
 
-    minio = cluster.minio_client
     s3_objects = list(minio.list_objects(cluster.minio_bucket, "data/", recursive=True))
     assert len(s3_objects) > 0, "Data should be written to S3"
 
     node.query(f"DROP TABLE {TABLE_NAME}_encrypted SYNC")
-    remove_minio_objects(minio, "data/")
+
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data")
+    wait_blobs_count_synchronization(minio, 0, bucket="root", path="data2")

--- a/tests/integration/test_log_family_s3/test.py
+++ b/tests/integration/test_log_family_s3/test.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.blobs import wait_blobs_count_synchronization
 
 
 @pytest.fixture(scope="module")
@@ -22,16 +23,6 @@ def cluster():
         yield cluster
     finally:
         cluster.shutdown()
-
-
-def assert_objects_count(cluster, objects_count, path="data/"):
-    minio = cluster.minio_client
-    s3_objects = list(minio.list_objects(cluster.minio_bucket, path, recursive=True))
-    if objects_count != len(s3_objects):
-        for s3_object in s3_objects:
-            object_meta = minio.stat_object(cluster.minio_bucket, s3_object.object_name)
-            logging.info("Existing S3 object: %s", str(object_meta))
-        assert objects_count == len(s3_objects)
 
 
 # TinyLog: files: id.bin, sizes.json
@@ -65,26 +56,26 @@ def test_log_family_s3(cluster, log_engine, files_overhead, files_overhead_per_i
     try:
         node.query("INSERT INTO s3_test SELECT number FROM numbers(5)")
         assert node.query("SELECT * FROM s3_test") == "0\n1\n2\n3\n4\n"
-        assert_objects_count(cluster, files_overhead_per_insert + files_overhead)
+        wait_blobs_count_synchronization(cluster.minio_client, files_overhead_per_insert + files_overhead)
 
         node.query("INSERT INTO s3_test SELECT number + 5 FROM numbers(3)")
         assert (
             node.query("SELECT * FROM s3_test order by id")
             == "0\n1\n2\n3\n4\n5\n6\n7\n"
         )
-        assert_objects_count(cluster, files_overhead_per_insert * 2 + files_overhead)
+        wait_blobs_count_synchronization(cluster.minio_client, files_overhead_per_insert * 2 + files_overhead)
 
         node.query("INSERT INTO s3_test SELECT number + 8 FROM numbers(1)")
         assert (
             node.query("SELECT * FROM s3_test order by id")
             == "0\n1\n2\n3\n4\n5\n6\n7\n8\n"
         )
-        assert_objects_count(cluster, files_overhead_per_insert * 3 + files_overhead)
+        wait_blobs_count_synchronization(cluster.minio_client, files_overhead_per_insert * 3 + files_overhead)
 
         node.query("TRUNCATE TABLE s3_test")
-        assert_objects_count(cluster, 0)
+        wait_blobs_count_synchronization(cluster.minio_client, 0)
     finally:
-        node.query("DROP TABLE s3_test")
+        node.query("DROP TABLE s3_test SYNC")
 
 
 # Imitate case when error occurs while inserting into table.
@@ -120,4 +111,4 @@ def test_stripe_log_truncate(cluster):
     node.query("DETACH TABLE stripe_table")
     node.query("ATTACH TABLE stripe_table")
 
-    assert node.query("DROP TABLE stripe_table") == ""
+    assert node.query("DROP TABLE stripe_table SYNC") == ""

--- a/tests/integration/test_merge_tree_load_parts/test.py
+++ b/tests/integration/test_merge_tree_load_parts/test.py
@@ -1,4 +1,6 @@
 import time
+import random
+import string
 
 import pytest
 
@@ -39,52 +41,48 @@ def started_cluster():
         cluster.shutdown()
 
 
+def random_string(length):
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
+
+
 def test_merge_tree_load_parts(started_cluster):
+    table = f"mt_load_parts_{random_string(6)}"
     node1.query(
-        """
-        CREATE TABLE mt_load_parts (pk UInt32, id UInt32, s String)
+        f"""
+        CREATE TABLE {table} (pk UInt32, id UInt32, s String)
         ENGINE = MergeTree ORDER BY id PARTITION BY pk"""
     )
 
-    node1.query("SYSTEM STOP MERGES mt_load_parts")
+    node1.query(f"SYSTEM STOP MERGES {table}")
 
     for i in range(20):
-        node1.query(
-            f"INSERT INTO mt_load_parts VALUES (44, {i}, randomPrintableASCII(10))"
-        )
+        node1.query(f"INSERT INTO {table} VALUES (44, {i}, randomPrintableASCII(10))")
 
     node1.restart_clickhouse(kill=True)
     for i in range(1, 21):
         assert node1.contains_in_log(f"Loading Active part 44_{i}_{i}_0")
 
-    node1.query("OPTIMIZE TABLE mt_load_parts FINAL")
+    node1.query(f"OPTIMIZE TABLE {table} FINAL")
     node1.restart_clickhouse(kill=True)
 
-    node1.query("SYSTEM WAIT LOADING PARTS mt_load_parts")
+    node1.query(f"SYSTEM WAIT LOADING PARTS {table}")
 
     assert node1.contains_in_log("Loading Active part 44_1_20")
     for i in range(1, 21):
         assert not node1.contains_in_log(f"Loading Active part 44_{i}_{i}_0")
         assert node1.contains_in_log(f"Loading Outdated part 44_{i}_{i}_0")
 
-    assert node1.query("SELECT count() FROM mt_load_parts") == "20\n"
+    assert node1.query(f"SELECT count() FROM {table}") == "20\n"
 
-    assert (
-        node1.query(
-            "SELECT count() FROM system.parts WHERE table = 'mt_load_parts' AND active"
-        )
-        == "1\n"
-    )
+    assert node1.query(f"SELECT count() FROM system.parts WHERE table = '{table}' AND active") == "1\n"
 
-    node1.query("ALTER TABLE mt_load_parts MODIFY SETTING old_parts_lifetime = 1")
-    node1.query("DETACH TABLE mt_load_parts")
-    node1.query("ATTACH TABLE mt_load_parts")
+    node1.query(f"ALTER TABLE {table} MODIFY SETTING old_parts_lifetime = 1, cleanup_delay_period=1, cleanup_delay_period_random_add=0, cleanup_thread_preferred_points_per_iteration=0;")
+    node1.query(f"DETACH TABLE {table}")
+    node1.query(f"ATTACH TABLE {table}")
 
-    node1.query("SYSTEM WAIT LOADING PARTS mt_load_parts")
+    node1.query(f"SYSTEM WAIT LOADING PARTS {table}")
 
-    table_path = node1.query(
-        "SELECT data_paths[1] FROM system.tables WHERE table = 'mt_load_parts'"
-    ).strip()
+    table_path = node1.query(f"SELECT data_paths[1] FROM system.tables WHERE table = '{table}'").strip()
 
     part_dirs = node1.exec_in_container(["bash", "-c", f"ls {table_path}"], user="root")
 
@@ -110,51 +108,43 @@ def test_merge_tree_load_parts(started_cluster):
 
 
 def test_merge_tree_load_parts_corrupted(started_cluster):
+    table = f"mt_load_parts_2_{random_string(6)}"
+
     for i, node in enumerate([node1, node2]):
         node.query(
             f"""
-            CREATE TABLE mt_load_parts_2 (pk UInt32, id UInt32, s String)
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/mt_load_parts_2', '{i}') ORDER BY id PARTITION BY pk"""
+            CREATE TABLE {table} (pk UInt32, id UInt32, s String)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/0/{table}', '{i}') ORDER BY id PARTITION BY pk"""
         )
 
     """min-max blocks in created parts: 1_1_0, 2_2_0, 1_2_1, 3_3_0, 1_3_2"""
     for partition in [111, 222, 333]:
-        node1.query(
-            f"INSERT INTO mt_load_parts_2 VALUES ({partition}, 0, randomPrintableASCII(10))"
-        )
+        node1.query(f"INSERT INTO {table} VALUES ({partition}, 0, randomPrintableASCII(10))")
+        node1.query(f"INSERT INTO {table} VALUES ({partition}, 1, randomPrintableASCII(10))")
+        node1.query(f"OPTIMIZE TABLE {table} PARTITION {partition} FINAL")
+        node1.query(f"INSERT INTO {table} VALUES ({partition}, 2, randomPrintableASCII(10))")
+        node1.query(f"OPTIMIZE TABLE {table} PARTITION {partition} FINAL")
 
-        node1.query(
-            f"INSERT INTO mt_load_parts_2 VALUES ({partition}, 1, randomPrintableASCII(10))"
-        )
-
-        node1.query(f"OPTIMIZE TABLE mt_load_parts_2 PARTITION {partition} FINAL")
-
-        node1.query(
-            f"INSERT INTO mt_load_parts_2 VALUES ({partition}, 2, randomPrintableASCII(10))"
-        )
-
-        node1.query(f"OPTIMIZE TABLE mt_load_parts_2 PARTITION {partition} FINAL")
-
-    node2.query("SYSTEM SYNC REPLICA mt_load_parts_2", timeout=30)
+    node2.query(f"SYSTEM SYNC REPLICA {table}", timeout=30)
 
     def get_part_name(node, partition, min_block, max_block):
         return node.query(
             f"""
             SELECT name FROM system.parts
-            WHERE table = 'mt_load_parts_2'
+            WHERE table = '{table}'
             AND partition = '{partition}'
             AND min_block_number = {min_block}
             AND max_block_number = {max_block}"""
         ).strip()
 
-    corrupt_part_data_on_disk(node1, "mt_load_parts_2", get_part_name(node1, 111, 0, 2))
-    corrupt_part_data_on_disk(node1, "mt_load_parts_2", get_part_name(node1, 222, 0, 2))
-    corrupt_part_data_on_disk(node1, "mt_load_parts_2", get_part_name(node1, 222, 0, 1))
-    corrupt_part_data_on_disk(node1, "mt_load_parts_2", get_part_name(node1, 333, 0, 1))
-    corrupt_part_data_on_disk(node1, "mt_load_parts_2", get_part_name(node1, 333, 2, 2))
+    corrupt_part_data_on_disk(node1, table, get_part_name(node1, 111, 0, 2))
+    corrupt_part_data_on_disk(node1, table, get_part_name(node1, 222, 0, 2))
+    corrupt_part_data_on_disk(node1, table, get_part_name(node1, 222, 0, 1))
+    corrupt_part_data_on_disk(node1, table, get_part_name(node1, 333, 0, 1))
+    corrupt_part_data_on_disk(node1, table, get_part_name(node1, 333, 2, 2))
 
     node1.restart_clickhouse(kill=True)
-    node1.query("SYSTEM WAIT LOADING PARTS mt_load_parts_2")
+    node1.query(f"SYSTEM WAIT LOADING PARTS {table}")
 
     def check_parts_loading(node, partition, loaded, failed, skipped):
         # The whole test produces around 6-700 lines, so 2k is plenty enough.
@@ -163,10 +153,11 @@ def test_merge_tree_load_parts_corrupted(started_cluster):
         for min_block, max_block in loaded:
             part_name = f"{partition}_{min_block}_{max_block}"
             assert node.wait_for_log_line(
-                f"Loading Active part {part_name}", look_behind_lines=look_behind_lines
+                f"{table}.*Loading Active part {part_name}",
+                look_behind_lines=look_behind_lines,
             )
             assert node.wait_for_log_line(
-                f"Finished loading Active part {part_name}",
+                f"{table}.*Finished loading Active part {part_name}",
                 look_behind_lines=look_behind_lines,
             )
 
@@ -177,18 +168,17 @@ def test_merge_tree_load_parts_corrupted(started_cluster):
             part_name = f"{partition}_{min_block}_{max_block}"
             failed_part_names.append(part_name)
             assert node.wait_for_log_line(
-                f"Loading Active part {part_name}", look_behind_lines=look_behind_lines
+                f"{table}.*Loading Active part {part_name}",
+                look_behind_lines=look_behind_lines,
             )
 
         for failed_part_name in failed_part_names:
-            assert not node.contains_in_log(
-                f"Finished loading Active part {failed_part_name}"
-            )
+            assert not node.contains_in_log(f"{table}.*Finished loading Active part {failed_part_name}")
 
         for min_block, max_block in skipped:
             part_name = f"{partition}_{min_block}_{max_block}"
-            assert not node.contains_in_log(f"Loading Active part {part_name}")
-            assert not node.contains_in_log(f"Finished loading Active part {part_name}")
+            assert not node.contains_in_log(f"{table}.*Loading Active part {part_name}")
+            assert not node.contains_in_log(f"{table}.*Finished loading Active part {part_name}")
 
     check_parts_loading(
         node1, 111, loaded=[(0, 1), (2, 2)], failed=[(0, 2)], skipped=[(0, 0), (1, 1)]
@@ -200,23 +190,23 @@ def test_merge_tree_load_parts_corrupted(started_cluster):
         node1, 333, loaded=[(0, 2)], failed=[], skipped=[(0, 0), (1, 1), (2, 2), (0, 1)]
     )
 
-    node1.query("SYSTEM SYNC REPLICA mt_load_parts_2", timeout=30)
-    node1.query("OPTIMIZE TABLE mt_load_parts_2 FINAL")
-    node1.query("SYSTEM SYNC REPLICA mt_load_parts_2", timeout=30)
+    node1.query(f"SYSTEM SYNC REPLICA {table}", timeout=30)
+    node1.query(f"OPTIMIZE TABLE {table} FINAL")
+    node1.query(f"SYSTEM SYNC REPLICA {table}", timeout=30)
 
     assert (
         node1.query(
-            """
-            SELECT pk, count() FROM mt_load_parts_2
+            f"""
+            SELECT pk, count() FROM {table}
             GROUP BY pk ORDER BY pk"""
         )
         == "111\t3\n222\t3\n333\t3\n"
     )
     assert (
         node1.query(
-            """
+            f"""
             SELECT partition, count()
-            FROM system.parts WHERE table = 'mt_load_parts_2' AND active
+            FROM system.parts WHERE table = '{table}' AND active
             GROUP BY partition ORDER BY partition"""
         )
         == "111\t1\n222\t1\n333\t1\n"
@@ -224,6 +214,7 @@ def test_merge_tree_load_parts_corrupted(started_cluster):
 
 
 def test_merge_tree_load_parts_filesystem_error(started_cluster):
+    table = f"mt_load_parts_fs_error_{random_string(6)}"
     if node3.is_built_with_sanitizer() or node3.is_debug_build():
         pytest.skip(
             "Skip with debug build and sanitizers. \
@@ -231,16 +222,16 @@ def test_merge_tree_load_parts_filesystem_error(started_cluster):
         )
 
     node3.query(
-        """
-        CREATE TABLE mt_load_parts (id UInt32)
+        f"""
+        CREATE TABLE {table} (id UInt32)
         ENGINE = MergeTree ORDER BY id
         SETTINGS index_granularity_bytes = 0"""
     )
 
-    node3.query("SYSTEM STOP MERGES mt_load_parts")
+    node3.query(f"SYSTEM STOP MERGES {table}")
 
     for i in range(2):
-        node3.query(f"INSERT INTO mt_load_parts VALUES ({i})")
+        node3.query(f"INSERT INTO {table} VALUES ({i})")
 
     # We want to somehow check that exception thrown on part creation is handled during part loading.
     # It can be a filesystem exception triggered at initialization of part storage but it hard
@@ -263,13 +254,11 @@ def test_merge_tree_load_parts_filesystem_error(started_cluster):
             privileged=True,
         )
 
-    corrupt_part("mt_load_parts", "all_1_1_0")
+    corrupt_part(table, "all_1_1_0")
     node3.restart_clickhouse(kill=True)
 
-    assert node3.query("SELECT * FROM mt_load_parts") == "1\n"
+    assert node3.query(f"SELECT * FROM {table}") == "1\n"
     assert (
-        node3.query(
-            "SELECT name FROM system.detached_parts WHERE table = 'mt_load_parts'"
-        )
+        node3.query(f"SELECT name FROM system.detached_parts WHERE table = '{table}'")
         == "broken-on-start_all_1_1_0\n"
     )

--- a/tests/integration/test_merge_tree_s3/test.py
+++ b/tests/integration/test_merge_tree_s3/test.py
@@ -9,6 +9,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.mock_servers import start_mock_servers, start_s3_mock
 from helpers.utility import SafeThread, generate_values, replace_config
+from helpers.blobs import wait_blobs_count_synchronization
 from helpers.wait_for_helpers import (
     wait_for_delete_empty_parts,
     wait_for_delete_inactive_parts,
@@ -95,6 +96,9 @@ def create_table(node, table_name, **additional_settings):
         "index_granularity": 512,
         "temporary_directories_lifetime": 1,
         "write_marks_for_substreams_in_compact_parts": 1,
+        "cleanup_delay_period": 1,
+        "cleanup_delay_period_random_add": 0,
+        "cleanup_thread_preferred_points_per_iteration": 0,
     }
     settings.update(additional_settings)
 
@@ -179,7 +183,7 @@ def clear_minio(cluster):
 def check_no_objects_after_drop(cluster, table_name="s3_test", node_name="node"):
     node = cluster.instances[node_name]
     node.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
-    return wait_for_delete_s3_objects(cluster, 0, timeout=0)
+    return wait_for_delete_s3_objects(cluster, 0, timeout=30)
 
 
 @pytest.mark.parametrize(
@@ -203,7 +207,7 @@ def test_simple_insert_select(
         "INSERT INTO s3_test VALUES {}".format(values1), query_id=insert_query_id
     )
     assert node.query("SELECT * FROM s3_test order by dt, id FORMAT Values") == values1
-    assert len(list_objects(cluster, "data/")) == FILES_OVERHEAD + files_per_part
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + files_per_part)
 
     node.query("SYSTEM FLUSH LOGS")
     blob_storage_log = node.query(
@@ -229,7 +233,7 @@ def test_simple_insert_select(
         node.query("SELECT * FROM s3_test ORDER BY dt, id FORMAT Values")
         == values1 + "," + values2
     )
-    assert len(list_objects(cluster, "data/")) == FILES_OVERHEAD + files_per_part * 2
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + files_per_part * 2)
 
     assert (
         node.query("SELECT count(*) FROM s3_test where id = 1 FORMAT Values") == "(2)"
@@ -247,6 +251,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical, node_name):
 
     node = cluster.instances[node_name]
     create_table(node, "s3_test", **settings)
+    minio = cluster.minio_client
 
     node.query("SYSTEM STOP MERGES s3_test")
     node.query(
@@ -271,10 +276,7 @@ def test_insert_same_partition_and_merge(cluster, merge_vertical, node_name):
     assert (
         node.query("SELECT count(distinct(id)) FROM s3_test FORMAT Values") == "(8192)"
     )
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD_PER_PART_WIDE * 6 + FILES_OVERHEAD
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD_PER_PART_WIDE * 6 + FILES_OVERHEAD)
 
     node.query("SYSTEM START MERGES s3_test")
 
@@ -390,6 +392,7 @@ def test_alter_table_columns(cluster, node_name):
 def test_attach_detach_partition(cluster, node_name):
     node = cluster.instances[node_name]
     create_table(node, "s3_test")
+    minio = cluster.minio_client
 
     node.query(
         "INSERT INTO s3_test VALUES {}".format(generate_values("2020-01-03", 4096))
@@ -398,57 +401,36 @@ def test_attach_detach_partition(cluster, node_name):
         "INSERT INTO s3_test VALUES {}".format(generate_values("2020-01-04", 4096))
     )
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
 
     node.query("ALTER TABLE s3_test DETACH PARTITION '2020-01-03'")
     wait_for_delete_empty_parts(node, "s3_test")
     wait_for_delete_inactive_parts(node, "s3_test")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(4096)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD
-        + FILES_OVERHEAD_PER_PART_WIDE * 2
-        - FILES_OVERHEAD_METADATA_VERSION
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2 - FILES_OVERHEAD_METADATA_VERSION)
 
     node.query("ALTER TABLE s3_test ATTACH PARTITION '2020-01-03'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
 
     node.query("ALTER TABLE s3_test DROP PARTITION '2020-01-03'")
     wait_for_delete_empty_parts(node, "s3_test")
     wait_for_delete_inactive_parts(node, "s3_test")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(4096)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 1
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 1)
 
     node.query("ALTER TABLE s3_test DETACH PARTITION '2020-01-04'")
     wait_for_delete_empty_parts(node, "s3_test")
     wait_for_delete_inactive_parts(node, "s3_test")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(0)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD
-        + FILES_OVERHEAD_PER_PART_WIDE * 1
-        - FILES_OVERHEAD_METADATA_VERSION
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 1 - FILES_OVERHEAD_METADATA_VERSION)
+
     node.query(
         "ALTER TABLE s3_test DROP DETACHED PARTITION '2020-01-04'",
         settings={"allow_drop_detached": 1},
     )
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(0)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 0
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 0)
 
     check_no_objects_after_drop(cluster)
 
@@ -457,6 +439,7 @@ def test_attach_detach_partition(cluster, node_name):
 def test_move_partition_to_another_disk(cluster, node_name):
     node = cluster.instances[node_name]
     create_table(node, "s3_test")
+    minio = cluster.minio_client
 
     node.query(
         "INSERT INTO s3_test VALUES {}".format(generate_values("2020-01-03", 4096))
@@ -465,24 +448,15 @@ def test_move_partition_to_another_disk(cluster, node_name):
         "INSERT INTO s3_test VALUES {}".format(generate_values("2020-01-04", 4096))
     )
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
 
     node.query("ALTER TABLE s3_test MOVE PARTITION '2020-01-04' TO DISK 'hdd'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE)
 
     node.query("ALTER TABLE s3_test MOVE PARTITION '2020-01-04' TO DISK 's3'")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
 
     check_no_objects_after_drop(cluster)
 
@@ -491,6 +465,7 @@ def test_move_partition_to_another_disk(cluster, node_name):
 def test_table_manipulations(cluster, node_name):
     node = cluster.instances[node_name]
     create_table(node, "s3_test")
+    minio = cluster.minio_client
 
     node.query(
         "INSERT INTO s3_test VALUES {}".format(generate_values("2020-01-03", 4096))
@@ -501,10 +476,7 @@ def test_table_manipulations(cluster, node_name):
 
     node.query("RENAME TABLE s3_test TO s3_renamed")
     assert node.query("SELECT count(*) FROM s3_renamed FORMAT Values") == "(8192)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
 
     node.query("RENAME TABLE s3_renamed TO s3_test")
 
@@ -513,16 +485,13 @@ def test_table_manipulations(cluster, node_name):
     node.query("DETACH TABLE s3_test")
     node.query("ATTACH TABLE s3_test")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(8192)"
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 2)
 
     node.query("TRUNCATE TABLE s3_test")
     wait_for_delete_empty_parts(node, "s3_test")
     wait_for_delete_inactive_parts(node, "s3_test")
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(0)"
-    assert len(list_objects(cluster, "data/")) == FILES_OVERHEAD
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD)
 
     check_no_objects_after_drop(cluster)
 
@@ -531,6 +500,7 @@ def test_table_manipulations(cluster, node_name):
 def test_move_replace_partition_to_another_table(cluster, node_name):
     node = cluster.instances[node_name]
     create_table(node, "s3_test")
+    minio = cluster.minio_client
 
     node.query(
         "INSERT INTO s3_test VALUES {}".format(generate_values("2020-01-03", 4096))
@@ -547,10 +517,7 @@ def test_move_replace_partition_to_another_table(cluster, node_name):
     assert node.query("SELECT sum(id) FROM s3_test FORMAT Values") == "(0)"
     assert node.query("SELECT count(*) FROM s3_test FORMAT Values") == "(16384)"
 
-    assert (
-        len(list_objects(cluster, "data/", "Objects at start"))
-        == FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 4
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + FILES_OVERHEAD_PER_PART_WIDE * 4)
     create_table(node, "s3_clone")
 
     node.query("ALTER TABLE s3_test MOVE PARTITION '2020-01-03' TO TABLE s3_clone")
@@ -638,6 +605,7 @@ def test_move_replace_partition_to_another_table(cluster, node_name):
 def test_freeze_unfreeze(cluster, node_name):
     node = cluster.instances[node_name]
     create_table(node, "s3_test")
+    minio = cluster.minio_client
 
     node.query(
         "INSERT INTO s3_test VALUES {}".format(generate_values("2020-01-03", 4096))
@@ -651,11 +619,7 @@ def test_freeze_unfreeze(cluster, node_name):
     node.query("TRUNCATE TABLE s3_test")
     wait_for_delete_empty_parts(node, "s3_test")
     wait_for_delete_inactive_parts(node, "s3_test")
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD
-        + (FILES_OVERHEAD_PER_PART_WIDE - FILES_OVERHEAD_METADATA_VERSION) * 2
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + (FILES_OVERHEAD_PER_PART_WIDE - FILES_OVERHEAD_METADATA_VERSION) * 2)
 
     # Unfreeze single partition from backup1.
     node.query(
@@ -675,6 +639,7 @@ def test_freeze_system_unfreeze(cluster, node_name):
     node = cluster.instances[node_name]
     create_table(node, "s3_test")
     create_table(node, "s3_test_removed")
+    minio = cluster.minio_client
 
     node.query(
         "INSERT INTO s3_test VALUES {}".format(generate_values("2020-01-04", 4096))
@@ -689,11 +654,7 @@ def test_freeze_system_unfreeze(cluster, node_name):
     wait_for_delete_empty_parts(node, "s3_test")
     wait_for_delete_inactive_parts(node, "s3_test")
     node.query("DROP TABLE s3_test_removed SYNC")
-    assert (
-        len(list_objects(cluster, "data/"))
-        == FILES_OVERHEAD
-        + (FILES_OVERHEAD_PER_PART_WIDE - FILES_OVERHEAD_METADATA_VERSION) * 2
-    )
+    wait_blobs_count_synchronization(minio, FILES_OVERHEAD + (FILES_OVERHEAD_PER_PART_WIDE - FILES_OVERHEAD_METADATA_VERSION) * 2)
 
     # Unfreeze all data from backup3.
     node.query("SYSTEM UNFREEZE WITH NAME 'backup3'")
@@ -707,6 +668,7 @@ def test_freeze_system_unfreeze(cluster, node_name):
 @pytest.mark.parametrize("node_name", ["node"])
 def test_s3_disk_apply_new_settings(cluster, node_name):
     node = cluster.instances[node_name]
+    check_no_objects_after_drop(cluster)
     create_table(node, "s3_test")
 
     config_path = os.path.join(
@@ -1039,7 +1001,7 @@ def test_s3_disk_heavy_write_check_mem(cluster, broken_s3, node_name):
         " storage_policy='broken_s3'",
     )
 
-    uuid = node.query("SELECT uuid FROM system.tables WHERE name='s3_test'")
+    uuid = node.query("SELECT uuid FROM system.tables WHERE name='s3_test'").strip()
 
     node.query("SYSTEM STOP MERGES s3_test")
 

--- a/tests/integration/test_s3_plain_rewritable/test.py
+++ b/tests/integration/test_s3_plain_rewritable/test.py
@@ -63,7 +63,7 @@ def test(storage_policy, key_prefix):
             ) ENGINE=MergeTree()
             PARTITION BY id % 10
             ORDER BY id
-            SETTINGS storage_policy='{}'
+            SETTINGS storage_policy='{}', cleanup_delay_period=1, cleanup_delay_period_random_add=0, cleanup_thread_preferred_points_per_iteration=0
             """.format(
                 table_name, storage_policy
             )

--- a/tests/queries/0_stateless/01560_ttl_remove_empty_parts.sh
+++ b/tests/queries/0_stateless/01560_ttl_remove_empty_parts.sh
@@ -10,7 +10,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ${CLICKHOUSE_CLIENT} -q 'DROP TABLE IF EXISTS ttl_empty_parts'
 
 ${CLICKHOUSE_CLIENT} -q '
-    CREATE TABLE ttl_empty_parts (id UInt32, d Date) ENGINE = MergeTree ORDER BY tuple() PARTITION BY id SETTINGS old_parts_lifetime=5
+    CREATE TABLE ttl_empty_parts (id UInt32, d Date) ENGINE = MergeTree ORDER BY tuple() PARTITION BY id SETTINGS old_parts_lifetime = 5, merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0
 '
 
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO ttl_empty_parts SELECT 0, toDate('2005-01-01') + number from numbers(500);"

--- a/tests/queries/0_stateless/02421_new_type_json_empty_parts.sh
+++ b/tests/queries/0_stateless/02421_new_type_json_empty_parts.sh
@@ -11,7 +11,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_empty_parts;"
 ${CLICKHOUSE_CLIENT} -q "SELECT 'Collapsing';"
-${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_empty_parts (id UInt64, s Int8, data JSON) ENGINE = CollapsingMergeTree(s) ORDER BY id SETTINGS old_parts_lifetime=5;" --enable_json_type 1
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_empty_parts (id UInt64, s Int8, data JSON) ENGINE = CollapsingMergeTree(s) ORDER BY id SETTINGS old_parts_lifetime=5, merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;" --enable_json_type 1
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_empty_parts VALUES (1, 1, '{\"k1\": \"aaa\"}') (1, -1, '{\"k2\": \"bbb\"}');"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_json_empty_parts;"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.parts WHERE table = 't_json_empty_parts' AND database = currentDatabase() AND active;"
@@ -19,7 +19,7 @@ ${CLICKHOUSE_CLIENT} -q "SELECT DISTINCT arrayJoin(JSONAllPathsWithTypes(data)) 
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_empty_parts;"
 ${CLICKHOUSE_CLIENT} -q "SELECT 'DELETE all';"
-${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_empty_parts (id UInt64, data JSON) ENGINE = MergeTree ORDER BY id SETTINGS old_parts_lifetime=5;" --enable_json_type 1
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_empty_parts (id UInt64, data JSON) ENGINE = MergeTree ORDER BY id SETTINGS old_parts_lifetime=5, merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;" --enable_json_type 1
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_empty_parts VALUES (1, '{\"k1\": \"aaa\"}') (1, '{\"k2\": \"bbb\"}');"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_json_empty_parts;"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.parts WHERE table = 't_json_empty_parts' AND database = currentDatabase() AND active;"
@@ -32,7 +32,7 @@ ${CLICKHOUSE_CLIENT} -q "SELECT DISTINCT arrayJoin(JSONAllPathsWithTypes(data)) 
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_empty_parts;"
 ${CLICKHOUSE_CLIENT} -q "SELECT 'TTL';"
-${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_empty_parts (id UInt64, d Date, data JSON) ENGINE = MergeTree ORDER BY id TTL d WHERE id % 2 = 1 SETTINGS old_parts_lifetime=5;" --enable_json_type 1
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE t_json_empty_parts (id UInt64, d Date, data JSON) ENGINE = MergeTree ORDER BY id TTL d WHERE id % 2 = 1 SETTINGS old_parts_lifetime=5, merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;" --enable_json_type 1
 ${CLICKHOUSE_CLIENT} -q "INSERT INTO t_json_empty_parts VALUES (1, '2000-01-01', '{\"k1\": \"aaa\"}') (2, '2000-01-01', '{\"k2\": \"bbb\"}');"
 ${CLICKHOUSE_CLIENT} -q "OPTIMIZE TABLE t_json_empty_parts FINAL;"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t_json_empty_parts;"

--- a/tests/queries/0_stateless/03008_s3_plain_rewritable_fault.sh
+++ b/tests/queries/0_stateless/03008_s3_plain_rewritable_fault.sh
@@ -64,7 +64,7 @@ SETTINGS
         endpoint = 'http://localhost:11111/test/03008_test_s3_mt_fault/',
         access_key_id = clickhouse,
         secret_access_key = clickhouse),
-    old_parts_lifetime = 1;
+    old_parts_lifetime = 1, merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;
 "
 
 ${CLICKHOUSE_CLIENT} --query "

--- a/tests/queries/0_stateless/03198_unload_primary_key_outdated.sh
+++ b/tests/queries/0_stateless/03198_unload_primary_key_outdated.sh
@@ -9,7 +9,7 @@ $CLICKHOUSE_CLIENT "
 
     CREATE TABLE t_unload_primary_key (a UInt64, b UInt64)
     ENGINE = MergeTree ORDER BY a
-    SETTINGS old_parts_lifetime = 10000, use_primary_key_cache = 0;
+    SETTINGS old_parts_lifetime = 10000, use_primary_key_cache = 0, merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;
 
     INSERT INTO t_unload_primary_key VALUES (1, 1);
 

--- a/tests/queries/0_stateless/03305_mutations_counters.sh
+++ b/tests/queries/0_stateless/03305_mutations_counters.sh
@@ -26,7 +26,7 @@ function wait_for_mutation_cleanup()
 $CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS t_mutations_counters;
 
-    CREATE TABLE t_mutations_counters (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a;
+    CREATE TABLE t_mutations_counters (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a SETTINGS cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;
 
     INSERT INTO t_mutations_counters VALUES (1, 2) (2, 3);
 

--- a/tests/queries/0_stateless/03305_rename_mutations_counter.sh
+++ b/tests/queries/0_stateless/03305_rename_mutations_counter.sh
@@ -26,7 +26,7 @@ function wait_for_mutation_cleanup()
 $CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS t_mutations_counters_rename;
 
-    CREATE TABLE t_mutations_counters_rename (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a;
+    CREATE TABLE t_mutations_counters_rename (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a SETTINGS cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;
 
     INSERT INTO t_mutations_counters_rename VALUES (1, 2) (2, 3);
 

--- a/tests/queries/0_stateless/03357_replacing_min_age_cleanup.sh
+++ b/tests/queries/0_stateless/03357_replacing_min_age_cleanup.sh
@@ -26,7 +26,7 @@ SET alter_sync = 2;
 
 DROP TABLE IF EXISTS replacing;
 
-CREATE TABLE replacing (key int, value int, version int, deleted UInt8) ENGINE = ReplacingMergeTree(version, deleted) ORDER BY key SETTINGS merge_tree_clear_old_parts_interval_seconds = 1;
+CREATE TABLE replacing (key int, value int, version int, deleted UInt8) ENGINE = ReplacingMergeTree(version, deleted) ORDER BY key SETTINGS merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;
 
 INSERT INTO replacing VALUES (1, 1, 1, 0), (1, 1, 2, 1);
 
@@ -59,6 +59,9 @@ CREATE TABLE replacing2 (key int, value int, version int, deleted UInt8) ENGINE 
 SETTINGS allow_experimental_replacing_merge_with_cleanup = true,
     enable_replacing_merge_with_cleanup_for_min_age_to_force_merge = true,
     merge_tree_clear_old_parts_interval_seconds = 1,
+    cleanup_delay_period = 1,
+    cleanup_delay_period_random_add = 0,
+    cleanup_thread_preferred_points_per_iteration = 0,
     number_of_free_entries_in_pool_to_execute_optimize_entire_partition = 1,
     min_age_to_force_merge_on_partition_only = true,
     min_age_to_force_merge_seconds = 1,

--- a/tests/queries/0_stateless/03742_clean_up_thread_for_merge_tree.reference
+++ b/tests/queries/0_stateless/03742_clean_up_thread_for_merge_tree.reference
@@ -1,0 +1,1 @@
+OK: parts count reached 1

--- a/tests/queries/0_stateless/03742_clean_up_thread_for_merge_tree.sh
+++ b/tests/queries/0_stateless/03742_clean_up_thread_for_merge_tree.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: Fails due to failpoint intersection
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+on_exit() {
+    $CLICKHOUSE_CLIENT --query "SYSTEM DISABLE FAILPOINT storage_merge_tree_background_schedule_merge_fail;"
+}
+
+trap on_exit EXIT
+
+# Prepare
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE IF EXISTS m;
+
+    CREATE TABLE m (
+        i Int32
+    ) ENGINE = MergeTree
+    ORDER BY i
+    SETTINGS old_parts_lifetime = 1, merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 1, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0;
+
+    SYSTEM ENABLE FAILPOINT storage_merge_tree_background_schedule_merge_fail;
+
+    INSERT INTO m VALUES (1);
+    INSERT INTO m VALUES (2);
+
+    OPTIMIZE TABLE m FINAL;
+"
+
+function parts_count() {
+    $CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 'm';"
+}
+
+# Wait up to 60 seconds until count = 1
+ok=0
+for _ in $(seq 1 60); do
+    CNT=$(parts_count)
+    if [ "$CNT" -eq 1 ]; then
+        ok=1
+        break
+    fi
+
+    sleep 1
+done
+
+if [ "$ok" -eq 1 ]; then
+    echo "OK: parts count reached 1"
+else
+    echo "FAIL: parts count never reached 1 within 60 seconds"
+fi
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS m;"
+
+$CLICKHOUSE_CLIENT --query "
+    DROP TABLE IF EXISTS m;
+"


### PR DESCRIPTION
25.8 Antalya backport of #91574: Add cleanup thread to MergeTree to avoid cleanup starvation

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add a dedicated cleanup thread for MergeTree to prevent cleanup delays under heavy merge load. This resolves https://github.com/ClickHouse/ClickHouse/issues/86181.

The MergeTree cleanup logic was tightly coupled with the merge scheduler, which caused cleanup tasks to be delayed or completely blocked when the table was under heavy merge load. ReplicatedMergeTree already had a separate cleanup thread, so this change aligns MergeTree with that design. @azat You might be interested in this one.
(https://github.com/ClickHouse/ClickHouse/pull/91574 by amosbird)

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
