### PR TITLE
Altinity 26.6 - patch unit tests

### DIFF
--- a/.github/grype/run_grype_scan.sh
+++ b/.github/grype/run_grype_scan.sh
@@ -3,7 +3,7 @@ set -e
 
 IMAGE=$1
 
-GRYPE_VERSION=${GRYPE_VERSION:-"v0.92.2"}
+GRYPE_VERSION=${GRYPE_VERSION:-"v0.115.0"}
 
 docker pull $IMAGE
 docker pull anchore/grype:${GRYPE_VERSION}

--- a/.github/workflows/grype_scan.yml
+++ b/.github/workflows/grype_scan.yml
@@ -30,7 +30,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  GRYPE_VERSION: "v0.92.2-arm64v8"
+  GRYPE_VERSION: "v0.115.0-arm64v8"
 
 jobs:
     grype_scan:

--- a/src/IO/tests/gtest_silk_fiber_stream_socket.cpp
+++ b/src/IO/tests/gtest_silk_fiber_stream_socket.cpp
@@ -34,29 +34,6 @@
 namespace
 {
 
-class SilkEnvironment : public ::testing::Environment
-{
-public:
-    void SetUp() override
-    {
-        /// TODO(mstetsyuk): Silk::initializeFiberScheduler and Silk::destroyFiberScheduler are coming in another PR.
-        silk::initialize();
-        silk::FiberScheduler::Options options;
-        /// OpenSSL handshakes run on fiber stacks and need more room than the silk default.
-        options.fiberStackSize = 320 * 1024;
-        silk::FiberScheduler::initialize(&options);
-    }
-
-    void TearDown() override
-    {
-        silk::FiberScheduler::destroy();
-        silk::destroy();
-    }
-};
-
-::testing::Environment * const silk_env = ::testing::AddGlobalTestEnvironment(new SilkEnvironment);
-
-
 struct PlainPolicy
 {
     using Listener = Poco::Net::ServerSocket;
@@ -86,6 +63,22 @@ template <typename Policy>
 class SilkFiberSocketTest : public ::testing::Test
 {
 protected:
+    static void SetUpTestSuite()
+    {
+        /// Initialize silk only for this suite; global env setup breaks unrelated filtered runs.
+        silk::initialize();
+        silk::FiberScheduler::Options options;
+        /// OpenSSL handshakes run on fiber stacks and need more room than the silk default.
+        options.fiberStackSize = 320 * 1024;
+        silk::FiberScheduler::initialize(&options);
+    }
+
+    static void TearDownTestSuite()
+    {
+        silk::FiberScheduler::destroy();
+        silk::destroy();
+    }
+
     Policy policy;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Properly disable silk tests that are incompatible with our runners.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
