### PR TITLE
Stable 25.8: Backports of #88490 and #89999

### DIFF
--- a/src/Disks/ObjectStorages/IMetadataStorage.h
+++ b/src/Disks/ObjectStorages/IMetadataStorage.h
@@ -325,6 +325,9 @@ public:
         const std::string & /* config_prefix */,
         ContextPtr /* context */) {}
 
+    /// Only support writing with Append if MetadataTransactionPtr created by `createTransaction` has `supportAddingBlobToMetadata`
+    virtual bool supportWritingWithAppend() const { return false; }
+
 protected:
     [[noreturn]] static void throwNotImplemented()
     {

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.cpp
@@ -134,6 +134,12 @@ MetadataTransactionPtr MetadataStorageFromDisk::createTransaction()
     return std::make_shared<MetadataStorageFromDiskTransaction>(*this);
 }
 
+/// It supports writing with Append because `createTransaction` creates `MetadataStorageFromDiskTransaction` which has `supportAddingBlobToMetadata`
+bool MetadataStorageFromDisk::supportWritingWithAppend() const
+{
+    return true;
+}
+
 StoredObjects MetadataStorageFromDisk::getStorageObjects(const std::string & path) const
 {
     auto metadata = readMetadata(path);

--- a/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
+++ b/src/Disks/ObjectStorages/MetadataStorageFromDisk.h
@@ -33,6 +33,8 @@ public:
 
     MetadataTransactionPtr createTransaction() override;
 
+    bool supportWritingWithAppend() const override;
+
     const std::string & getPath() const override;
 
     MetadataStorageType getType() const override { return MetadataStorageType::Local; }

--- a/src/Disks/supportWritingWithAppend.cpp
+++ b/src/Disks/supportWritingWithAppend.cpp
@@ -1,0 +1,21 @@
+#include <Disks/supportWritingWithAppend.h>
+
+#include <Disks/ObjectStorages/DiskObjectStorage.h>
+
+namespace DB
+{
+bool supportWritingWithAppend(const DiskPtr & disk)
+{
+    auto target_disk = disk;
+    if (auto delegate_disk = target_disk->getDelegateDiskIfExists())
+        target_disk = delegate_disk;
+
+    if (auto * object_storage = dynamic_cast<DiskObjectStorage *>(target_disk.get()))
+    {
+        if (!object_storage->getMetadataStorage()->supportWritingWithAppend())
+            return false;
+    }
+    return true;
+}
+}
+

--- a/src/Disks/supportWritingWithAppend.h
+++ b/src/Disks/supportWritingWithAppend.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <Disks/IDisk.h>
+namespace DB
+{
+bool supportWritingWithAppend(const DiskPtr & disk);
+}

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -4,9 +4,12 @@
 #include <ranges>
 
 #include <Backups/BackupEntriesCollector.h>
+#include <Core/BackgroundSchedulePool.h>
+#include <Core/Names.h>
 #include <Core/QueryProcessingStage.h>
 #include <Core/Settings.h>
 #include <Databases/IDatabase.h>
+#include <Disks/ObjectStorages/DiskObjectStorage.h>
 #include <IO/SharedThreadPools.h>
 #include <IO/copyData.h>
 #include <Interpreters/ClusterProxy/SelectStreamFactory.h>
@@ -24,6 +27,7 @@
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Storages/AlterCommands.h>
 #include <Storages/MergeTree/ActiveDataPartSet.h>
+#include <Storages/MergeTree/AlterConversions.h>
 #include <Storages/MergeTree/Compaction/CompactionStatistics.h>
 #include <Storages/MergeTree/Compaction/ConstructFuturePart.h>
 #include <Storages/MergeTree/Compaction/MergePredicates/MergeTreeMergePredicate.h>
@@ -35,12 +39,11 @@
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/MergeTreeSink.h>
+#include <Storages/MergeTree/MergeTreeSinkPatch.h>
+#include <Storages/MergeTree/PatchParts/PatchPartsUtils.h>
 #include <Storages/MergeTree/checkDataPart.h>
 #include <Storages/PartitionCommands.h>
 #include <Storages/buildQueryTreeForShard.h>
-#include <Storages/MergeTree/MergeTreeSinkPatch.h>
-#include <Storages/MergeTree/PatchParts/PatchPartsUtils.h>
-#include <Storages/MergeTree/AlterConversions.h>
 #include <fmt/core.h>
 #include <Common/ErrorCodes.h>
 #include <Common/Exception.h>
@@ -48,8 +51,6 @@
 #include <Common/MemoryTracker.h>
 #include <Common/ProfileEventsScope.h>
 #include <Common/escapeForFileName.h>
-#include <Core/BackgroundSchedulePool.h>
-#include <Core/Names.h>
 
 
 namespace ProfileEvents
@@ -147,6 +148,22 @@ static MergeTreeTransactionPtr tryGetTransactionForMutation(const MergeTreeMutat
     return {};
 }
 
+static bool supportTransaction(const Disks & disks, LoggerPtr log)
+{
+    for (const auto & disk : disks)
+    {
+        if (auto * object_storage = dynamic_cast<DiskObjectStorage *>(disk.get()))
+        {
+            if (!object_storage->getMetadataStorage()->supportWritingWithAppend())
+            {
+                LOG_DEBUG(log, "Disk {} does not support writing with append", object_storage->getName());
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 StorageMergeTree::StorageMergeTree(
     const StorageID & table_id_,
     const String & relative_data_path_,
@@ -157,18 +174,19 @@ StorageMergeTree::StorageMergeTree(
     const MergingParams & merging_params_,
     std::unique_ptr<MergeTreeSettings> storage_settings_)
     : MergeTreeData(
-        table_id_,
-        metadata_,
-        context_,
-        date_column_name,
-        merging_params_,
-        std::move(storage_settings_),
-        false,      /// require_part_metadata
-        mode)
+          table_id_,
+          metadata_,
+          context_,
+          date_column_name,
+          merging_params_,
+          std::move(storage_settings_),
+          false, /// require_part_metadata
+          mode)
     , reader(*this)
     , writer(*this)
     , merger_mutator(*this)
     , cleanup_thread(*this)
+    , support_transaction(supportTransaction(getDisks(), log.load()))
 {
     initializeDirectoriesAndFormatVersion(relative_data_path_, LoadingStrictnessLevel::ATTACH <= mode, date_column_name);
 
@@ -186,10 +204,7 @@ StorageMergeTree::StorageMergeTree(
     loadMutations();
     loadDeduplicationLog();
 
-    prewarmCaches(
-        getActivePartsLoadingThreadPool().get(),
-        getMarkCacheToPrewarm(0),
-        getPrimaryIndexCacheToPrewarm(0));
+    prewarmCaches(getActivePartsLoadingThreadPool().get(), getMarkCacheToPrewarm(0), getPrimaryIndexCacheToPrewarm(0));
 }
 
 
@@ -2930,5 +2945,4 @@ CommittingBlocksSet StorageMergeTree::getCommittingBlocks() const
     std::lock_guard lock(committing_blocks_mutex);
     return committing_blocks;
 }
-
 }

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -9,7 +9,7 @@
 #include <Core/QueryProcessingStage.h>
 #include <Core/Settings.h>
 #include <Databases/IDatabase.h>
-#include <Disks/ObjectStorages/DiskObjectStorage.h>
+#include <Disks/supportWritingWithAppend.h>
 #include <IO/SharedThreadPools.h>
 #include <IO/copyData.h>
 #include <Interpreters/ClusterProxy/SelectStreamFactory.h>
@@ -152,13 +152,10 @@ static bool supportTransaction(const Disks & disks, LoggerPtr log)
 {
     for (const auto & disk : disks)
     {
-        if (auto * object_storage = dynamic_cast<DiskObjectStorage *>(disk.get()))
+        if (!supportWritingWithAppend(disk))
         {
-            if (!object_storage->getMetadataStorage()->supportWritingWithAppend())
-            {
-                LOG_DEBUG(log, "Disk {} does not support writing with append", object_storage->getName());
-                return false;
-            }
+            LOG_DEBUG(log, "Disk {} does not support writing with append", disk->getName());
+            return false;
         }
     }
     return true;

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -59,7 +59,7 @@ public:
 
     bool supportsParallelInsert() const override { return true; }
 
-    bool supportsTransactions() const override { return true; }
+    bool supportsTransactions() const override { return support_transaction; }
 
     void read(
         QueryPlan & query_plan,
@@ -176,6 +176,8 @@ private:
     std::mutex mutation_prepared_sets_cache_mutex;
     std::map<Int64, PreparedSetsCachePtr::weak_type> mutation_prepared_sets_cache;
     PlainLightweightUpdatesSync lightweight_updates_sync;
+
+    const bool support_transaction;
 
     void loadMutations();
 

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -42,6 +42,14 @@
                 <background_download_queue_size_limit>0</background_download_queue_size_limit>
                 <load_metadata_asynchronously>0</load_metadata_asynchronously>
             </s3_cache_02933>
+            <s3_plain_rewritable>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain_rewritable</metadata_type>
+                <endpoint>http://localhost:11111/test/s3_plain_rewritable/</endpoint>
+                <access_key_id>clickhouse</access_key_id>
+                <secret_access_key>clickhouse</secret_access_key>
+            </s3_plain_rewritable>
             <!-- local disks -->
             <local_disk>
                 <type>object_storage</type>
@@ -79,6 +87,12 @@
                 <max_size>22548578304</max_size>
                 <cache_on_write_operations>1</cache_on_write_operations>
             </local_cache_3>
+            <local_plain_rewritable>
+                <type>object_storage</type>
+                <object_storage_type>local</object_storage_type>
+                <path>disks/test/local_plain_rewritable/</path>
+                <metadata_type>plain_rewritable</metadata_type>
+            </local_plain_rewritable>
             <!-- multi layer cache -->
             <s3_cache_multi>
                 <type>cache</type>

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -50,6 +50,16 @@
                 <access_key_id>clickhouse</access_key_id>
                 <secret_access_key>clickhouse</secret_access_key>
             </s3_plain_rewritable>
+            <s3_plain_rewritable_cache>
+                <type>cache</type>
+                <disk>s3_plain_rewritable</disk>
+                <path>s3_plain_rewritable_cache/</path>
+                <max_size>128Mi</max_size>
+                <cache_on_write_operations>1</cache_on_write_operations>
+                <background_download_threads>0</background_download_threads>
+                <background_download_queue_size_limit>0</background_download_queue_size_limit>
+                <load_metadata_asynchronously>0</load_metadata_asynchronously>
+            </s3_plain_rewritable_cache>
             <!-- local disks -->
             <local_disk>
                 <type>object_storage</type>
@@ -113,6 +123,23 @@
                 <secret_access_key>clickhouse</secret_access_key>
                 <s3_check_objects_after_upload>0</s3_check_objects_after_upload>
             </s3_no_cache>
+            <s3_plain_rewritable_cache_multi>
+                <type>cache</type>
+                <disk>s3_plain_rewritable_cache</disk>
+                <path>s3_plain_rewritable_cache_multi/</path>
+                <max_size>22548578304</max_size>
+            </s3_plain_rewritable_cache_multi>
+            <local_cache_multi>
+                <type>cache</type>
+                <disk>local_cache</disk>
+                <path>local_cache_multi/</path>
+                <max_size>22548578304</max_size>
+            </local_cache_multi>
+            <encrypted_s3_plain_rewritable_cache>
+                <type>encrypted</type>
+                <disk>s3_plain_rewritable_cache</disk>
+                <key>1234567812345678</key>
+            </encrypted_s3_plain_rewritable_cache>
         </disks>
         <policies>
             <local_remote>

--- a/tests/queries/0_stateless/03657_merge_tree_disk_support_transaction.sql
+++ b/tests/queries/0_stateless/03657_merge_tree_disk_support_transaction.sql
@@ -1,0 +1,41 @@
+-- Tags: no-ordinary-database, no-fasttest, no-encrypted-storage, no-async-insert
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x;
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (1);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (2);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk_2';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (3);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk_3';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (4);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_disk';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (5);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_plain_rewritable';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (6); -- { serverError NOT_IMPLEMENTED }
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t  (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_cache';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (7);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t  (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_plain_rewritable';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (8); -- { serverError NOT_IMPLEMENTED }
+SET implicit_transaction=False;

--- a/tests/queries/0_stateless/03657_merge_tree_disk_support_transaction.sql
+++ b/tests/queries/0_stateless/03657_merge_tree_disk_support_transaction.sql
@@ -7,35 +7,59 @@ SET implicit_transaction=False;
 
 CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk';
 SET implicit_transaction=True;
-INSERT INTO TABLE t VALUES (2);
+INSERT INTO TABLE t VALUES (1);
 SET implicit_transaction=False;
 
 CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk_2';
 SET implicit_transaction=True;
-INSERT INTO TABLE t VALUES (3);
+INSERT INTO TABLE t VALUES (1);
 SET implicit_transaction=False;
 
 CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_disk_3';
 SET implicit_transaction=True;
-INSERT INTO TABLE t VALUES (4);
+INSERT INTO TABLE t VALUES (1);
 SET implicit_transaction=False;
 
 CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_disk';
 SET implicit_transaction=True;
-INSERT INTO TABLE t VALUES (5);
+INSERT INTO TABLE t VALUES (1);
 SET implicit_transaction=False;
 
 CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_plain_rewritable';
 SET implicit_transaction=True;
-INSERT INTO TABLE t VALUES (6); -- { serverError NOT_IMPLEMENTED }
+INSERT INTO TABLE t VALUES (1); -- { serverError NOT_IMPLEMENTED }
 SET implicit_transaction=False;
 
 CREATE OR REPLACE TABLE t  (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_cache';
 SET implicit_transaction=True;
-INSERT INTO TABLE t VALUES (7);
+INSERT INTO TABLE t VALUES (1);
 SET implicit_transaction=False;
 
 CREATE OR REPLACE TABLE t  (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_plain_rewritable';
 SET implicit_transaction=True;
-INSERT INTO TABLE t VALUES (8); -- { serverError NOT_IMPLEMENTED }
+INSERT INTO TABLE t VALUES (1); -- { serverError NOT_IMPLEMENTED }
 SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_plain_rewritable_cache';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (1); -- { serverError NOT_IMPLEMENTED }
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='s3_plain_rewritable_cache_multi';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (1); -- { serverError NOT_IMPLEMENTED }
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_cache';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (1);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='local_cache_multi';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (1);
+SET implicit_transaction=False;
+
+CREATE OR REPLACE TABLE t (x INT) ENGINE=MergeTree ORDER BY x SETTINGS disk='encrypted_s3_plain_rewritable_cache';
+SET implicit_transaction=True;
+INSERT INTO TABLE t VALUES (1); -- { serverError NOT_IMPLEMENTED }


### PR DESCRIPTION
Backporting to stable-25.8 because this crash is currently failing the Stress test on our CI (server aborts on transaction commit over non-append disks).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
For MergeTree tables using object storage which do not support writing with append, it will not support transactions. (https://github.com/ClickHouse/ClickHouse/pull/88490 by @tuanpach)
Check if encrypted disks support writing with append (https://github.com/ClickHouse/ClickHouse/pull/89999 by @tuanpach)
Closes https://github.com/ClickHouse/ClickHouse/issues/84669

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_oauth--> OAuth (5m)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [x] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [x] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
