### PR TITLE
Antalya 25.8: fix some failing tests

### DIFF
--- a/tests/queries/0_stateless/04299_constraint_subst_correlated_subquery_root.sql
+++ b/tests/queries/0_stateless/04299_constraint_subst_correlated_subquery_root.sql
@@ -17,6 +17,10 @@ CREATE TABLE t_constraint_corr_root
 -- fail with `NOT_IMPLEMENTED` on this version, so use `MergeTree`, whose read step is cloneable.
 ENGINE = MergeTree ORDER BY tuple();
 
+-- With parallel replicas the read becomes a `ReadFromPreparedSource` step, which is not
+-- cloneable either, so decorrelation would fail the same way. Disable parallel replicas.
+SET enable_parallel_replicas = 0;
+
 INSERT INTO t_constraint_corr_root VALUES ('1', '2', '3', '4');
 
 SELECT count() FROM t_constraint_corr_root

--- a/tests/queries/0_stateless/04340_datalake_schema_deep_recursion.reference
+++ b/tests/queries/0_stateless/04340_datalake_schema_deep_recursion.reference
@@ -1,2 +1,1 @@
-delta_depth: JSONException
 iceberg_depth: JSONException

--- a/tests/queries/0_stateless/04340_datalake_schema_deep_recursion.sh
+++ b/tests/queries/0_stateless/04340_datalake_schema_deep_recursion.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 # Tags: no-fasttest, no-msan
-# Tag no-msan: the delta-kernel-rs library is not built with MSan, so the deltaLakeLocal table
-# function is not registered there and the delta case below would fail with UNKNOWN_FUNCTION.
-# Regression test: DeltaLake/Iceberg parse table-metadata schema JSON with Poco::JSON::Parser, which
-# defaulted to unlimited depth (setDepth was a no-op), so a deeply nested schema overflowed the
-# native stack inside Poco's recursive parser. The parsers now set a depth limit, so deep nesting is
+# Regression test: Iceberg parses table-metadata JSON with Poco::JSON::Parser, which defaulted to
+# unlimited depth (setDepth was a no-op), so a deeply nested metadata file overflowed the native
+# stack inside Poco's recursive parser. The parser now sets a depth limit, so deep nesting is
 # rejected with a clean JSON exception instead of crashing.
+#
+# The DeltaLake half of the upstream test is dropped here: the Antalya fork does not register the
+# deltaLakeLocal table function (only icebergLocal exists), so there is no lightweight local path to
+# exercise the C++ DeltaLake metadata parser. Iceberg covers the same shared Poco depth-limit fix.
+# Tag no-msan is retained from the original test (kept to avoid changing which CI configs run this).
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
 TMP_DIR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
-mkdir -p "$TMP_DIR/dl/_delta_log"
+mkdir -p "$TMP_DIR"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 # Reads a query's combined output from stdin. If it contains $2, print a stable "<label>: <marker>"
@@ -28,35 +31,15 @@ expect_contains() {
     fi
 }
 
