### PR TITLE
Antalya 26.6 - Backport flaky-fix commits from upstream (2026-07-21)

### DIFF
--- a/tests/integration/helpers/catalog_manager_aws_glue.py
+++ b/tests/integration/helpers/catalog_manager_aws_glue.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import logging
 import os
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -218,11 +219,86 @@ class AwsGlueCatalogManager(CatalogManager):
         log.info("Created Glue Iceberg table '%s'", table_identifier)
         return table_name
 
-    def wait_for_table_ready(self, table_name: str) -> None:
-        pass
+    def _namespace_for(self, table_name: str) -> Optional[str]:
+        # Each create_table() puts the table in its own namespace; use the
+        # most recent matching entry.
+        for ns, tn in reversed(self._tables_created):
+            if tn == table_name:
+                return ns
+        return None
 
-    def wait_for_table_gone(self, table_name: str) -> None:
-        pass
+    def wait_for_table_ready(
+        self,
+        table_name: str,
+        timeout: float = 120,
+        poll_interval: float = 5,
+    ) -> None:
+        """Poll until the table is both loadable AND visible in the Glue
+        namespace listing. Glue is eventually-consistent for GetTables, so a
+        freshly-created table can be briefly absent from the listing.
+        """
+        namespace = self._namespace_for(table_name)
+        if namespace is None:
+            return
+        identifier = f"{namespace}.{table_name}"
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                self.catalog.load_table(identifier)
+                listed = self.catalog.list_tables(namespace)
+                listed_names = [t[-1] for t in listed]
+                if table_name in listed_names:
+                    log.info(
+                        "Table '%s' ready and listed after %d attempts",
+                        identifier, attempt,
+                    )
+                    return
+                log.warning(
+                    "Table '%s' loadable but not yet listed (attempt %d)",
+                    identifier, attempt,
+                )
+            except Exception as exc:
+                log.warning(
+                    "load_table('%s') failed (attempt %d): %s",
+                    identifier, attempt, exc,
+                )
+
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Table '{identifier}' not ready/listed via pyiceberg "
+                    f"after {timeout}s ({attempt} attempts)."
+                )
+            time.sleep(poll_interval)
+
+    def wait_for_table_gone(
+        self,
+        table_name: str,
+        timeout: float = 120,
+        poll_interval: float = 5,
+    ) -> None:
+        """Poll until load_table raises, confirming the table is gone."""
+        namespace = self._namespace_for(table_name)
+        if namespace is None:
+            return
+        identifier = f"{namespace}.{table_name}"
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                self.catalog.load_table(identifier)
+            except Exception:
+                log.info("Table '%s' gone after %d attempts", identifier, attempt)
+                return
+
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Table '{identifier}' still visible via pyiceberg "
+                    f"after {timeout}s ({attempt} attempts)."
+                )
+            time.sleep(poll_interval)
 
     def _delete_s3_prefix(self, namespace: str, table_name: str) -> None:
         prefix = f"{self.config.prefix}/{namespace}/{table_name}/"

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1,5 +1,4 @@
 import base64
-import concurrent
 import errno
 import http.client
 import json
@@ -4666,19 +4665,12 @@ class ClickHouseCluster:
 
     def process_integration_nodes(self, integration: str, nodes: list, action: str):
         base_cmd = getattr(self, f"base_{integration}_cmd")
-
-        def process_single_node(node):
-            logging.info("%sing %s node: %s", action.capitalize(), integration, node)
-            subprocess_check_call(base_cmd + [action, node])
-            logging.info("%sed %s node: %s", action.capitalize(), integration, node)
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(nodes)) as executor:
-            futures = []
-            for n in nodes:
-                futures += [executor.submit(process_single_node, n)]
-
-            for future in concurrent.futures.as_completed(futures):
-                future.result()
+        # One `docker compose` invocation for all nodes: concurrent compose commands on
+        # the same project race on shared project state and can silently drop a node's
+        # action. compose parallelizes the services internally.
+        logging.info("%sing %s nodes: %s", action.capitalize(), integration, nodes)
+        subprocess_check_call(base_cmd + [action] + list(nodes))
+        logging.info("%sed %s nodes: %s", action.capitalize(), integration, nodes)
 
     # Faster than waiting for clean stop
     def kill_zookeeper_nodes(self, zk_nodes):

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -2260,7 +2260,9 @@ def test_async_backup_restore_with_max_execution_time_zero():
     backup_name = new_backup_name()
     inst.query("CREATE DATABASE IF NOT EXISTS test")
     inst.query("CREATE TABLE test.table(x UInt32, y String) ENGINE=MergeTree ORDER BY y PARTITION BY x%10")
-    inst.query("INSERT INTO test.table SELECT number, toString(number) FROM numbers(100)")
+    # The node's 0.5s profile timeout (used below to trigger the bug) also caps this
+    # foreground setup query; disable it so a slow CI lane can't time out the INSERT.
+    inst.query("INSERT INTO test.table SELECT number, toString(number) FROM numbers(100) SETTINGS max_execution_time = 0")
 
     try:
         # Pause backup before it starts so the 500ms profile-level timeout fires.
@@ -2298,7 +2300,11 @@ def test_async_backup_restore_with_max_execution_time_zero():
             TSV([["RESTORED", ""]]),
         )
 
-        assert inst.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+        # Same: don't let the 0.5s profile timeout cap this foreground verification query.
+        assert (
+            inst.query("SELECT count(), sum(x) FROM test.table SETTINGS max_execution_time = 0")
+            == "100\t4950\n"
+        )
     finally:
         inst.query("SYSTEM DISABLE FAILPOINT backup_pause_on_start")
         inst.query("SYSTEM DISABLE FAILPOINT restore_pause_on_start")

--- a/tests/integration/test_backup_restore_on_cluster/configs/lesser_timeouts.xml
+++ b/tests/integration/test_backup_restore_on_cluster/configs/lesser_timeouts.xml
@@ -2,6 +2,6 @@
     <backups>
         <sync_period_ms>1000</sync_period_ms>
         <consistent_metadata_snapshot_timeout>10000</consistent_metadata_snapshot_timeout>
-        <create_table_timeout>3000</create_table_timeout>
+        <create_table_timeout>30000</create_table_timeout>
     </backups>
 </clickhouse>

--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -381,6 +381,31 @@ class NoTrashChecker:
             assert False
 
 
+# Waits until every BACKUP process from a previous test has finished, so its residual errors
+# and ZooKeeper cleanup don't land inside the next test's NoTrashChecker window. Tests run in
+# random order in CI, so any test may precede another.
+def wait_for_backups_to_finish():
+    for _ in range(30):
+        if not any(
+            int(node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")) > 0
+            for node in nodes
+        ):
+            break
+        time.sleep(1)
+
+    backup_process_counts = {
+        get_node_name(node): int(
+            node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")
+        )
+        for node in nodes
+    }
+    total_backup_processes = sum(backup_process_counts.values())
+    assert total_backup_processes == 0, (
+        "Backup queries still running after pre-test wait: "
+        + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
+    )
+
+
 __backup_id_of_successful_backup = None
 
 
@@ -534,7 +559,20 @@ def test_cancel_restore():
 
 # Test that shutdown cancels a running backup and doesn't wait until it finishes.
 def test_shutdown_cancels_backup():
+    wait_for_backups_to_finish()
+
     with NoTrashChecker() as no_trash_checker:
+        # Restarting a node mid-backup makes the surviving node briefly lose its connection
+        # to the restarting peer and to Keeper, so transient network/Keeper errors are expected.
+        no_trash_checker.allow_errors = [
+            "KEEPER_EXCEPTION",
+            "SOCKET_TIMEOUT",
+            "CANNOT_READ_ALL_DATA",
+            "NETWORK_ERROR",
+            "TABLE_IS_READ_ONLY",
+            "NO_REPLICA_HAS_PART",
+        ]
+
         create_and_fill_table(random_node())
 
         initiator = random_node()
@@ -598,25 +636,17 @@ def test_error_leaves_no_trash():
 
 # A backup must be stopped if Zookeeper is disconnected longer than `failure_after_host_disconnected_for_seconds`.
 def test_long_disconnection_stops_backup():
+    wait_for_backups_to_finish()
+
     create_and_fill_table(random_node(), num_parts=100)
 
     with NoTrashChecker() as no_trash_checker, ConfigManager() as config_manager:
-        # Config "faster_zk_disconnect_detect.xml" is used in this test to decrease number of retries when reconnecting to ZooKeeper.
-        # Without this config this test can take several minutes (instead of seconds) to run.
-        config_manager.add_main_config(nodes, "configs/faster_zk_disconnect_detect.xml")
-
-        initiator = random_node()
-        print(f"Using {get_node_name(initiator)} as initiator")
-
         backup_id = random_id()
-        initiator.query(
-            f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {get_backup_name(backup_id)} SETTINGS id='{backup_id}' ASYNC",
-            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 3},
-        )
 
-        assert get_status(initiator, backup_id=backup_id) == "CREATING_BACKUP"
-        assert get_num_system_processes(initiator, backup_id=backup_id) >= 1
-
+        # Set the relaxations before any statement that can raise, so __exit__ doesn't mask
+        # a real body failure with a spurious "unexpected error" assertion: this test
+        # deliberately disconnects ZooKeeper, so transient ZK/network errors are expected and
+        # the backup is left unfinished.
         no_trash_checker.allow_unfinished_backups = [backup_id]
         no_trash_checker.allow_errors = [
             "FAILED_TO_SYNC_BACKUP_OR_RESTORE",
@@ -628,6 +658,21 @@ def test_long_disconnection_stops_backup():
             "NO_REPLICA_HAS_PART",
         ]
         no_trash_checker.check_zookeeper = False
+
+        # Config "faster_zk_disconnect_detect.xml" is used in this test to decrease number of retries when reconnecting to ZooKeeper.
+        # Without this config this test can take several minutes (instead of seconds) to run.
+        config_manager.add_main_config(nodes, "configs/faster_zk_disconnect_detect.xml")
+
+        initiator = random_node()
+        print(f"Using {get_node_name(initiator)} as initiator")
+
+        initiator.query(
+            f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {get_backup_name(backup_id)} SETTINGS id='{backup_id}' ASYNC",
+            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 3},
+        )
+
+        assert get_status(initiator, backup_id=backup_id) == "CREATING_BACKUP"
+        assert get_num_system_processes(initiator, backup_id=backup_id) >= 1
 
         with PartitionManager() as pm:
             random_sleep(3)
@@ -656,28 +701,7 @@ def test_long_disconnection_stops_backup():
 
 # A backup must NOT be stopped if Zookeeper is disconnected shorter than `failure_after_host_disconnected_for_seconds`.
 def test_short_disconnection_doesnt_stop_backup():
