### PR TITLE
Stable 25.3: Fix Install Packages (aarch64) and Docker Server Image jobs

### DIFF
--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -26,7 +26,6 @@ RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list 
         tzdata \
         wget \
     && apt-get upgrade --yes --no-install-recommends \
-    && busybox --install -s \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
 

--- a/tests/ci/s3_helper.py
+++ b/tests/ci/s3_helper.py
@@ -144,7 +144,9 @@ class S3Helper:
                 logging.info("Processing file without compression")
             logging.info("File is too large, do not provide content type")
 
-        self.client.upload_file(file_path, bucket_name, s3_path, ExtraArgs=metadata)
+        self.client.upload_file(
+            str(file_path), bucket_name, s3_path, ExtraArgs=metadata
+        )
         url = self.s3_url(bucket_name, s3_path)
         logging.info("Upload %s to %s Meta: %s", file_path, url, metadata)
         return url
@@ -228,7 +230,7 @@ class S3Helper:
                 for i in range(5):
                     try:
                         self.client.upload_file(
-                            file_path, bucket_name, s3_path, ExtraArgs=metadata
+                            str(file_path), bucket_name, s3_path, ExtraArgs=metadata
                         )
                         break
                     except Exception as ex:

--- a/tests/ci/s3_helper.py
+++ b/tests/ci/s3_helper.py
@@ -175,7 +175,7 @@ class S3Helper:
         if Path(local_file_path).is_dir():
             local_file_path = Path(local_file_path) / s3_path.split("/")[-1]
         try:
-            self.client.download_file(bucket, s3_path, local_file_path)
+            self.client.download_file(bucket, s3_path, str(local_file_path))
         except botocore.exceptions.ClientError as e:
             if e.response and e.response["ResponseMetadata"]["HTTPStatusCode"] == 404:
                 assert False, f"No such object [s3://{S3_BUILDS_BUCKET}/{s3_path}]"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