-# Minimal Delta table whose metaData.schemaString is a struct nested 2000 deep. The depth only needs
-# to exceed the parser depth limit (1000) to be rejected; we keep it modest so the test stays cheap
-# and does not stress memory (a much deeper schema used to overflow the native stack unpatched).
-python3 - 2000 "$TMP_DIR/dl/_delta_log/00000000000000000000.json" <<'PYEOF'
-import json, sys
-N = int(sys.argv[1])
-pre = '{"type":"struct","fields":[{"name":"f","type":'
-suf = ',"nullable":false,"metadata":{}}]}'
-schema = '{"type":"struct","fields":[{"name":"x","type":' + pre * N + '"integer"' + suf * N + ',"nullable":false,"metadata":{}}]}'
-proto = {"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}}
-meta = {"metaData": {"id": "deep", "format": {"provider": "parquet", "options": {}},
-                     "schemaString": schema, "partitionColumns": [], "configuration": {},
-                     "createdTime": 1700000000000}}
-open(sys.argv[2], "w").write(json.dumps(proto) + "\n" + json.dumps(meta) + "\n")
-PYEOF
-
-# allow_experimental_delta_kernel_rs=0 selects the C++ metadata parser (the Rust kernel has its own
-# recursion limit). The deep schema must be rejected with a JSON exception, not crash the process.
-$CLICKHOUSE_LOCAL --query "DESCRIBE TABLE deltaLakeLocal('$TMP_DIR/dl') SETTINGS allow_experimental_delta_kernel_rs=0 FORMAT Null" 2>&1 \
-    | expect_contains delta_depth JSONException
-
 # Iceberg parses the whole metadata JSON with Poco before any field validation, so a deeply nested
-# metadata file overflows the parser (reachable at default settings, no kernel involved). Must be
-# rejected with a JSON exception.
+# metadata file (a struct nested 2000 deep, exceeding the parser depth limit of 1000) overflows the
+# parser and must be rejected with a JSON exception, not crash the process.
+# allow_local_data_lakes=1 lifts the Altinity guard that otherwise disables the *Local table functions.
 mkdir -p "$TMP_DIR/ice/metadata"
 python3 -c "
 N = 2000
 open('$TMP_DIR/ice/metadata/v1.metadata.json', 'wb').write(b'{' + b'\"a\":{' * N + b'\"x\":1' + b'}' * N + b'}')
 open('$TMP_DIR/ice/metadata/version-hint.text', 'w').write('1')
 "
-$CLICKHOUSE_LOCAL --query "DESCRIBE TABLE icebergLocal('$TMP_DIR/ice') FORMAT Null" 2>&1 \
+$CLICKHOUSE_LOCAL --query "DESCRIBE TABLE icebergLocal('$TMP_DIR/ice') SETTINGS allow_local_data_lakes=1 FORMAT Null" 2>&1 \
     | expect_contains iceberg_depth JSONException

--- a/tests/queries/0_stateless/04409_explain_actions_secret_args.sql
+++ b/tests/queries/0_stateless/04409_explain_actions_secret_args.sql
@@ -1,6 +1,9 @@
--- Tags: no-fasttest, no-old-analyzer
+-- Tags: no-fasttest
 -- Tag no-fasttest: the encryption functions are not available in the fast test build
--- Tag no-old-analyzer: the old analyzer builds the ActionsDAG without query-tree masking, so it still leaks the key
+
+-- The old analyzer builds the ActionsDAG without query-tree masking (and does not support
+-- EXPLAIN QUERY TREE at all), so force the new analyzer explicitly.
+SET enable_analyzer = 1;
 
 -- Secret arguments of recognized scalar functions must be hidden in the ActionsDAG dump of
 -- EXPLAIN actions, just like they already are for EXPLAIN SYNTAX and EXPLAIN QUERY TREE.

--- a/tests/queries/0_stateless/04410_explain_actions_secret_args_secondary.sh
+++ b/tests/queries/0_stateless/04410_explain_actions_secret_args_secondary.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-old-analyzer
+# Tags: no-fasttest
 # Tag no-fasttest: the encryption functions are not available in the fast test build
-# Tag no-old-analyzer: the old analyzer builds the ActionsDAG without query-tree masking, so it still leaks the key
 
 # On a secondary (shard) query the planner skips AST-level optimizations, so a secret argument
 # folded into a constant (e.g. concat('SECRET_', 'KEY')) used to be named by its source expression,
@@ -15,4 +14,5 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 QUERY="EXPLAIN actions = 1 SELECT encrypt('aes-128-ecb', toString(number), concat('SECRET_', 'KEY')) FROM numbers(1)"
 
 echo "-- secondary query, secrets hidden by default"
-${CLICKHOUSE_CLIENT} --query_kind secondary_query --query "${QUERY}"
+# The old analyzer builds the ActionsDAG without query-tree masking, so force the new analyzer.
+${CLICKHOUSE_CLIENT} --enable_analyzer=1 --query_kind secondary_query --query "${QUERY}"


### PR DESCRIPTION
* `04340_datalake_schema_deep_recursion`
* `04409_explain_actions_secret_args`
* `04410_explain_actions_secret_args_secondary`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_oauth--> OAuth (5m)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