-    # Wait for any backup processes from the previous test to finish their ZooKeeper cleanup
-    # before creating the NoTrashChecker, so residual errors don't fall in its time window.
-    for _ in range(30):
-        if not any(
-            int(node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")) > 0
-            for node in nodes
-        ):
-            break
-        time.sleep(1)
-
-    backup_process_counts = {
-        get_node_name(node): int(
-            node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")
-        )
-        for node in nodes
-    }
-    total_backup_processes = sum(backup_process_counts.values())
-    assert total_backup_processes == 0, (
-        "Backup queries still running after pre-test wait in "
-        "test_short_disconnection_doesnt_stop_backup: "
-        + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
-    )
+    wait_for_backups_to_finish()
 
     create_and_fill_table(random_node())
 
@@ -734,28 +758,7 @@ def test_short_disconnection_doesnt_stop_backup():
 
 # A restore must NOT be stopped if Zookeeper is disconnected shorter than `failure_after_host_disconnected_for_seconds`.
 def test_short_disconnection_doesnt_stop_restore():
-    # Wait for any backup processes from the previous test to finish their ZooKeeper cleanup
-    # before creating the NoTrashChecker, so residual errors don't fall in its time window.
-    for _ in range(30):
-        if not any(
-            int(node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")) > 0
-            for node in nodes
-        ):
-            break
-        time.sleep(1)
-
-    backup_process_counts = {
-        get_node_name(node): int(
-            node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")
-        )
-        for node in nodes
-    }
-    total_backup_processes = sum(backup_process_counts.values())
-    assert total_backup_processes == 0, (
-        "Backup queries still running after pre-test wait in "
-        "test_short_disconnection_doesnt_stop_backup: "
-        + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
-    )
+    wait_for_backups_to_finish()
 
     # Make a backup.
     backup_id = get_backup_id_of_successful_backup()

--- a/tests/integration/test_backup_restore_on_cluster_with_checksum_data_file_name/configs/lesser_timeouts.xml
+++ b/tests/integration/test_backup_restore_on_cluster_with_checksum_data_file_name/configs/lesser_timeouts.xml
@@ -2,6 +2,6 @@
     <backups>
         <sync_period_ms>1000</sync_period_ms>
         <consistent_metadata_snapshot_timeout>10000</consistent_metadata_snapshot_timeout>
-        <create_table_timeout>3000</create_table_timeout>
+        <create_table_timeout>30000</create_table_timeout>
     </backups>
 </clickhouse>

--- a/tests/integration/test_dictionaries_postgresql/test.py
+++ b/tests/integration/test_dictionaries_postgresql/test.py
@@ -9,6 +9,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.config_cluster import pg_pass
 from helpers.postgres_utility import get_postgres_conn
 from helpers.port_forward import PortForward
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -352,52 +353,63 @@ def test_invalidate_query(started_cluster):
     # invalidate query: SELECT value FROM test0 WHERE id = 0
     dict_name = "dict0"
     create_dict(table_name)
+
+    def last_update():
+        # 1970-01-01 00:00:00 means the dictionary was never updated yet.
+        return node1.query(
+            "SELECT toTimeZone(last_successful_update_time, 'UTC') "
+            f"FROM system.dictionaries WHERE name = '{dict_name}'"
+        ).strip()
+
+    def wait_baseline_settled():
+        # SYSTEM RELOAD does a forced full reload but does not run the invalidate
+        # query, so the stored invalidate response is left empty. The first
+        # periodic check then always sees a "modified" source and reloads once
+        # more. Wait until the invalidate baseline settles, i.e.
+        # last_successful_update_time stops advancing across a full check period,
+        # so subsequent "no update" checks are reliable.
+        prev = last_update()
+        while True:
+            time.sleep(7)  # dict lifetime is 1s and the periodic check runs every 5s
+            cur = last_update()
+            if cur == prev:
+                return cur
+            prev = cur
+
+    def dict_get(key):
+        return node1.query(
+            f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64({key}))"
+        ).strip()
+
     node1.query(f"SYSTEM RELOAD DICTIONARY {dict_name}")
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))")
-        == "0\n"
-    )
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(1))")
-        == "1\n"
-    )
+    wait_baseline_settled()
+    assert dict_get(0) == "0"
+    assert dict_get(1) == "1"
 
-    # update should happen
-    cursor.execute(f"UPDATE {table_name} SET value=value+1 WHERE id = 0")
-    while True:
-        result = node1.query(
-            f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))"
-        )
-        if result != "0\n":
-            break
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))")
-        == "1\n"
+    # update should happen: the invalidate query result (value at id = 0) changes
+    cursor.execute(f"UPDATE {table_name} SET value = value + 1 WHERE id = 0")
+    assert_eq_with_retry(
+        node1, f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))", "1"
     )
+    settled = wait_baseline_settled()
+    assert dict_get(0) == "1"
 
-    # no update should happen
-    cursor.execute(f"UPDATE {table_name} SET value=value*2 WHERE id != 0")
-    time.sleep(5)
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))")
-        == "1\n"
-    )
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(1))")
-        == "1\n"
-    )
+    # no update should happen: the invalidate query result (value at id = 0) is
+    # unchanged, so the dictionary must not reload and pick up the change to
+    # other rows. Verify directly that no reload was triggered.
+    cursor.execute(f"UPDATE {table_name} SET value = value * 2 WHERE id != 0")
+    time.sleep(7)  # more than one periodic check period
+    assert last_update() == settled
+    assert dict_get(0) == "1"
+    assert dict_get(1) == "1"
 
-    # update should happen
-    cursor.execute(f"UPDATE {table_name} SET value=value+1 WHERE id = 0")
-    time.sleep(5)
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))")
-        == "2\n"
+    # update should happen: the invalidate query result (value at id = 0) changes
+    cursor.execute(f"UPDATE {table_name} SET value = value + 1 WHERE id = 0")
+    assert_eq_with_retry(
+        node1, f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))", "2"
     )
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(1))")
-        == "2\n"
-    )
+    assert dict_get(0) == "2"
+    assert dict_get(1) == "2"
 
     node1.query(f"DROP TABLE IF EXISTS {table_name}")
     node1.query(f"DROP DICTIONARY IF EXISTS {dict_name}")

--- a/tests/integration/test_distributed_frozen_replica/test.py
+++ b/tests/integration/test_distributed_frozen_replica/test.py
@@ -129,7 +129,13 @@ def test_distributed_query(
     # Stop fetches on node2 so that it will be considered stale and node1 is tried first
     node2.query("SYSTEM STOP FETCHES")
     try:
-        node1.query("DELETE FROM local_table WHERE i = 5")
+        # lightweight_deletes_sync defaults to 2 (wait on all replicas); node2 is
+        # deliberately stalled above, so the default would block until node2 applies
+        # the mutation. Wait only on node1 (=1) to keep node2 stale, as intended.
+        node1.query(
+            "DELETE FROM local_table WHERE i = 5",
+            settings={"lightweight_deletes_sync": 1},
+        )
         node1.query("INSERT INTO local_table VALUES (5, now())")
         time.sleep(10)
         assert (
@@ -188,7 +194,13 @@ def test_distributed_query_network_timeout(
     # Stop fetches on node2 so that it will be considered stale and node1 is tried first
     node2.query("SYSTEM STOP FETCHES")
     try:
-        node1.query("DELETE FROM local_table WHERE i = 5")
+        # lightweight_deletes_sync defaults to 2 (wait on all replicas); node2 is
+        # deliberately stalled above, so the default would block until node2 applies
+        # the mutation. Wait only on node1 (=1) to keep node2 stale, as intended.
+        node1.query(
+            "DELETE FROM local_table WHERE i = 5",
+            settings={"lightweight_deletes_sync": 1},
+        )
         node1.query("INSERT INTO local_table VALUES (5, now())")
         time.sleep(10)
         assert (

--- a/tests/integration/test_implicit_index_upgrade/test.py
+++ b/tests/integration/test_implicit_index_upgrade/test.py
@@ -225,6 +225,12 @@ def test_implicit_index_upgrade_alter_replay(started_cluster):
 
     wait_for_active_replica(node2, "test_alter_replay")
 
+    # wait_for_active_replica only waits for is_readonly = 0, not for the freshly-joined
+    # replica to finish fetching parts. SYSTEM SYNC REPLICA blocks until node2 has fetched
+    # all parts; otherwise the count assertion below races with the background fetch and can
+    # observe only the small VALUES part (1 row) before the 10000-row part arrives.
+    node2.query("SYSTEM SYNC REPLICA test_alter_replay;")
+
     # Verify node2 has the ALTER-added column and all data.
     assert node2.query("SELECT count() FROM test_alter_replay;").strip() == "10001"
     assert (

--- a/tests/integration/test_keeper_disks/test.py
+++ b/tests/integration/test_keeper_disks/test.py
@@ -231,11 +231,25 @@ def test_snapshots_with_disks(started_cluster):
             cleanup_disks=False,
         )
 
-        ## all but the latest log should be on S3
+        # Relocating non-latest snapshots to the configured disk runs after the
+        # "Created persistent snapshot" log line, so poll for the count to settle
+        # instead of checking once (mirrors assert_single_local_log above).
+        def assert_single_local_snapshot():
+            local_snapshot_files = get_local_snapshots(node_snapshot)
+            start_time = time.time()
+            while len(local_snapshot_files) != 1:
+                logging.debug(f"Local snapshot files: {local_snapshot_files}")
+                assert (
+                    time.time() - start_time < 60
+                ), "local_snapshot_files size is not equal to 1 after 60s"
+                time.sleep(1)
+                local_snapshot_files = get_local_snapshots(node_snapshot)
+
+        ## all but the latest snapshot should be on S3
+        assert_single_local_snapshot()
+        local_snapshot_files = get_local_snapshots(node_snapshot)
         s3_snapshot_files = list_s3_objects(started_cluster, "snapshots/")
         assert set(s3_snapshot_files) == set(previous_snapshot_files[:-1])
-        local_snapshot_files = get_local_snapshots(node_snapshot)
-        assert len(local_snapshot_files) == 1
         assert local_snapshot_files[0] == previous_snapshot_files[-1]
 
         previous_snapshot_files = s3_snapshot_files + local_snapshot_files
@@ -250,9 +264,9 @@ def test_snapshots_with_disks(started_cluster):
         snapshot_idx = keeper_utils.send_4lw_cmd(cluster, node_snapshot, "csnp")
         node_snapshot.wait_for_log_line(f"Created persistent snapshot {snapshot_idx}")
 
-        snapshot_files = list_s3_objects(started_cluster, "snapshots/")
+        assert_single_local_snapshot()
         local_snapshot_files = get_local_snapshots(node_snapshot)
-        assert len(local_snapshot_files) == 1
+        snapshot_files = list_s3_objects(started_cluster, "snapshots/")
 
         snapshot_files.extend(local_snapshot_files)
 

--- a/tests/integration/test_keeper_ttl_nodes/test.py
+++ b/tests/integration/test_keeper_ttl_nodes/test.py
@@ -164,8 +164,14 @@ def test_many_nodes_with_different_ttls():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
 
+        # Consecutive nodes' destroy_times differ by this step. Each "still alive" assertion
+        # below runs right after wait_nodes_gone() for the previous node, whose return can
+        # overshoot the target's destroy_time (GC period + Raft commit + poll granularity +
+        # round-trips under load). Keep the step well above that overshoot so an assertion
+        # never races a just-expired node.
+        ttl_step_ms = 3000
         for i in range(10):
-            node1_zk.create(f"/n{i}", str(i).encode(), ttl=1000 * (i + 1))
+            node1_zk.create(f"/n{i}", str(i).encode(), ttl=ttl_step_ms * (i + 1))
 
         wait_nodes_gone([node1_zk, node2_zk], ["/n0"])
         for i in range(1, 10):

--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -313,7 +313,12 @@ def test_retry_loading_parts(cluster):
     node.query("INSERT INTO s3_retry_loading_parts VALUES (42)")
     node.query("DETACH TABLE s3_retry_loading_parts")
 
-    fail_request(cluster, 5)
+    # Fail the 5th GET request to S3 to break the first part-loading attempt.
+    # Use GET method filter to avoid counting background PUT/DELETE requests
+    # (e.g. cleanup, or metadata writes on the shared cluster) that could
+    # consume the fail counter and either land on a non-retryable write or
+    # miss the part-loading read entirely, making the test flaky.
+    fail_request(cluster, 5, "GET")
     node.query("ATTACH TABLE s3_retry_loading_parts")
 
     assert node.contains_in_log(

--- a/tests/integration/test_quorum_inserts_parallel/test.py
+++ b/tests/integration/test_quorum_inserts_parallel/test.py
@@ -78,7 +78,10 @@ def test_parallel_quorum_actually_parallel(started_cluster):
 def test_parallel_quorum_actually_quorum(started_cluster):
     for i, node in enumerate([node1, node2, node3]):
         node.query(
-            "CREATE TABLE q (a UInt64, b String) ENGINE=ReplicatedMergeTree('/test/q', '{num}') ORDER BY tuple()".format(
+            # node2 stays partitioned off node1/node3 (port 9009) for the whole test, so its
+            # GET_PART entries fail repeatedly and accumulate exponential fetch backoff. Disable
+            # it so node2 catches up promptly once the partition heals (see SYSTEM SYNC REPLICA).
+            "CREATE TABLE q (a UInt64, b String) ENGINE=ReplicatedMergeTree('/test/q', '{num}') ORDER BY tuple() SETTINGS max_postpone_time_for_failed_replicated_fetches_ms = 0".format(
                 num=i
             )
         )
@@ -175,5 +178,8 @@ def test_parallel_quorum_actually_quorum(started_cluster):
         p.close()
         p.join()
 
-    node2.query("SYSTEM SYNC REPLICA q", timeout=10)
+    # Generous barrier timeout: under the parallel sanitizer flaky-check the post-heal
+    # catch-up fetch can take several seconds. Correctness is still gated by the retrying
+    # assert below, so a real "node2 never syncs" bug fails there rather than being hidden.
+    node2.query("SYSTEM SYNC REPLICA q", timeout=60)
     assert_eq_with_retry(node2, "SELECT COUNT() FROM q", "3")

--- a/tests/integration/test_rename_column/test.py
+++ b/tests/integration/test_rename_column/test.py
@@ -269,6 +269,37 @@ def rename_column_on_cluster(
             break
 
 
+def _num2_converged(nodes, table_name):
+    return all(
+        node.query(
+            "SELECT count() FROM system.columns "
+            "WHERE database = 'default' AND table IN ('{t}', '{t}_replicated') "
+            "AND name = 'num2'".format(t=table_name)
+        ).strip()
+        == "2"
+        for node in nodes
+    )
+
+
+def wait_for_rename_to_num2(nodes, table_name, attempts=12, poll_seconds=5):
+    # Best-effort cleanup renames + async ON CLUSTER replication can leave the
+    # column as foo2/foo3 on some replicas. Re-drive the idempotent rename-back
+    # until num2 is present on every node's Distributed and _replicated tables,
+    # so the strict queries below do not race schema convergence (UNKNOWN_IDENTIFIER).
+    tables = [table_name, "%s_replicated" % table_name]
+    for _ in range(attempts):
+        if _num2_converged(nodes, table_name):
+            return
+        for old_name in ("foo2", "foo3"):
+            for table in tables:
+                rename_column_on_cluster(nodes[0], table, old_name, "num2", 1, True)
+        time.sleep(poll_seconds)
+    if not _num2_converged(nodes, table_name):
+        raise Exception(
+            "columns did not converge to num2 for {} on all nodes".format(table_name)
+        )
+
+
 def alter_move(node, table_name, iterations=1, ignore_exception=False):
     i = 0
     while True:
@@ -809,14 +840,7 @@ def test_rename_distributed_parallel_insert_and_select(started_cluster):
         for task in tasks:
             task.get(timeout=240)
 
-        rename_column_on_cluster(node1, table_name, "foo2", "num2", 1, True)
-        rename_column_on_cluster(
-            node1, "%s_replicated" % table_name, "foo2", "num2", 1, True
-        )
-        rename_column_on_cluster(node1, table_name, "foo3", "num2", 1, True)
-        rename_column_on_cluster(
-            node1, "%s_replicated" % table_name, "foo3", "num2", 1, True
-        )
+        wait_for_rename_to_num2(nodes, table_name)
 
         insert(node1, table_name, 1000, col_names=["num", "num2"])
         select(node1, table_name, "num2")

--- a/tests/integration/test_replication_without_zookeeper/test.py
+++ b/tests/integration/test_replication_without_zookeeper/test.py
@@ -49,7 +49,7 @@ def test_startup_without_zookeeper(start_cluster):
         == "0\n"
     )
 
-    cluster.run_kazoo_commands_with_retries(drop_zk)
+    cluster.run_kazoo_commands_with_retries(drop_zk, repeats=5)
 
     time.sleep(5)
     assert node1.query("SELECT COUNT(*) from test_table") == "3\n"

--- a/tests/integration/test_restore_db_replica/test.py
+++ b/tests/integration/test_restore_db_replica/test.py
@@ -510,14 +510,14 @@ def test_restore_db_replica_with_diffrent_table_metadata(
     for node in nodes:
         restore_database_and_wait(node, exclusive_database_name, None)
 
-    assert node_1.query_with_retry(
-        f"SELECT count(*) FROM {exclusive_database_name}.{test_table_1}",
-        check_callback=lambda x: x.strip() == str(count_test_table_1),
-    ) == TSV([count_test_table_1])
-    assert node_2.query_with_retry(
-        f"SELECT count(*) FROM {exclusive_database_name}.{test_table_1}",
-        check_callback=lambda x: x.strip() == str(count_test_table_1),
-    ) == TSV([count_test_table_1])
+    # SYSTEM SYNC REPLICA waits for the background fetch of all parts after the
+    # restore, instead of a fixed-budget count poll that can expire on slow builds.
+    check_contains_table(
+        node_1, f"{exclusive_database_name}.{test_table_1}", count_test_table_1
+    )
+    check_contains_table(
+        node_2, f"{exclusive_database_name}.{test_table_1}", count_test_table_1
+    )
 
     expected_count = ["0"]
     if restore_firstly_node_where_created:

--- a/tests/integration/test_s3_plain_rewritable/test.py
+++ b/tests/integration/test_s3_plain_rewritable/test.py
@@ -122,7 +122,11 @@ def test(storage_policy, key_prefix):
         node.query("ALTER TABLE test MOVE PARTITION 0 TO TABLE test_dst")
 
         count_part_1 = int(node.query("SELECT count(*) FROM test WHERE id % 10 = 1"))
-        node.query("ALTER TABLE test_dst REPLACE PARTITION 1 FROM test")
+        # Source partition 1 is empty when this node's random row count was 1 (only id=0).
+        # Opt in to the legacy no-op semantics; #23727 made empty-source REPLACE PARTITION throw by default.
+        node.query(
+            "ALTER TABLE test_dst REPLACE PARTITION 1 FROM test SETTINGS allow_replace_partition_from_empty_source = 1"
+        )
 
         count_dst = int(node.query("SELECT count(*) FROM test_dst"))
         assert count_dst > 0

--- a/tests/integration/test_storage_iceberg_disks/test.py
+++ b/tests/integration/test_storage_iceberg_disks/test.py
@@ -77,6 +77,7 @@ def generate_cluster_def(common_path, port, azure_container):
                 <endpoint>http://minio1:9001/root/var/lib/clickhouse/user_files/iceberg_data/default/</endpoint>
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+                <skip_access_check>true</skip_access_check>
             </disk_s3_common>
             <disk_azure_common>
                 <type>object_storage</type>
@@ -92,6 +93,7 @@ def generate_cluster_def(common_path, port, azure_container):
                 <disk>disk_s3_common</disk>
                 <path>/tmp/s3_cache/</path>
                 <max_size>1000000000</max_size>
+                <skip_access_check>true</skip_access_check>
             </disk_s3_with_cache>
             <disk_azure_with_cache>
                 <type>cache</type>

--- a/tests/integration/test_storage_iceberg_with_trino/test.py
+++ b/tests/integration/test_storage_iceberg_with_trino/test.py
@@ -17,6 +17,11 @@ WAREHOUSE_BUCKET = "warehouse-rest"
 
 CATALOG_DATABASE = "iceberg_trino_test"
 
+# Transient at startup: the coordinator registers in system.runtime.nodes (so the
+# readiness probe passes) before the scheduler's worker node map is populated, so the
+# first distributed scans fail with this until scheduling catches up.
+TRINO_NO_NODES_ERROR = "No nodes available to run query"
+
 
 def _get_uuid_str() -> str:
     return str(uuid.uuid4()).replace("-", "_")
@@ -56,34 +61,41 @@ def _trino_container_name(cluster: ClickHouseCluster) -> str:
     return f"{project}-trino-1"
 
 
-def _trino_exec(cluster: ClickHouseCluster, sql: str) -> str:
+def _trino_exec(cluster: ClickHouseCluster, sql: str, retries: int = 20) -> str:
     container = _trino_container_name(cluster)
-    proc = subprocess.run(
-        [
-            "docker",
-            "exec",
-            container,
-            "trino",
-            "--server",
-            "http://localhost:8080",
-            "--catalog",
-            "iceberg",
-            "--schema",
-            NAMESPACE,
-            "--output-format",
-            "TSV",
-            "--execute",
-            sql,
-        ],
-        capture_output=True,
-        text=True,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(
-            f"Trino query failed (exit {proc.returncode}):\n"
-            f"  SQL: {sql}\n  stdout: {proc.stdout}\n  stderr: {proc.stderr}"
+    last_proc = None
+    for attempt in range(retries):
+        last_proc = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container,
+                "trino",
+                "--server",
+                "http://localhost:8080",
+                "--catalog",
+                "iceberg",
+                "--schema",
+                NAMESPACE,
+                "--output-format",
+                "TSV",
+                "--execute",
+                sql,
+            ],
+            capture_output=True,
+            text=True,
         )
-    return proc.stdout
+        if last_proc.returncode == 0:
+            return last_proc.stdout
+        # Retry only the startup scheduling race; any other error is a real failure.
+        if TRINO_NO_NODES_ERROR in last_proc.stderr and attempt < retries - 1:
+            time.sleep(1)
+            continue
+        break
+    raise RuntimeError(
+        f"Trino query failed (exit {last_proc.returncode}):\n"
+        f"  SQL: {sql}\n  stdout: {last_proc.stdout}\n  stderr: {last_proc.stderr}"
+    )
 
 
 def _wait_for_trino_ready(cluster: ClickHouseCluster, timeout_seconds: int) -> None:

--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -1277,11 +1277,20 @@ def test_kafka_many_materialized_views(kafka_cluster, create_query_generator):
     k.kafka_produce(kafka_cluster, topic_name, messages)
 
     with k.existing_kafka_topic(k.get_admin_client(kafka_cluster), topic_name):
+        # query_with_retry returns the last (possibly short) snapshot once its retry
+        # budget is spent, so use a larger budget like the single-view test above to
+        # let each view receive all rows before the assertion below.
         result1 = instance.query_with_retry(
-            f"SELECT * FROM test.{kafka_table}_view1", check_callback=k.kafka_check_result
+            f"SELECT * FROM test.{kafka_table}_view1",
+            check_callback=k.kafka_check_result,
+            retry_count=40,
+            sleep_time=0.75,
         )
         result2 = instance.query_with_retry(
-            f"SELECT * FROM test.{kafka_table}_view2", check_callback=k.kafka_check_result
+            f"SELECT * FROM test.{kafka_table}_view2",
+            check_callback=k.kafka_check_result,
+            retry_count=40,
+            sleep_time=0.75,
         )
 
         instance.query(f"""

--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -3333,6 +3333,7 @@ def test_system_kafka_consumers(kafka_cluster, create_query_generator, consumer_
             f"""
             DROP TABLE IF EXISTS test.{kafka_table} SYNC;
             DROP TABLE IF EXISTS test.{kafka_table}_view SYNC;
+            DROP TABLE IF EXISTS test.{kafka_table}_target SYNC;
 
             {create_query_generator(
                 kafka_table,
@@ -3346,15 +3347,18 @@ def test_system_kafka_consumers(kafka_cluster, create_query_generator, consumer_
                 }
             )};
 
-            CREATE MATERIALIZED VIEW test.{kafka_table}_view ENGINE=MergeTree ORDER BY tuple() AS SELECT * FROM test.{kafka_table};
+            CREATE TABLE test.{kafka_table}_target (a UInt64, b String) ENGINE=MergeTree ORDER BY tuple();
+            CREATE MATERIALIZED VIEW test.{kafka_table}_view TO test.{kafka_table}_target AS SELECT * FROM test.{kafka_table};
             """
         )
         count = instance.query_with_retry(
-            f"SELECT count() FROM test.{kafka_table}_view",
+            f"SELECT count() FROM test.{kafka_table}_target",
             check_callback=lambda res: int(res) == 6,
         )
         assert int(count) == 6
 
+        # Drop only the materialized view (the explicit target table survives) so the
+        # background Kafka streamer can never observe a missing inner table mid-push.
         instance.query_with_retry(f"DROP TABLE test.{kafka_table}_view SYNC")
 
         check_query = f"""
@@ -3404,6 +3408,7 @@ last_used_and_last_poll_time: equal
         )
 
         instance.query(f"DROP TABLE test.{kafka_table}")
+        instance.query(f"DROP TABLE IF EXISTS test.{kafka_table}_target SYNC")
 
 
 def test_system_kafka_consumers_rebalance(kafka_cluster, max_retries=15):

--- a/tests/integration/test_storage_kafka/test_batch_slow_0.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_0.py
@@ -398,9 +398,17 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
         )
         errors_text = instance.query_with_retry(
             errors_query,
-            retry_count=30,
+            retry_count=60,
             sleep_time=1,
             check_callback=lambda res: len(res) > 0,
+        )
+        # query_with_retry returns the last result even if check_callback never
+        # passed, so guard against an empty error MV before json.loads (which
+        # would otherwise raise an opaque "Expecting value" JSONDecodeError).
+        assert (
+            len(errors_text) > 0
+        ), "Error row for format {} did not appear in kafka_errors_{}_mv".format(
+            format_name, format_name
         )
         errors_result = json.loads(errors_text)
         # print(errors_result.strip())

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -93,22 +93,17 @@ def unique(request):
 
 
 def check_expected_result_polling(expected, query, instance=instance, timeout=DEFAULT_TIMEOUT_SEC):
-    # Fail only if consumption from RabbitMQ stalls, i.e. there is no progress for `timeout`
-    # seconds. As long as the result keeps increasing, consumption is still in progress, so we
-    # keep waiting regardless of how long the whole consumption takes. This matters for heavy
-    # tests (e.g. consuming many large messages on a slow remote-disk configuration): a fixed
-    # deadline would abandon a test that is still steadily consuming.
     deadline = time.monotonic() + timeout
     prev_result = 0
     result = None
     while time.monotonic() < deadline:
         result = int(instance.query(query))
+        # In case it's consuming successfully from RabbitMQ in latest iteration, extend the deadline
+        if result > prev_result:
+            deadline += 1
+        prev_result = result
         if result == expected:
             break
-        # Progress was made since the previous iteration: reset the no-progress deadline.
-        if result > prev_result:
-            deadline = time.monotonic() + timeout
-        prev_result = result
         logging.debug(f"Result: {result} / {expected}. Now {time.monotonic()}, deadline {deadline}")
         time.sleep(1)
     else:

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -799,23 +799,32 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster, db, unique):
         time.sleep(random.uniform(0, 1))
         thread.start()
 
-    # with threadsanitizer the speed of execution is about 8-13k rows per second.
-    # so consumption of 1 mln rows will require about 125 seconds
-    deadline = time.monotonic() + 180
+    # With threadsanitizer the speed of execution is about 8-13k rows per second, so consuming
+    # ~1 mln rows takes ~125s and can exceed a fixed deadline on a loaded runner while still
+    # progressing. Fail only on a genuine stall: reset the no-progress deadline whenever the
+    # total row count increases, so a slow-but-steady run is not abandoned.
+    no_progress_timeout = 180
+    deadline = time.monotonic() + no_progress_timeout
     expected = messages_num * threads_num * NUM_MV
+    prev_result = 0
+    result = 0
     while time.monotonic() < deadline:
         result = 0
         for mv_id in range(NUM_MV):
             result += int(
                 instance.query(f"SELECT count() FROM {db}.combo_{mv_id}")
             )
-        if int(result) == expected:
+        if result == expected:
             break
+        if result > prev_result:
+            deadline = time.monotonic() + no_progress_timeout
+        prev_result = result
         logging.debug(f"Result: {result} / {expected}")
         time.sleep(1)
     else:
         pytest.fail(
-            "Time limit of 180 seconds reached. The result did not match the expected value."
+            f"Time limit of {no_progress_timeout} seconds reached without any RabbitMQ "
+            "consumption progress. The result did not match the expected value."
         )
 
     for thread in threads:

--- a/tests/integration/test_storage_s3_queue/test_1.py
+++ b/tests/integration/test_storage_s3_queue/test_1.py
@@ -338,7 +338,7 @@ def test_multiple_tables_streaming_sync_distributed(started_cluster, mode):
 @pytest.mark.parametrize("mode", ["unordered", "ordered"])
 def test_max_set_age(started_cluster, mode):
     # We use an instance without keeper fault injection,
-    # because otherwise we fail to update keeper state in 1.5 * max_age,
+    # because otherwise we fail to update keeper state within the wait window,
     # so we cannot check max_set_age correctness properly.
     node = started_cluster.instances["instance_without_keeper_fault_injection"]
     table_name = f"max_set_age_{mode}_{generate_random_string()}"
@@ -378,7 +378,14 @@ def test_max_set_age(started_cluster, mode):
     def get_count():
         return int(node.query(f"SELECT count() FROM {dst_table_name}"))
 
-    def wait_for_condition(check_function, max_wait_time=1.5 * max_age):
+    # Slow instrumented builds (sanitizers, coverage) ingest far slower, so give
+    # them a larger ceiling; fast release/debug builds keep the tighter
+    # 1.5 * max_age so a genuine regression is not masked. Either way the ceiling
+    # stays above max_age so the tracked_file_ttl expiry the test relies on fires.
+    slow_build = node.is_built_with_sanitizer() or node.is_built_with_llvm_coverage()
+    condition_wait_time = (3 if slow_build else 1.5) * max_age
+
+    def wait_for_condition(check_function, max_wait_time=condition_wait_time):
         before = time.time()
         while time.time() - before < max_wait_time:
             if check_function():

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -23,9 +23,15 @@ AVAILABLE_MODES = ["unordered", "ordered"]
 def s3_queue_setup_teardown(started_cluster):
     instance = started_cluster.instances["instance"]
     instance_2 = started_cluster.instances["instance2"]
+    instance_3 = started_cluster.instances["instance_without_keeper_fault_injection"]
 
     instance.query("DROP DATABASE IF EXISTS default; CREATE DATABASE default;")
     instance_2.query("DROP DATABASE IF EXISTS default; CREATE DATABASE default;")
+    # instance_without_keeper_fault_injection was not reset between tests, so S3Queue
+    # tables leaked from prior tests kept streaming and could consume a process-global
+    # ONCE failpoint (e.g. object_storage_queue_fail_commit_after_success) before the
+    # test that armed it committed. Reset it too so each test starts with no streamers.
+    instance_3.query("DROP DATABASE IF EXISTS default; CREATE DATABASE default;")
 
     minio = started_cluster.minio_client
     objects = list(minio.list_objects(started_cluster.minio_bucket, recursive=True))

--- a/tests/queries/0_stateless/00612_pk_in_tuple_perf.sh
+++ b/tests/queries/0_stateless/00612_pk_in_tuple_perf.sh
@@ -25,7 +25,9 @@ query="SELECT count() FROM pk_in_tuple_perf WHERE (v, u) IN ((2, 10), (2, 20)) S
 $CLICKHOUSE_CLIENT --query "$query"
 $CLICKHOUSE_CLIENT --query "$query FORMAT JSON" | grep "rows_read"
 
-## Test with non-const args in tuple
+## Test with non-const args in tuple.
+## Use a fixed date, not today(): today() is evaluated separately at INSERT and SELECT time,
+## so a midnight straddle (widened by slow builds) would make count() drop to 0.
 
 $CLICKHOUSE_CLIENT <<EOF
 DROP TABLE IF EXISTS pk_in_tuple_perf_non_const;
@@ -37,10 +39,10 @@ CREATE TABLE pk_in_tuple_perf_non_const
 ORDER BY (u, d)
 SETTINGS index_granularity = 1;
 
-INSERT INTO pk_in_tuple_perf_non_const SELECT today() - number, number FROM numbers(100);
+INSERT INTO pk_in_tuple_perf_non_const SELECT toDate('2020-01-01') - number, number FROM numbers(100);
 EOF
 
-query="SELECT count() FROM pk_in_tuple_perf_non_const WHERE (u, d) IN ((0, today()), (1, today())) SETTINGS merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0"
+query="SELECT count() FROM pk_in_tuple_perf_non_const WHERE (u, d) IN ((0, toDate('2020-01-01')), (1, toDate('2020-01-01'))) SETTINGS merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0"
 
 $CLICKHOUSE_CLIENT --query "$query"
 $CLICKHOUSE_CLIENT --query "$query FORMAT JSON" | grep "rows_read"

--- a/tests/queries/0_stateless/00974_query_profiler.sql
+++ b/tests/queries/0_stateless/00974_query_profiler.sql
@@ -18,6 +18,9 @@ WITH addressToLine(arrayJoin(trace) AS addr) || '#' || demangle(addressToSymbol(
 SELECT count() > 0 FROM system.trace_log t WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_id = (SELECT query_id FROM system.query_log WHERE current_database = currentDatabase() AND query LIKE '%test real time query profiler%' AND query NOT LIKE '%system%' ORDER BY event_time DESC LIMIT 1) AND symbol LIKE '%FunctionSleep%';
 
 -- Also test the real time profiler with CPU-bound work (numbers_mt).
+-- Use a short period so the fast multi-threaded scan reliably spans several
+-- profiler periods (a 100ms period races the tens-of-ms scan -> 0 samples).
+SET query_profiler_real_time_period_ns = 1e6;
 SET max_rows_to_read = 0;
 SET log_queries = 1;
 SELECT count(), ignore('test real time query profiler numbers_mt') FROM numbers_mt(1e9);

--- a/tests/queries/0_stateless/01017_uniqCombined_memory_usage.sql
+++ b/tests/queries/0_stateless/01017_uniqCombined_memory_usage.sql
@@ -32,14 +32,14 @@ SELECT 'K=16';
 SELECT 'UInt32';
 SET max_memory_usage = 2000000;
 SELECT sum(u) FROM (SELECT intDiv(number, 4096) AS k, uniqCombined(16)(number % 4096) u FROM numbers(4096 * 100) GROUP BY k); -- { serverError MEMORY_LIMIT_EXCEEDED }
-SET max_memory_usage = 5230000;
+SET max_memory_usage = 6300000;
 SELECT sum(u) FROM (SELECT intDiv(number, 4096) AS k, uniqCombined(16)(number % 4096) u FROM numbers(4096 * 100) GROUP BY k);
 
 -- HashTable for UInt64 (used until (1<<11) elements), hence 2048 elements
 SELECT 'UInt64';
 SET max_memory_usage = 2000000;
 SELECT sum(u) FROM (SELECT intDiv(number, 2048) AS k, uniqCombined(16)(reinterpretAsString(number % 2048)) u FROM numbers(2048 * 100) GROUP BY k); -- { serverError MEMORY_LIMIT_EXCEEDED }
-SET max_memory_usage = 5900000;
+SET max_memory_usage = 7100000;
 SELECT sum(u) FROM (SELECT intDiv(number, 2048) AS k, uniqCombined(16)(reinterpretAsString(number % 2048)) u FROM numbers(2048 * 100) GROUP BY k);
 
 SELECT 'K=18';

--- a/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
+++ b/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
@@ -12,6 +12,10 @@ SET log_queries = 0;
 SET query_profiler_cpu_time_period_ns = 0;
 SYSTEM FLUSH LOGS query_log, trace_log;
 
+-- Symbolization test, not a perf test: reading system.trace_log can be slow
+-- and false-positives the execution-time guards (TOO_SLOW / TIMEOUT_EXCEEDED).
+SET max_estimated_execution_time = 0, max_execution_time = 0;
+
 WITH
     lineWithInlines AS
     (

--- a/tests/queries/0_stateless/02421_simple_queries_for_opentelemetry.sh
+++ b/tests/queries/0_stateless/02421_simple_queries_for_opentelemetry.sh
@@ -108,7 +108,15 @@ function check_tcp_attributes()
 
 function execute_query_HTTP()
 {
-    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&database=${CLICKHOUSE_DATABASE}&query_id=$1" -d "$2"
+    # A traceparent header (with the sampled flag) forces the request to be traced, and the
+    # Referer / User-Agent headers populate the http.* attributes on the HTTPHandler span.
+    local trace_id
+    trace_id=$(${CLICKHOUSE_CLIENT} -q "SELECT lower(hex(generateUUIDv4()))")
+    ${CLICKHOUSE_CURL} -sS \
+        -H "traceparent: 00-${trace_id}-0000000000000010-01" \
+        -H "referer: some-referer" \
+        -H "user-agent: some-user-agent" \
+        "${CLICKHOUSE_URL}&database=${CLICKHOUSE_DATABASE}&query_id=$1" -d "$2"
 }
 
 function check_http_attributes()
@@ -119,15 +127,17 @@ function check_http_attributes()
   local agent="not found"
   local method="not found"
   
+  # The http.* attributes live on the HTTPHandler (SERVER) span, not on the child query span.
+  # Match it by the query_id embedded in the request URI (clickhouse.uri).
   result=$(${CLICKHOUSE_CLIENT} -q "
       SYSTEM FLUSH LOGS opentelemetry_span_log;
-      SELECT attribute['http.referer'],
-             attribute['http.user.agent'],
-             attribute['http.method']
+      SELECT attribute['http.referer']    AS referer,
+             attribute['http.user.agent'] AS user_agent,
+             attribute['http.method']     AS method
       FROM system.opentelemetry_span_log
       WHERE finish_date >= yesterday()
-      AND operation_name = 'query'
-      AND attribute['clickhouse.query_id'] = '${query_id}'
+      AND operation_name = 'HTTPHandler'
+      AND attribute['clickhouse.uri'] LIKE '%${query_id}%'
       FORMAT JSONEachRow;
     ")
 
@@ -135,16 +145,16 @@ function check_http_attributes()
     echo "Error: No result returned from ClickHouse server"
     return 1
   fi
-  
-  if [[ $result == *"http.referer"* ]]; then
+
+  if [[ $result == *'"referer":"some-referer"'* ]]; then
     referer="present"
   fi
-  
-  if [[ $result == *"http.user.agent"* ]]; then
+
+  if [[ $result == *'"user_agent":"some-user-agent"'* ]]; then
     agent="present"
   fi
 
-  if [[ $result == *"http.method"* ]]; then
+  if [[ $result == *'"method":"POST"'* ]]; then
     method="present"
   fi
 
@@ -191,9 +201,8 @@ query_id=$(${CLICKHOUSE_CLIENT} -q "select generateUUIDv4()")
 execute_query $query_id 'select * from opentelemetry_test format Null'
 check_tcp_attributes $query_id
 
-# Test 7: Executes a TCP SELECT query and checks for http attributes in OpenTelemetry spans.
+# Test 7: Executes an HTTP SELECT query and checks for http attributes in OpenTelemetry spans.
 query_id=$(${CLICKHOUSE_CLIENT} -q "select generateUUIDv4()")
-execute_query "$query_id" 'set opentelemetry_start_trace_probability=1'
 execute_query_HTTP "$query_id" 'select * from opentelemetry_test FORMAT Null'
 check_http_attributes "$query_id"
 #

--- a/tests/queries/0_stateless/02441_alter_delete_and_drop_column.sql
+++ b/tests/queries/0_stateless/02441_alter_delete_and_drop_column.sql
@@ -8,21 +8,21 @@ insert into mut values (1, 2, 3), (10, 20, 30);
 
 alter table mut delete where n = 10;
 
--- a funny way to wait for a MUTATE_PART to be assigned
-select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..10}&query=' || encodeURLComponent(
+-- a funny way to wait for a MUTATE_PART to be assigned (assignment is async via mergeSelectingTask; under load it can lag, so poll up to 60s)
+select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..30}&query=' || encodeURLComponent(
             'select 1 where ''MUTATE_PART'' not in (select type from system.replication_queue where database=''' || currentDatabase() || ''' and table=''mut'')'
     ), 'LineAsString', 's String') settings max_threads=1, http_make_head_request=0 format Null;
 
 alter table mut drop column k settings alter_sync=0;
 
 -- a funny way to wait for ALTER_METADATA to disappear from the replication queue
-select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..10}&query=' || encodeURLComponent(
+select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..30}&query=' || encodeURLComponent(
     'select * from system.replication_queue where database=''' || currentDatabase() || ''' and table=''mut'' and type=''ALTER_METADATA'''
     ), 'LineAsString', 's String') settings max_threads=1, http_make_head_request=0 format Null;
 
 system sync replica mut pull;
 
-select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..10}&query=' || encodeURLComponent(
+select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..30}&query=' || encodeURLComponent(
     'select * from system.replication_queue where database=''' || currentDatabase() || ''' and table=''mut'' and type=''ALTER_METADATA'''
     ), 'LineAsString', 's String') settings max_threads=1, http_make_head_request=0 format Null;
 

--- a/tests/queries/0_stateless/02676_optimize_old_parts_replicated.sh
+++ b/tests/queries/0_stateless/02676_optimize_old_parts_replicated.sh
@@ -55,7 +55,7 @@ SELECT 'With merge replicated partition only';
 
 CREATE TABLE test_replicated (i Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test02676_partition_only', 'node')  ORDER BY i
 PARTITION BY i
-SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true;
+SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, max_merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true, number_of_free_entries_in_pool_to_execute_optimize_entire_partition=1;
 INSERT INTO test_replicated SELECT 1;
 INSERT INTO test_replicated SELECT 2;
 SELECT sleep(3) FORMAT Null; -- Sleep so the first partition is older
@@ -75,7 +75,7 @@ SELECT 'With merge replicated partition only and disable limit';
 
 CREATE TABLE test_replicated_limit (i Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test02676_partition_only_limit', 'node')  ORDER BY i
 PARTITION BY i
-SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true, enable_max_bytes_limit_for_min_age_to_force_merge=false, max_bytes_to_merge_at_max_space_in_pool=1;
+SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, max_merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true, number_of_free_entries_in_pool_to_execute_optimize_entire_partition=1, enable_max_bytes_limit_for_min_age_to_force_merge=false, max_bytes_to_merge_at_max_space_in_pool=1;
 INSERT INTO test_replicated_limit SELECT 1;
 INSERT INTO test_replicated_limit SELECT 2;
 SELECT sleep(3) FORMAT Null; -- Sleep so the first partition is older
@@ -91,7 +91,7 @@ SELECT 'With merge replicated partition only and enable limit';
 
 CREATE TABLE test_replicated_limit (i Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test02676_partition_only_limit', 'node')  ORDER BY i
 PARTITION BY i
-SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true, enable_max_bytes_limit_for_min_age_to_force_merge=true, max_bytes_to_merge_at_max_space_in_pool=1;
+SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, max_merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true, number_of_free_entries_in_pool_to_execute_optimize_entire_partition=1, enable_max_bytes_limit_for_min_age_to_force_merge=true, max_bytes_to_merge_at_max_space_in_pool=1;
 INSERT INTO test_replicated_limit SELECT 1;
 INSERT INTO test_replicated_limit SELECT 2;
 SELECT sleep(3) FORMAT Null; -- Sleep so the first partition is older

--- a/tests/queries/0_stateless/02789_filesystem_cache_alignment.sh
+++ b/tests/queries/0_stateless/02789_filesystem_cache_alignment.sh
@@ -31,7 +31,13 @@ SELECT * FROM test WHERE NOT ignore() LIMIT 1 FORMAT Null;
 SYSTEM FLUSH LOGS filesystem_cache_log;
 "
 
-query="
+# Materialize the file-segment view once instead of re-deriving it for every
+# assertion below. Scanning system.remote_data_paths walks the metadata of all
+# disks, which is slow under thread fuzzer; evaluating it once keeps the test
+# from timing out.
+$CLICKHOUSE_CLIENT -m -q "
+DROP TABLE IF EXISTS file_segments;
+CREATE TABLE file_segments ENGINE = Memory AS
 SELECT cache_path, file_size,
     tupleElement(file_segment_range, 2) - tupleElement(file_segment_range, 1) + 1 as file_segment_size,
     formatReadableSize(file_size) as formatted_file_size,
@@ -47,19 +53,20 @@ FROM (
 ) AS data_paths
 INNER JOIN system.filesystem_cache_log AS cache_log
 ON data_paths.remote_path = cache_log.source_file_path
-WHERE query_id = '$QUERY_ID' "
+WHERE query_id = '$QUERY_ID';
+"
 
 # File segments cannot be less that 20Mi,
 # except for last file segment in a file or if file size is less.
 $CLICKHOUSE_CLIENT -m -q "
-SELECT count() FROM ($query)
+SELECT count() FROM file_segments
 WHERE file_segment_size < file_size
 AND end_offset + 1 != file_size
 AND file_segment_size < 20 * 1024 * 1024;
 "
 
 all=$($CLICKHOUSE_CLIENT -m -q "
-SELECT count() FROM ($query)
+SELECT count() FROM file_segments
 WHERE file_segment_size < file_size AND end_offset + 1 != file_size;
 ")
 #echo $all
@@ -71,7 +78,7 @@ else
 fi
 
 count=$($CLICKHOUSE_CLIENT -m -q "
-SELECT count() FROM ($query)
+SELECT count() FROM file_segments
 WHERE file_segment_size < file_size
 AND end_offset + 1 != file_size
 AND formatted_file_segment_size in ('20.00 MiB', '40.00 MiB')
@@ -83,28 +90,32 @@ else
   echo "FAIL"
 fi
 
-query2="
+# Same idea for the join against system.filesystem_cache: materialize once.
+$CLICKHOUSE_CLIENT -m -q "
+DROP TABLE IF EXISTS file_segments_cache;
+CREATE TABLE file_segments_cache ENGINE = Memory AS
 SELECT *
-FROM (SELECT * FROM ($query)) AS cache_log
+FROM file_segments AS cache_log
 INNER JOIN system.filesystem_cache AS cache
-ON cache_log.cache_path = cache.cache_path AND cache.cache_name = '$CLICKHOUSE_TEST_UNIQUE_NAME'"
+ON cache_log.cache_path = cache.cache_path AND cache.cache_name = '$CLICKHOUSE_TEST_UNIQUE_NAME';
+"
 
 $CLICKHOUSE_CLIENT -m -q "
-SELECT count() FROM ($query2)
+SELECT count() FROM file_segments_cache
 WHERE file_segment_range_begin - file_segment_range_end + 1 < file_size
 AND file_segment_range_end + 1 != file_size
 AND downloaded_size < 20 * 1024 * 1024;
 "
 
 $CLICKHOUSE_CLIENT -m -q "
-SELECT count() FROM ($query2)
+SELECT count() FROM file_segments_cache
 WHERE file_segment_range_begin - file_segment_range_end + 1 < file_size
 AND file_segment_range_end + 1 != file_size
 AND formatReadableSize(downloaded_size) not in ('20.00 MiB', '40.00 MiB');
 "
 
 all=$($CLICKHOUSE_CLIENT -m -q "
-SELECT count() FROM ($query2)
+SELECT count() FROM file_segments_cache
 WHERE file_segment_size < file_size AND file_segment_range_end + 1 != file_size;
 ")
 
@@ -115,7 +126,7 @@ else
 fi
 
 count2=$($CLICKHOUSE_CLIENT -m -q "
-SELECT count() FROM ($query2)
+SELECT count() FROM file_segments_cache
 WHERE file_segment_range_begin - file_segment_range_end + 1 < file_size
 AND file_segment_range_end + 1 != file_size
 AND formatReadableSize(downloaded_size) in ('20.00 MiB', '40.00 MiB');

--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_with_aggregation.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_with_aggregation.sql
@@ -3,6 +3,9 @@
 -- Reset the global max_rows_to_group_by; distributed aggregation rejects a nonzero limit.
 SET max_rows_to_group_by = 0;
 SET distributed_plan_optimize_exchanges = 1;
+-- Pin off: statistics change the estimated group count, flipping the distributed aggregation
+-- strategy (Shuffle vs partial+merge) and thus the asserted plan.
+SET use_statistics = 0;
 
 DROP TABLE IF EXISTS test;
 CREATE TABLE test(path String, lang String, hits UInt64) ENGINE MergeTree() ORDER BY tuple();

--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_with_in.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_with_in.sql
@@ -2,6 +2,9 @@
 
 -- Reset the global max_rows_to_group_by; distributed aggregation rejects a nonzero limit.
 SET max_rows_to_group_by = 0;
+-- Pin off: statistics change the estimated group count, flipping the distributed aggregation
+-- strategy (Shuffle vs partial+merge) and thus the asserted plan.
+SET use_statistics = 0;
 
 DROP TABLE IF EXISTS test;
 

--- a/tests/queries/0_stateless/03583_rewrite_in_to_join.reference
+++ b/tests/queries/0_stateless/03583_rewrite_in_to_join.reference
@@ -5,47 +5,47 @@ SELECT explain FROM (
     SETTINGS enable_join_runtime_filters = 0
 ) WHERE explain ILIKE '%join%';
   JoinLogical
-SELECT number IN (SELECT * FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT * FROM numbers(2)) FROM numbers(3) ORDER BY number;
 1
 1
 0
-SELECT number IN (SELECT number FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2)) FROM numbers(3) ORDER BY number;
 1
 1
 0
-SELECT * FROM numbers(3) WHERE number IN (SELECT number FROM numbers(2));
+SELECT * FROM numbers(3) WHERE number IN (SELECT number FROM numbers(2)) ORDER BY number;
 0
 1
 SELECT number IN (SELECT number, number FROM numbers(2)) FROM numbers(3); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
-SELECT number IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 1
 1
 0
-SELECT number IN (SELECT number FROM numbers(2) WHERE number IN (SELECT * FROM numbers(1))) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2) WHERE number IN (SELECT * FROM numbers(1))) FROM numbers(3) ORDER BY number;
 1
 0
 0
 -- NOT IN
-SELECT number NOT IN (SELECT * FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT * FROM numbers(2)) FROM numbers(3) ORDER BY number;
 0
 0
 1
-SELECT * FROM numbers(3) WHERE number NOT IN (SELECT number FROM numbers(2));
+SELECT * FROM numbers(3) WHERE number NOT IN (SELECT number FROM numbers(2)) ORDER BY number;
 2
 SELECT number NOT IN (SELECT number, number FROM numbers(2)) FROM numbers(3); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
-SELECT number NOT IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 0
 0
 1
-SELECT number IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 1
 1
 0
-SELECT number NOT IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 0
 0
 1
-SELECT number IN (SELECT number FROM numbers(2) WHERE number NOT IN (SELECT * FROM numbers(1))) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2) WHERE number NOT IN (SELECT * FROM numbers(1))) FROM numbers(3) ORDER BY number;
 0
 1
 0
@@ -80,7 +80,8 @@ WITH
     t as (select number from numbers(5))
 SELECT *
 FROM numbers(8)
-WHERE number IN t;
+WHERE number IN t
+ORDER BY number;
 0
 1
 2
@@ -89,7 +90,8 @@ WHERE number IN t;
 -- Tuple
 SELECT *
 FROM numbers(8)
-WHERE (number+1, number+2) IN (select number, number+1 from numbers(5));
+WHERE (number+1, number+2) IN (select number, number+1 from numbers(5))
+ORDER BY number;
 0
 1
 2
@@ -99,7 +101,8 @@ WITH
     t as (select number, number+1 from numbers(5))
 SELECT *
 FROM numbers(8)
-WHERE (number+1, number+2) in (t);
+WHERE (number+1, number+2) in (t)
+ORDER BY number;
 0
 1
 2

--- a/tests/queries/0_stateless/03583_rewrite_in_to_join.sql
+++ b/tests/queries/0_stateless/03583_rewrite_in_to_join.sql
@@ -11,32 +11,32 @@ SELECT explain FROM (
     SETTINGS enable_join_runtime_filters = 0
 ) WHERE explain ILIKE '%join%';
 
-SELECT number IN (SELECT * FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT * FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number IN (SELECT number FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT * FROM numbers(3) WHERE number IN (SELECT number FROM numbers(2));
+SELECT * FROM numbers(3) WHERE number IN (SELECT number FROM numbers(2)) ORDER BY number;
 
 SELECT number IN (SELECT number, number FROM numbers(2)) FROM numbers(3); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
 
-SELECT number IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number IN (SELECT number FROM numbers(2) WHERE number IN (SELECT * FROM numbers(1))) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2) WHERE number IN (SELECT * FROM numbers(1))) FROM numbers(3) ORDER BY number;
 
 -- NOT IN
-SELECT number NOT IN (SELECT * FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT * FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT * FROM numbers(3) WHERE number NOT IN (SELECT number FROM numbers(2));
+SELECT * FROM numbers(3) WHERE number NOT IN (SELECT number FROM numbers(2)) ORDER BY number;
 
 SELECT number NOT IN (SELECT number, number FROM numbers(2)) FROM numbers(3); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
 
-SELECT number NOT IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number NOT IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number IN (SELECT number FROM numbers(2) WHERE number NOT IN (SELECT * FROM numbers(1))) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2) WHERE number NOT IN (SELECT * FROM numbers(1))) FROM numbers(3) ORDER BY number;
 
 
 EXPLAIN keep_logical_steps=1, description=0
@@ -59,19 +59,22 @@ WITH
     t as (select number from numbers(5))
 SELECT *
 FROM numbers(8)
-WHERE number IN t;
+WHERE number IN t
+ORDER BY number;
 
 -- Tuple
 SELECT *
 FROM numbers(8)
-WHERE (number+1, number+2) IN (select number, number+1 from numbers(5));
+WHERE (number+1, number+2) IN (select number, number+1 from numbers(5))
+ORDER BY number;
 
 -- Tuple and CTE
 WITH
     t as (select number, number+1 from numbers(5))
 SELECT *
 FROM numbers(8)
-WHERE (number+1, number+2) in (t);
+WHERE (number+1, number+2) in (t)
+ORDER BY number;
 
 -- Mismatching number of elements 
 SELECT *

--- a/tests/queries/0_stateless/03986_kill_query_mutation_sync_replicated.sh
+++ b/tests/queries/0_stateless/03986_kill_query_mutation_sync_replicated.sh
@@ -21,27 +21,30 @@ $CLICKHOUSE_CLIENT --query "
 
 $CLICKHOUSE_CLIENT --query "INSERT INTO ${CLICKHOUSE_DATABASE}.t_kill_mutation SELECT number, toString(number) FROM numbers(100)"
 
-# This ALTER DELETE uses sleepEachRow to make the mutation take a very long time
-# (100 rows * 3 seconds = ~300 seconds) without consuming significant memory.
-# The condition is always false (sleepEachRow returns 0), so no rows are deleted,
-# but the mutation still scans every row. With mutations_sync=1 the query blocks
-# waiting for the mutation to complete.
+# Stop merges so the mutation entry is created but never executed by the background pool.
+# The mutation stays incomplete forever, so with mutations_sync=1 the ALTER blocks inside
+# waitMutationToFinishOnReplicas (the code path fixed by #97589). This makes the test
+# deterministic and CPU-independent: it does not rely on a long-running or memory-heavy
+# mutation to keep the query alive, and it leaves no in-flight background work to stall
+# teardown.
+$CLICKHOUSE_CLIENT --query "SYSTEM STOP MERGES ${CLICKHOUSE_DATABASE}.t_kill_mutation"
+
 $CLICKHOUSE_CLIENT --query_id="$query_id" --query "
-    ALTER TABLE ${CLICKHOUSE_DATABASE}.t_kill_mutation DELETE WHERE sleepEachRow(3) = 1
-    SETTINGS mutations_sync = 1, allow_nondeterministic_mutations = 1
+    ALTER TABLE ${CLICKHOUSE_DATABASE}.t_kill_mutation DELETE WHERE value = 'nonexistent'
+    SETTINGS mutations_sync = 1
 " >/dev/null 2>&1 &
 
 wait_for_query_to_start "$query_id"
 
-# Use async KILL (without SYNC) to avoid blocking if propagation is slow.
-# The background ALTER client will exit when the server sends back the cancellation error.
+# KILL QUERY must unblock the ALTER waiting on the mutation. The background ALTER client
+# exits once the server returns the cancellation error.
 $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "KILL QUERY WHERE query_id = '$query_id'" >/dev/null
-
-# Kill the mutation immediately so it stops consuming resources in the background.
-$CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "KILL MUTATION WHERE database = '${CLICKHOUSE_DATABASE}' AND table = 't_kill_mutation'" >/dev/null 2>&1 || true
 
 # Wait for the ALTER client to finish (should exit promptly after the kill).
 wait
+
+# Remove the never-executed mutation entry so the table can be dropped cleanly.
+$CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "KILL MUTATION WHERE database = '${CLICKHOUSE_DATABASE}' AND table = 't_kill_mutation'" >/dev/null 2>&1 || true
 
 $CLICKHOUSE_CURL -sS "$CLICKHOUSE_URL" -d "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.t_kill_mutation SYNC"
 

--- a/tests/queries/0_stateless/04051_pk_analysis_stats.sql
+++ b/tests/queries/0_stateless/04051_pk_analysis_stats.sql
@@ -1,3 +1,7 @@
+-- Tags: no-parallel
+-- Tag no-parallel: depends on the server-level query condition cache entry written by the
+-- pre-warm query still being resident for the measured query (same reason as 04065, 04275).
+
 -- Previously, the logs looked like this:
 --
 -- (SelectExecutor): Key condition: unknown

--- a/tests/queries/0_stateless/04053_merge_table_large_query_performance.sh
+++ b/tests/queries/0_stateless/04053_merge_table_large_query_performance.sh
@@ -139,30 +139,53 @@ WHERE
     ) <= 16
 GROUP BY
     addDays(CAST(date, 'Date'), -1 * (((7 + if(toDayOfWeek(date) = 7, 1, toDayOfWeek(date) + 1)) - 2) % 7))
+-- JIT off so every timed run is the identical cold workload: the query is timed TIMING_RUNS
+-- times, which crosses min_count_to_compile_*=3, and a compiled run would measure a warmed
+-- execution mode instead of the cold planning path this test guards.
+SETTINGS compile_expressions = 0, compile_aggregate_expressions = 0
 FORMAT Null"
 
 # Compare planning time on the Merge table against a single underlying table.
 # Pre-fix, planning was O(N * query_tree_size), so merge-table latency scaled with N.
 # With N=200 underlying tables this would be ~100x-200x slower than a single-table query.
 # Post-fix, the Merge planner shares the cloned query tree across tables of identical
-# structure, so merge-table latency stays close to single-table latency.
-# A loose 20x ratio is enough to catch the regression while tolerating CI noise.
-# The single-table timed run is fast (~250-400ms) and small absolute fluctuations cause
-# large ratio swings under parallel CI load, so the threshold needs comfortable margin.
+# structure, so merge-table latency stays close to single-table latency (~1.8x).
+# A loose 20x ratio catches the regression with wide margin either side.
 QUERY_SINGLE_TIMING="${QUERY/t_merge_perf_all/t_merge_perf_0}"
 
 # Warm up the data-side cache with a small query so the timed runs measure planning.
 $CLICKHOUSE_CLIENT -q "SELECT count() FROM ${CLICKHOUSE_DATABASE}.t_merge_perf_0 FORMAT Null"
 
-T_START=$(date +%s%N)
-$CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 30 -q "$QUERY" >/dev/null || { echo "FAIL: query on merge table timed out" >&2; exit 1; }
-T_END=$(date +%s%N)
-TIME_MERGE_NS=$((T_END - T_START))
+# Take the minimum wall-clock over several runs. Timing noise is one-sided: under parallel
+# CI load a run can only be slower than the true CPU-bound planning latency (scheduler /
+# allocator stall), never faster, so the minimum is a stable estimate that discards transient
+# stalls. A single sample can be inflated by one unlucky stall and blow the 20x threshold.
+TIMING_RUNS=5
 
-T_START=$(date +%s%N)
-$CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 30 -q "$QUERY_SINGLE_TIMING" >/dev/null || { echo "FAIL: query on single table timed out" >&2; exit 1; }
-T_END=$(date +%s%N)
-TIME_SINGLE_NS=$((T_END - T_START))
+# Sets global TIMED_MIN_NS to the min elapsed ns over TIMING_RUNS; returns 1 if a run times out.
+# (Uses a global rather than command substitution so a timeout can exit the whole script:
+# 'exit' inside $(...) would only leave the subshell.)
+time_query_min() {
+    local query="$1"
+    local best_ns=""
+    local i t_start t_end elapsed
+    for i in $(seq 1 "$TIMING_RUNS"); do
+        t_start=$(date +%s%N)
+        $CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 30 -q "$query" >/dev/null || return 1
+        t_end=$(date +%s%N)
+        elapsed=$((t_end - t_start))
+        if [ -z "$best_ns" ] || [ "$elapsed" -lt "$best_ns" ]; then
+            best_ns=$elapsed
+        fi
+    done
+    TIMED_MIN_NS=$best_ns
+}
+
+time_query_min "$QUERY" || { echo "FAIL: query on merge table timed out" >&2; exit 1; }
+TIME_MERGE_NS=$TIMED_MIN_NS
+
+time_query_min "$QUERY_SINGLE_TIMING" || { echo "FAIL: query on single table timed out" >&2; exit 1; }
+TIME_SINGLE_NS=$TIMED_MIN_NS
 
 if [ "$TIME_MERGE_NS" -gt $((TIME_SINGLE_NS * 20)) ]; then
     echo "FAIL: merge-table query (${TIME_MERGE_NS}ns) is more than 20x slower than single-table query (${TIME_SINGLE_NS}ns)" >&2

--- a/tests/queries/0_stateless/04146_iceberg_orc_row_policy_prewhere.sh
+++ b/tests/queries/0_stateless/04146_iceberg_orc_row_policy_prewhere.sh
@@ -36,6 +36,9 @@ rm -rf "${ICEBERG_PATH}"
 # passes) but write a mix of ORC and Parquet data files into it.
 ${CLICKHOUSE_CLIENT} --query "
     SET allow_experimental_insert_into_iceberg = 1;
+    -- StorageObjectStorage caches supportsPrewhere() at CREATE time from this
+    -- session setting; pinning it only on the SELECTs below is too late.
+    SET input_format_parquet_use_native_reader_v3 = 1;
 
     CREATE TABLE ${TEST_TABLE} (c0 Int64, c1 String)
         ENGINE = IcebergLocal('${ICEBERG_PATH}', 'Parquet');

--- a/tests/queries/0_stateless/04240_statistics_countmin_numeric_types.reference
+++ b/tests/queries/0_stateless/04240_statistics_countmin_numeric_types.reference
@@ -1,12 +1,12 @@
-Float32 - expect b first (BUG: shows a first):
+Float32 - expect b first:
         Prewhere info
           Prewhere filter
           Prewhere filter column: and(equals(b, 1.5_Float64), equals(a, 1.5_Float64)) (removed)
-Float64 - expect b first (CORRECT):
+Float64 - expect b first:
         Prewhere info
           Prewhere filter
           Prewhere filter column: and(equals(b, 1.5_Float64), equals(a, 1.5_Float64)) (removed)
-Int16 - expect b first (CORRECT):
+Int16 - expect b first:
         Prewhere info
           Prewhere filter
           Prewhere filter column: and(equals(b, 15_UInt8), equals(a, 15_UInt8)) (removed)

--- a/tests/queries/0_stateless/04240_statistics_countmin_numeric_types.sql
+++ b/tests/queries/0_stateless/04240_statistics_countmin_numeric_types.sql
@@ -9,31 +9,34 @@ SET optimize_move_to_prewhere = 1;
 SET query_plan_optimize_prewhere = 1;
 SET allow_reorder_prewhere_conditions = 1;
 
+-- b matches exactly 1 of 1010 rows (selectivity ~0.001, well below default_cond_equal_factor 0.01),
+-- so PREWHERE keeps b first even if a's estimate falls back to the default; refresh_statistics_interval = 0
+-- disables the background statistics cache so EXPLAIN never reads a stale single-part snapshot where a and b tie.
 DROP TABLE IF EXISTS test_f32;
-CREATE TABLE test_f32 (a Float32 STATISTICS(countmin), b Float32 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '';
-INSERT INTO test_f32 SELECT 1.5, 1.5 FROM numbers(10);
-INSERT INTO test_f32 SELECT 1.5, 99.5 FROM numbers(990);
+CREATE TABLE test_f32 (a Float32 STATISTICS(countmin), b Float32 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '', refresh_statistics_interval = 0;
+INSERT INTO test_f32 SELECT 1.5, 1.5 FROM numbers(1);
+INSERT INTO test_f32 SELECT 1.5, 99.5 FROM numbers(999);
 INSERT INTO test_f32 SELECT 99.5, 99.5 FROM numbers(10);
 
 DROP TABLE IF EXISTS test_f64;
-CREATE TABLE test_f64 (a Float64 STATISTICS(countmin), b Float64 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '';
-INSERT INTO test_f64 SELECT 1.5, 1.5 FROM numbers(10);
-INSERT INTO test_f64 SELECT 1.5, 99.5 FROM numbers(990);
+CREATE TABLE test_f64 (a Float64 STATISTICS(countmin), b Float64 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '', refresh_statistics_interval = 0;
+INSERT INTO test_f64 SELECT 1.5, 1.5 FROM numbers(1);
+INSERT INTO test_f64 SELECT 1.5, 99.5 FROM numbers(999);
 INSERT INTO test_f64 SELECT 99.5, 99.5 FROM numbers(10);
 
 DROP TABLE IF EXISTS test_i16;
-CREATE TABLE test_i16 (a Int16 STATISTICS(countmin), b Int16 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '';
-INSERT INTO test_i16 SELECT 15, 15 FROM numbers(10);
-INSERT INTO test_i16 SELECT 15, 995 FROM numbers(990);
+CREATE TABLE test_i16 (a Int16 STATISTICS(countmin), b Int16 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '', refresh_statistics_interval = 0;
+INSERT INTO test_i16 SELECT 15, 15 FROM numbers(1);
+INSERT INTO test_i16 SELECT 15, 995 FROM numbers(999);
 INSERT INTO test_i16 SELECT 995, 995 FROM numbers(10);
 
-SELECT 'Float32 - expect b first (BUG: shows a first):';
+SELECT 'Float32 - expect b first:';
 SELECT replaceRegexpAll(explain, '__table1\\.', '') FROM (EXPLAIN actions=1 SELECT count(*) FROM test_f32 WHERE a = 1.5 AND b = 1.5) WHERE explain LIKE '%Prewhere%';
 
-SELECT 'Float64 - expect b first (CORRECT):';
+SELECT 'Float64 - expect b first:';
 SELECT replaceRegexpAll(explain, '__table1\\.', '') FROM (EXPLAIN actions=1 SELECT count(*) FROM test_f64 WHERE a = 1.5 AND b = 1.5) WHERE explain LIKE '%Prewhere%';
 
-SELECT 'Int16 - expect b first (CORRECT):';
+SELECT 'Int16 - expect b first:';
 SELECT replaceRegexpAll(explain, '__table1\\.', '') FROM (EXPLAIN actions=1 SELECT count(*) FROM test_i16 WHERE a = 15 AND b = 15) WHERE explain LIKE '%Prewhere%';
 
 DROP TABLE test_f32;

--- a/tests/queries/0_stateless/04312_client_chime_on_slow_query_92718.sh
+++ b/tests/queries/0_stateless/04312_client_chime_on_slow_query_92718.sh
@@ -57,7 +57,9 @@ echo "3. clickhouse-client (no --chime), 1.5s < default 5s threshold: $(bel_coun
 # Case 4: `--chime 1`, slow query that ends in an error, stderr redirected — expect no
 # `BEL` (suppressed by the TTY guard) AND verify the error path actually fires so the
 # test would loudly notice if `throwIf` semantics or the error path itself changes.
-${CLICKHOUSE_CLIENT} --chime 1 -q "SELECT sleep(1.5), throwIf(1 = 1, 'expected error')" 2> "$err4" > /dev/null
+# `sleep` is nested inside `throwIf`'s argument so it always runs before the throw;
+# as sibling projection columns their evaluation order would be unspecified.
+${CLICKHOUSE_CLIENT} --chime 1 -q "SELECT throwIf(sleep(1.5) = 0, 'expected error')" 2> "$err4" > /dev/null
 rc=$?
 if [ "$rc" -eq 0 ]; then
     case4_status="FAIL: query unexpectedly succeeded"
@@ -121,7 +123,9 @@ echo "10. clickhouse-client (no --chime), slow query (~6s > default 5s threshold
 # place where the "chime on error in TTY" contract is exercised: case 4 covers
 # the non-TTY suppression branch and would still pass if a regression emitted
 # `BEL` only on success and silently dropped it on errors.
-/usr/bin/script -eqc "${CLICKHOUSE_CLIENT} --chime 1 -q \"SELECT sleep(1.5), throwIf(1 = 1, 'expected error')\"" /dev/null > "$tty11" 2>&1
+# `sleep` is nested inside `throwIf`'s argument so it always runs before the throw;
+# as sibling projection columns their evaluation order would be unspecified.
+/usr/bin/script -eqc "${CLICKHOUSE_CLIENT} --chime 1 -q \"SELECT throwIf(sleep(1.5) = 0, 'expected error')\"" /dev/null > "$tty11" 2>&1
 rc=$?
 if [ "$rc" -eq 0 ]; then
     case11_status="FAIL: query unexpectedly succeeded"

--- a/tests/queries/0_stateless/04321_multiple_quotas_per_user.sh
+++ b/tests/queries/0_stateless/04321_multiple_quotas_per_user.sh
@@ -4,6 +4,11 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# Lower the client log level so transient server warnings (e.g. QuotaCache's "Re-chose quotas
+# ... in N ms", emitted when a recompute is slow under load) cannot leak onto stderr and fail
+# the stdout-only assertions below.
+CLICKHOUSE_CLIENT=$(echo "${CLICKHOUSE_CLIENT}" | sed "s/--send_logs_level=${CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL}/--send_logs_level=error/")
+
 # A user can be assigned several quotas at once (here, of different key types). All of them must
 # be enforced together: a query is rejected if ANY assigned quota is exceeded. Previously only one
 # quota per user was enforced, chosen non-deterministically, so the others were silently ignored.

--- a/tests/queries/0_stateless/04365_cancel_insert_when_client_dies_distributed.sh
+++ b/tests/queries/0_stateless/04365_cancel_insert_when_client_dies_distributed.sh
@@ -87,8 +87,12 @@ $CLICKHOUSE_CLIENT -q 'select count() from dedup_test'
 
 $CLICKHOUSE_CLIENT -q 'system flush logs text_log'
 
-# Ensure that thread_cancel actually did something
+# Ensure that thread_cancel actually did something. Native-protocol SIGINT sends a graceful
+# 'Cancel' packet (connection preserved) rather than dropping the socket, so match the
+# QUERY_WAS_CANCELLED_BY_CLIENT messages too; the socket-drop messages only fire on SIGKILL.
 $CLICKHOUSE_CLIENT -q "select count() > 0 from system.text_log where event_date >= yesterday() AND event_time >= now() - 600 and query_id like '$TEST_MARK%' and (
   message_format_string in ('Unexpected end of file while reading chunk header of HTTP chunked data', 'Unexpected EOF, got {} of {} bytes',
-  'Query was cancelled or a client has unexpectedly dropped the connection') or
+  'Query was cancelled or a client has unexpectedly dropped the connection',
+  'Received ''Cancel'' packet from the client, canceling the query.',
+  'Packet ''Cancel'' has been received from the client, canceling the query.') or
   message like '%Connection reset by peer%' or message like '%Broken pipe, while writing to socket%') SETTINGS max_rows_to_read = 0"


### PR DESCRIPTION
Automated backport of upstream flaky-fix commits.
(manual push)

- [x] <!---ci_exclude_regression--> Exclude all Regression
- [x] <!---no_ci_cache--> Disable CI Cache

### Cherry-picked

- [`b0f0a79749ff`](https://github.com/ClickHouse/ClickHouse/commit/b0f0a79749fff46de8e05b829974c3aff45c9b7b) Fix flaky test_kafka_formats_with_broken_message (slow-build errors-MV flush)  _(committed 2026-06-23T03:05:07Z)_
- [`aa58245e52cc`](https://github.com/ClickHouse/ClickHouse/commit/aa58245e52cc227c663f81206dd2a2f634165a01) Fix flaky test_system_kafka_consumers (DROP-view-vs-streamer race)  _(committed 2026-06-23T22:37:59Z)_
- [`401bc6c8948a`](https://github.com/ClickHouse/ClickHouse/commit/401bc6c8948aafec9d012dc420984876161f259e) Fix flaky test 04365_cancel_insert_when_client_dies_distributed  _(committed 2026-06-23T23:22:05Z)_
- [`177ed2411dae`](https://github.com/ClickHouse/ClickHouse/commit/177ed2411daef99acbb487b24c5178dc349bf293) Fix flaky test_s3_plain_rewritable: opt in to legacy REPLACE PARTITION from empty source  _(committed 2026-06-24T04:18:40Z)_
- [`d2d81c115a4b`](https://github.com/ClickHouse/ClickHouse/commit/d2d81c115a4bcc9de9f93eb0e0835c3e8ca9624c) Revert "Fix flaky test_rabbitmq_big_message: keep polling while consumption progresses"  _(committed 2026-06-24T20:16:22Z)_
- [`f641ece7d2f4`](https://github.com/ClickHouse/ClickHouse/commit/f641ece7d2f420a053c20eff25cbbef9ed42d8e6) Fix flaky test 04240_statistics_countmin_numeric_types  _(committed 2026-06-24T22:53:27Z)_
- [`13b91d57a817`](https://github.com/ClickHouse/ClickHouse/commit/13b91d57a817409ea63fa9742c7802558b7150ae) Fix flaky test_parallel_quorum_actually_quorum  _(committed 2026-06-25T08:03:00Z)_
- [`16493775c22e`](https://github.com/ClickHouse/ClickHouse/commit/16493775c22ebc58c3b33ce89e995c89242d2849) Fix flaky test_shutdown_cancels_backup and test_long_disconnection_stops_backup  _(committed 2026-06-25T11:32:24Z)_
- [`90e888a545ff`](https://github.com/ClickHouse/ClickHouse/commit/90e888a545ff7b6db616087cd2cdbbe606cc4e7e) Fix flaky test 02161_addressToLineWithInlines  _(committed 2026-06-25T15:14:25Z)_
- [`80c8a4312037`](https://github.com/ClickHouse/ClickHouse/commit/80c8a4312037f91700caa0ccbbd5eff8a8ca228a) Fix flaky test_keeper_disks::test_snapshots_with_disks  _(committed 2026-06-25T16:08:16Z)_
- [`852a2c260ad1`](https://github.com/ClickHouse/ClickHouse/commit/852a2c260ad14d48a47eea52487722e846e157f5) Fix flaky test_distributed_frozen_replica: pin lightweight_deletes_sync=1 on DELETE  _(committed 2026-06-25T19:03:22Z)_
- [`985c43696455`](https://github.com/ClickHouse/ClickHouse/commit/985c436964550ab2af6b42eeb94915993dcac735) Fix flaky test 03583_rewrite_in_to_join (row ordering)  _(committed 2026-06-26T01:11:37Z)_
- [`2e30a6b9ae66`](https://github.com/ClickHouse/ClickHouse/commit/2e30a6b9ae669015526971d597f7ea0b204183ed) Fix flaky test_async_backup_restore_with_max_execution_time_zero on slow CI lanes  _(committed 2026-06-26T03:18:31Z)_
- [`fb1000fcf6a7`](https://github.com/ClickHouse/ClickHouse/commit/fb1000fcf6a7b3afe9d21e17b0a59724f76d1686) Fix flaky test_e2e_catalogs[glue]: implement wait_for_table_ready  _(committed 2026-06-26T12:15:07Z)_
- [`01e92533ed62`](https://github.com/ClickHouse/ClickHouse/commit/01e92533ed62cca72715e5a83038545181284bb2) Fix flaky test_storage_s3_queue/test_1.py::test_max_set_age  _(committed 2026-06-26T17:02:24Z)_
- [`ea12275689c3`](https://github.com/ClickHouse/ClickHouse/commit/ea12275689c3095503043ec64255f33d8c447ea1) Fix flaky test_kafka_many_materialized_views (view2 result race)  _(committed 2026-06-26T23:36:58Z)_
- [`1287728b9f92`](https://github.com/ClickHouse/ClickHouse/commit/1287728b9f9261295da79118a191e5f50b3d7868) Fix flaky test_startup_without_zookeeper: retry the recursive ZK delete  _(committed 2026-06-29T05:21:34Z)_
- [`b59a7ddf8fed`](https://github.com/ClickHouse/ClickHouse/commit/b59a7ddf8fedb6d56fc4e0c4fe5be14e696921f5) Fix flaky test test_clickhouse_writes_trino_reads (No nodes available to run query)  _(committed 2026-06-29T17:34:52Z)_
- [`aa30a607b4a3`](https://github.com/ClickHouse/ClickHouse/commit/aa30a607b4a3af118f44666fb01fbf1488e56383) Fix flaky test_restore_db_replica_with_diffrent_table_metadata  _(committed 2026-06-29T21:12:07Z)_
- [`24c098df579d`](https://github.com/ClickHouse/ClickHouse/commit/24c098df579d4d96ab68391ae21cc44eea73c0cd) Fix flaky test 02441_alter_delete_and_drop_column  _(committed 2026-06-30T11:28:21Z)_
- [`b6dfe3b89c4a`](https://github.com/ClickHouse/ClickHouse/commit/b6dfe3b89c4a0f96246f8b69683c864a4ee59dca) Fix flaky test_implicit_index_upgrade_alter_replay (replica fetch race)  _(committed 2026-06-30T16:08:56Z)_
- [`9083e3a89c80`](https://github.com/ClickHouse/ClickHouse/commit/9083e3a89c8035af3de1f2b9c090e5160b7d8bee) Fix flaky test 04051_pk_analysis_stats: QCC entry evicted by parallel tests  _(committed 2026-06-30T16:33:51Z)_
- [`e78459d82170`](https://github.com/ClickHouse/ClickHouse/commit/e78459d82170ecd8320fa5a4bf014bd6f7cefb64) Fix flaky test 02789_filesystem_cache_alignment  _(committed 2026-06-30T17:46:14Z)_
- [`17e2ed58e64d`](https://github.com/ClickHouse/ClickHouse/commit/17e2ed58e64d92c50d51f77e691b8ada2738757c) Fix flaky test_backup_restore_on_cluster restore timeout  _(committed 2026-06-30T21:15:30Z)_
- [`2f861264e4ae`](https://github.com/ClickHouse/ClickHouse/commit/2f861264e4ae4a8757ddedf3a841f98ecee2eb79) Fix flaky test 04312_client_chime_on_slow_query_92718  _(committed 2026-06-30T23:22:37Z)_
- [`9f90342fdca8`](https://github.com/ClickHouse/ClickHouse/commit/9f90342fdca8dc556d5b7f2dd5491f3d1a737ae7) Fix flaky test_keeper_session_refuse_stale_server  _(committed 2026-07-01T09:16:10Z)_
- [`c5e22ee8f3ae`](https://github.com/ClickHouse/ClickHouse/commit/c5e22ee8f3ae1f1ed39ae797b2e68558b53f34ff) Fix flaky test 00612_pk_in_tuple_perf  _(committed 2026-07-01T10:02:40Z)_
- [`aa8dda746e24`](https://github.com/ClickHouse/ClickHouse/commit/aa8dda746e24a295a4316b286d21346c51a3e223) Fix flaky test 00974_query_profiler  _(committed 2026-07-01T13:35:23Z)_
- [`0c3e7fd50d2c`](https://github.com/ClickHouse/ClickHouse/commit/0c3e7fd50d2c0ff7bdcc468012ea9d7821a7f6f3) Fix flaky test 04053_merge_table_large_query_performance  _(committed 2026-07-01T18:53:11Z)_
- [`925fb1cb175e`](https://github.com/ClickHouse/ClickHouse/commit/925fb1cb175e6613cd4eb5f9074e13b0a1a4ad68) Fix flaky test 03986_kill_query_mutation_sync_replicated  _(committed 2026-07-02T14:24:16Z)_
- [`8a019722ef68`](https://github.com/ClickHouse/ClickHouse/commit/8a019722ef68e85c81a31d9f6b5d6b408963b151) Fix flaky test test_keeper_ttl_nodes::test_many_nodes_with_different_ttls  _(committed 2026-07-02T14:49:44Z)_
- [`610cd689085a`](https://github.com/ClickHouse/ClickHouse/commit/610cd689085a3a7a1b29f0263949ea00d0069684) Fix flaky test 04321_multiple_quotas_per_user  _(committed 2026-07-03T12:19:01Z)_
- [`4aef3f83c4df`](https://github.com/ClickHouse/ClickHouse/commit/4aef3f83c4df8c3997c9765e537c2e0e3cb998e6) Fix flaky test 04146_iceberg_orc_row_policy_prewhere on release branches  _(committed 2026-07-03T14:24:57Z)_
- [`ff85e04b78e8`](https://github.com/ClickHouse/ClickHouse/commit/ff85e04b78e8bc22e5d262da4ed92f9d1c5ae347) Fix flaky test_failed_commit_after_success (s3_queue)  _(committed 2026-07-03T17:23:12Z)_
- [`03765d162a91`](https://github.com/ClickHouse/ClickHouse/commit/03765d162a91feb3f21d696c01f820bbda6105fb) Fix flaky test 03394_distributed_shuffle_join_with_aggregation  _(committed 2026-07-04T03:19:47Z)_
- [`01abbd025ddd`](https://github.com/ClickHouse/ClickHouse/commit/01abbd025ddde2bacca291c9fe96f5a991a531ee) Fix flaky test test_dictionaries_postgresql::test_invalidate_query  _(committed 2026-07-04T05:08:06Z)_
- [`da4060455b06`](https://github.com/ClickHouse/ClickHouse/commit/da4060455b063ad62bdaecd1e658b86ea1fe4234) Fix flaky test 03394_distributed_shuffle_join_with_in  _(committed 2026-07-04T10:26:13Z)_
- [`eb79a6daff00`](https://github.com/ClickHouse/ClickHouse/commit/eb79a6daff003f1b412d83061a4670095bc46df2) Fix flaky test_retry_loading_parts in test_merge_tree_s3_failover  _(committed 2026-07-06T20:58:34Z)_
- [`6edf3b2fe4a3`](https://github.com/ClickHouse/ClickHouse/commit/6edf3b2fe4a3ebd7a4342a5d023406a2921e47a7) Fix flaky test_rabbitmq_mv_combo: keep polling while consumption progresses  _(committed 2026-07-09T12:45:30Z)_
- [`e1d7ad5f9fa1`](https://github.com/ClickHouse/ClickHouse/commit/e1d7ad5f9fa17f1ea970a1d1c85f04df2b46b72c) Fix flaky test 02676_optimize_old_parts_replicated  _(committed 2026-07-12T19:23:23Z)_
- [`aac9fbc6206e`](https://github.com/ClickHouse/ClickHouse/commit/aac9fbc6206eb00740d1d1ae6dfed1af2bb39c03) Fix flaky test_storage_iceberg_disks: skip S3 disk startup access check  _(committed 2026-07-15T16:39:35Z)_
- [`6944c75587ca`](https://github.com/ClickHouse/ClickHouse/commit/6944c75587cad4497c1bde904e2e4e471749d985) Fix flaky test 02421_simple_queries_for_opentelemetry  _(committed 2026-07-17T11:54:59Z)_
- [`5e662b6d2710`](https://github.com/ClickHouse/ClickHouse/commit/5e662b6d271004d2bd81f12092b330d37f974eec) Fix flaky test 01017_uniqCombined_memory_usage  _(committed 2026-07-17T17:02:35Z)_
- [`51eea395dd90`](https://github.com/ClickHouse/ClickHouse/commit/51eea395dd9091ce12f453f5407c861d2a6c1368) Fix flaky test_rename_distributed_parallel_insert_and_select  _(committed 2026-07-20T17:49:36Z)_

### Skipped (cherry-pick conflict — manual backport needed)

- [`f6300c9717a0`](https://github.com/ClickHouse/ClickHouse/commit/f6300c9717a06e2b7444a738e2846e30eede4152) Fix flaky test 04402_map_functions_lowcardinality  _(committed 2026-06-27T01:45:32Z)_
- [`404b36c92268`](https://github.com/ClickHouse/ClickHouse/commit/404b36c92268fdc58b85b870336e0f866fdf7dbe) Fix flaky test 04489_regexp_compile_error_bounded by measuring the longest line  _(committed 2026-06-30T06:47:44Z)_
- [`0fc750e4c48e`](https://github.com/ClickHouse/ClickHouse/commit/0fc750e4c48e8d5779a7a27ae909aa6dc6550236) Fix flaky test 04344_server_ast_fuzzer_insert_limit (sync-drop timeout)  _(committed 2026-07-02T18:18:39Z)_
- [`9b93db63a3c0`](https://github.com/ClickHouse/ClickHouse/commit/9b93db63a3c021ff87bf8ca4c96bfd45e26b8889) Fix flaky test 04061_spilling_hash_join_overflow_limits  _(committed 2026-07-03T16:46:15Z)_
- [`4410afb70270`](https://github.com/ClickHouse/ClickHouse/commit/4410afb70270867a989414532b498d819d72ecf4) Fix flaky test 04001_join_reorder_through_expression under randomized join order  _(committed 2026-07-06T13:28:51Z)_
- [`47a0bc338877`](https://github.com/ClickHouse/ClickHouse/commit/47a0bc338877cf1d609af7562ed3a6e11d332b49) Fix flaky test_server_no_logging: poll for async "Restored console logger level" line  _(committed 2026-07-10T18:19:46Z)_
- [`2f69c7a06ffb`](https://github.com/ClickHouse/ClickHouse/commit/2f69c7a06ffb0aff15d210c9f1a07f4d12f61886) Fix flaky test_parallel_replicas_protocol backward-compat OPTIMIZE hang  _(committed 2026-07-12T01:05:34Z)_
- [`1b38d200d72d`](https://github.com/ClickHouse/ClickHouse/commit/1b38d200d72dea0a7033654fa243b83e84e0992f) Fix flaky test 04491_outfile_compression_level_range  _(committed 2026-07-14T09:18:49Z)_