### PR TITLE
EXPORT PARTITION with position matching + extra columns in source

### DIFF
--- a/docs/en/antalya/part_export.md
+++ b/docs/en/antalya/part_export.md
@@ -55,7 +55,7 @@ Source and destination tables must support positional schema conversion. The fol
 
 The following must match between source and destination:
 
-1. **Column count** - source and destination must have the same number of columns.
+1. **Column count** - source and destination must have the same number of columns by default. A mismatch in either direction throws `NUMBER_OF_COLUMNS_DOESNT_MATCH`. Set `export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'` to allow a source table with extra trailing columns; the destination having more columns than the source is still rejected in this mode.
 2. **`PARTITION BY` expressions** - for destinations other than data lakes, the source and destination `PARTITION BY` expressions must be identical. For Apache Iceberg destinations, the source partition key must be representable as an Iceberg partition spec and must match the destination partition fields and transforms.
 3. **The position of every column backing the partition key** - it is not enough for the `PARTITION BY` expressions to be textually identical: every top-level column that provides a column or subcolumn used by the source table's partition key must have the same name at the same position in the destination table's schema. If such a column contains a named `Tuple`, its element names must also be declared in the same order (an unnamed `Tuple` on either side is exempt from this, per the allowance above). This comparison is recursive through nested tuples and through container types such as `Array` and `Map`.
 
@@ -135,6 +135,16 @@ In case a table function is used as the destination, the schema can be omitted a
   When exporting to Apache Iceberg, the partition value written to the metadata is derived from the source partition columns by casting them to the destination partition-field types and applying the destination partition transform — the same computation the exported data files use. This keeps the Iceberg metadata consistent with the data files.
 
   **Warning:** A lossy cast on a partition column remains semantically truncating. For example, if a table is partitioned by an `Int64` column and some partition values do not fit into a destination `Int32` partition column, both the data files and the Iceberg metadata will contain the truncated `Int32` value (they agree with each other, but the original `Int64` value is lost). Such casts require `export_merge_tree_part_allow_lossy_cast = 1`.
+
+### `export_merge_tree_part_schema_mismatch_mode` (Optional)
+
+- **Type**: `MergeTreePartExportSchemaMismatchMode`
+- **Default**: `strict`
+- **Description**: Controls whether `EXPORT PART`/`EXPORT PARTITION` allows a column-count mismatch between the source `MergeTree` table and the destination table. Columns are matched positionally, like `INSERT INTO dest SELECT * FROM src`. Possible values:
+  - `strict` - the source and destination must have the same number of columns. A mismatch in either direction throws `NUMBER_OF_COLUMNS_DOESNT_MATCH`.
+  - `ignore_extra_source_columns_by_position` - the source may have more columns than the destination. The extra trailing source columns (by position) are dropped and not exported. The destination having more columns than the source is still rejected in this mode.
+
+  The extra trailing source columns are still read and evaluated (including `MATERIALIZED`/`ALIAS` columns, and any column another kept column's `ALIAS`/`MATERIALIZED` expression depends on) before being dropped, so this setting only changes which columns end up in the destination, not what is computed while reading the part.
 
 
 ## Examples

--- a/docs/en/antalya/partition_export.md
+++ b/docs/en/antalya/partition_export.md
@@ -47,7 +47,7 @@ TO TABLE [destination_database.]destination_table
 
 `EXPORT PARTITION` exports each part via the same mechanism as [`EXPORT PART`](/docs/en/antalya/part_export.md#requirements), so the source and destination tables must satisfy the same compatibility requirements. Column names may differ (columns are matched by position, not by name), and column types may differ as long as they are safely castable (or `export_merge_tree_part_allow_lossy_cast = 1` is set). Beyond that, the following must match:
 
-1. **Column count** - source and destination must have the same number of columns.
+1. **Column count** - source and destination must have the same number of columns by default. Set `export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'` to allow a source table with extra trailing columns; the destination having more columns than the source is still rejected in this mode.
 2. **`PARTITION BY` expressions** - for destinations other than data lakes, the source and destination `PARTITION BY` expressions must be identical. For Apache Iceberg destinations, the source partition key must match the destination partition fields and transforms.
 3. **Partition key column positions and layouts** - every top-level column that provides a column or subcolumn used by the source table's partition key must have the same name at the same position in the destination table's schema. Named `Tuple` elements within such a column must also be declared in the same order, including tuples nested inside `Array` or `Map`. This applies even if both tables' `PARTITION BY` expressions are textually identical. See [`EXPORT PART` requirements](/docs/en/antalya/part_export.md#requirements) for a worked example and the corresponding exception message.
 
@@ -127,6 +127,16 @@ Notes:
   When exporting to Apache Iceberg, the partition value written to the metadata is derived from the source partition columns by casting them to the destination partition-field types and applying the destination partition transform — the same computation the exported data files use. This keeps the Iceberg metadata consistent with the data files.
 
   **Warning:** A lossy cast on a partition column remains semantically truncating. For example, if a table is partitioned by an `Int64` column and some partition values do not fit into a destination `Int32` partition column, both the data files and the Iceberg metadata will contain the truncated `Int32` value (they agree with each other, but the original `Int64` value is lost). Such casts require `export_merge_tree_part_allow_lossy_cast = 1`.
+
+### `export_merge_tree_part_schema_mismatch_mode` (Optional)
+
+- **Type**: `MergeTreePartExportSchemaMismatchMode`
+- **Default**: `strict`
+- **Description**: Controls whether `EXPORT PART`/`EXPORT PARTITION` allows a column-count mismatch between the source `MergeTree` table and the destination table. Columns are matched positionally, like `INSERT INTO dest SELECT * FROM src`. Possible values:
+  - `strict` - the source and destination must have the same number of columns. A mismatch in either direction throws `NUMBER_OF_COLUMNS_DOESNT_MATCH`.
+  - `ignore_extra_source_columns_by_position` - the source may have more columns than the destination. The extra trailing source columns (by position) are dropped and not exported. The destination having more columns than the source is still rejected in this mode.
+
+  The extra trailing source columns are still read and evaluated (including `MATERIALIZED`/`ALIAS` columns, and any column another kept column's `ALIAS`/`MATERIALIZED` expression depends on) before being dropped, so this setting only changes which columns end up in the destination, not what is computed while reading the part.
 
 ## Examples
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7627,6 +7627,12 @@ Allow `EXPORT PART`/`EXPORT PARTITION` to apply lossy (non-value-preserving) cas
 
 When exporting to Apache Iceberg, the partition value written to the metadata is derived from the source partition columns by casting them to the destination partition-field types and applying the destination partition transform — the same computation the exported data files use, so the metadata stays consistent with the data. A lossy cast on a partition column remains semantically truncating: both the data files and the metadata contain the truncated value, and such casts require this setting to be enabled.
 )", 0) \
+    DECLARE(MergeTreePartExportSchemaMismatchMode, export_merge_tree_part_schema_mismatch_mode, MergeTreePartExportSchemaMismatchMode::strict, R"(
+Controls whether `EXPORT PART`/`EXPORT PARTITION` allows a column-count mismatch between the source `MergeTree` table and the destination table. Columns are matched positionally, like `INSERT INTO dest SELECT * FROM src`.
+Possible values:
+- `strict` (default) - the source and destination must have the same number of columns. A mismatch in either direction throws `NUMBER_OF_COLUMNS_DOESNT_MATCH`.
+- `ignore_extra_source_columns_by_position` - the source may have more columns than the destination. The extra trailing source columns (by position) are dropped and not exported. The destination having more columns than the source is still rejected in this mode.
+)", 0) \
     \
     /* ####################################################### */ \
     /* ########### START OF EXPERIMENTAL FEATURES ############ */ \

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -85,6 +85,7 @@ class WriteBuffer;
     M(CLASS_NAME, Map) \
     M(CLASS_NAME, MaxThreads) \
     M(CLASS_NAME, MergeTreePartExportFileAlreadyExistsPolicy) \
+    M(CLASS_NAME, MergeTreePartExportSchemaMismatchMode) \
     M(CLASS_NAME, Milliseconds) \
     M(CLASS_NAME, MsgPackUUIDRepresentation) \
     M(CLASS_NAME, MySQLDataTypesSupport) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,6 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"object_storage_cluster_join_mode", "allow", "allow", "New setting"},
             {"export_merge_tree_partition_task_timeout_seconds", "3600", "86400", "Increase default value to make it more realistic"},
             {"export_merge_tree_part_allow_lossy_cast", false, false, "New setting to gate lossy casts in EXPORT PART/PARTITION behind explicit acknowledgment"},
+            {"export_merge_tree_part_schema_mismatch_mode", "strict", "strict", "New setting to allow EXPORT PART/EXPORT PARTITION when the source table has more columns than the destination"},
             {"export_merge_tree_partition_retry_initial_backoff_seconds", 5, 5, "New setting for exponential back-off between failed part export retries in an export partition task"},
             {"export_merge_tree_partition_retry_max_backoff_seconds", 300, 300, "New setting capping the exponential back-off between failed part export retries in an export partition task"},
             {"export_merge_tree_partition_max_retries", 3, 3, "Obsolete and ignored: export partition tasks now retry retryable failures until the task timeout and fail immediately on non-retryable errors, instead of using a fixed retry budget"},

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -483,6 +483,8 @@ IMPLEMENT_SETTING_ENUM(JemallocProfileFormat, ErrorCodes::BAD_ARGUMENTS,
 
 IMPLEMENT_SETTING_AUTO_ENUM(MergeTreePartExportFileAlreadyExistsPolicy, ErrorCodes::BAD_ARGUMENTS);
 
+IMPLEMENT_SETTING_AUTO_ENUM(MergeTreePartExportSchemaMismatchMode, ErrorCodes::BAD_ARGUMENTS);
+
 IMPLEMENT_SETTING_AUTO_ENUM(ExportPartitionAllOnError, ErrorCodes::BAD_ARGUMENTS);
 
 }

--- a/src/Core/SettingsEnums.h
+++ b/src/Core/SettingsEnums.h
@@ -574,6 +574,14 @@ enum class MergeTreePartExportFileAlreadyExistsPolicy : uint8_t
 
 DECLARE_SETTING_ENUM(MergeTreePartExportFileAlreadyExistsPolicy)
 
+enum class MergeTreePartExportSchemaMismatchMode : uint8_t
+{
+    strict,
+    ignore_extra_source_columns_by_position,
+};
+
+DECLARE_SETTING_ENUM(MergeTreePartExportSchemaMismatchMode)
+
 enum class ExportPartitionAllOnError : uint8_t
 {
     throw_first,

--- a/src/Storages/ExportReplicatedMergeTreePartitionManifest.h
+++ b/src/Storages/ExportReplicatedMergeTreePartitionManifest.h
@@ -241,7 +241,6 @@ struct ExportReplicatedMergeTreePartitionManifest
     String filename_pattern;
     bool write_full_path_in_iceberg_metadata = false;
     bool allow_lossy_cast = false;
-    MergeTreePartExportSchemaMismatchMode schema_mismatch_mode = MergeTreePartExportSchemaMismatchMode::strict;
     String iceberg_metadata_json;
 
     /// Optional because of backwards compatibility
@@ -249,6 +248,7 @@ struct ExportReplicatedMergeTreePartitionManifest
     std::optional<UInt64> output_format_compression_level;
     std::optional<UInt64> parquet_row_group_size;
     std::optional<UInt64> parquet_row_group_size_bytes;
+    std::optional<MergeTreePartExportSchemaMismatchMode> schema_mismatch_mode;
 
     std::string toJsonString() const
     {
@@ -283,7 +283,6 @@ struct ExportReplicatedMergeTreePartitionManifest
         json.set("task_timeout_seconds", task_timeout_seconds);
         json.set("write_full_path_in_iceberg_metadata", write_full_path_in_iceberg_metadata);
         json.set("allow_lossy_cast", allow_lossy_cast);
-        json.set("schema_mismatch_mode", String(magic_enum::enum_name(schema_mismatch_mode)));
         if (parquet_compression_method)
             json.set("parquet_compression_method", *parquet_compression_method);
         if (output_format_compression_level)
@@ -292,6 +291,8 @@ struct ExportReplicatedMergeTreePartitionManifest
             json.set("parquet_row_group_size", *parquet_row_group_size);
         if (parquet_row_group_size_bytes)
             json.set("parquet_row_group_size_bytes", *parquet_row_group_size_bytes);
+        if (schema_mismatch_mode)
+            json.set("schema_mismatch_mode", String(magic_enum::enum_name(*schema_mismatch_mode)));
         std::ostringstream oss;     // STYLE_CHECK_ALLOW_STD_STRING_STREAM
         oss.exceptions(std::ios::failbit);
         Poco::JSON::Stringifier::stringify(json, oss);
@@ -359,14 +360,15 @@ struct ExportReplicatedMergeTreePartitionManifest
         /// on upgrade. New tasks always persist the initiator's actual choice.
         manifest.allow_lossy_cast = json->has("allow_lossy_cast") ? json->getValue<bool>("allow_lossy_cast") : true;
 
-        /// Tasks created before this field existed were always scheduled under the old,
-        /// strict column-count check (a mismatch could never reach scheduling in the first
-        /// place), so the struct's default of `strict` is the correct fallback here.
+        /// Left unset (nullopt) for tasks created before this field existed - such tasks were
+        /// always scheduled under the old, strict column-count check (a mismatch could never
+        /// reach scheduling in the first place), so callers should treat an absent value as
+        /// `strict`.
         if (json->has("schema_mismatch_mode"))
         {
             const auto schema_mismatch_mode = magic_enum::enum_cast<MergeTreePartExportSchemaMismatchMode>(json->getValue<String>("schema_mismatch_mode"));
             if (schema_mismatch_mode)
-                manifest.schema_mismatch_mode = schema_mismatch_mode.value();
+                manifest.schema_mismatch_mode = schema_mismatch_mode;
         }
 
         if (json->has("parquet_compression_method"))

--- a/src/Storages/ExportReplicatedMergeTreePartitionManifest.h
+++ b/src/Storages/ExportReplicatedMergeTreePartitionManifest.h
@@ -241,6 +241,7 @@ struct ExportReplicatedMergeTreePartitionManifest
     String filename_pattern;
     bool write_full_path_in_iceberg_metadata = false;
     bool allow_lossy_cast = false;
+    MergeTreePartExportSchemaMismatchMode schema_mismatch_mode = MergeTreePartExportSchemaMismatchMode::strict;
     String iceberg_metadata_json;
 
     /// Optional because of backwards compatibility
@@ -282,6 +283,7 @@ struct ExportReplicatedMergeTreePartitionManifest
         json.set("task_timeout_seconds", task_timeout_seconds);
         json.set("write_full_path_in_iceberg_metadata", write_full_path_in_iceberg_metadata);
         json.set("allow_lossy_cast", allow_lossy_cast);
+        json.set("schema_mismatch_mode", String(magic_enum::enum_name(schema_mismatch_mode)));
         if (parquet_compression_method)
             json.set("parquet_compression_method", *parquet_compression_method);
         if (output_format_compression_level)
@@ -357,6 +359,15 @@ struct ExportReplicatedMergeTreePartitionManifest
         /// on upgrade. New tasks always persist the initiator's actual choice.
         manifest.allow_lossy_cast = json->has("allow_lossy_cast") ? json->getValue<bool>("allow_lossy_cast") : true;
 
+        /// Tasks created before this field existed were always scheduled under the old,
+        /// strict column-count check (a mismatch could never reach scheduling in the first
+        /// place), so the struct's default of `strict` is the correct fallback here.
+        if (json->has("schema_mismatch_mode"))
+        {
+            const auto schema_mismatch_mode = magic_enum::enum_cast<MergeTreePartExportSchemaMismatchMode>(json->getValue<String>("schema_mismatch_mode"));
+            if (schema_mismatch_mode)
+                manifest.schema_mismatch_mode = schema_mismatch_mode.value();
+        }
 
         if (json->has("parquet_compression_method"))
         {

--- a/src/Storages/MergeTree/ExportPartTask.cpp
+++ b/src/Storages/MergeTree/ExportPartTask.cpp
@@ -129,7 +129,7 @@ namespace
     {
         const auto destination_header
             = destination_storage.getInMemoryMetadataPtr()->getSampleBlockNonMaterialized();
-        const auto destination_columns = destination_header.getColumnsWithTypeAndName();
+        const auto & destination_columns = destination_header.getColumnsWithTypeAndName();
 
         const bool ignore_extra_source_columns_by_position =
             local_context->getSettingsRef()[Setting::export_merge_tree_part_schema_mismatch_mode]
@@ -139,6 +139,12 @@ namespace
 
         if (ignore_extra_source_columns_by_position && source_columns.size() > destination_columns.size())
         {
+            LOG_DEBUG(getLogger("ExportPartTask"),
+                "Source has {} columns while destination has {} columns, "
+                "the {} extra trailing source column(s) will be ignored",
+                source_columns.size(), destination_columns.size(),
+                source_columns.size() - destination_columns.size());
+
             Names kept_names;
             kept_names.reserve(destination_columns.size());
             for (size_t i = 0; i < destination_columns.size(); ++i)

--- a/src/Storages/MergeTree/ExportPartTask.cpp
+++ b/src/Storages/MergeTree/ExportPartTask.cpp
@@ -65,6 +65,7 @@ namespace Setting
     extern const SettingsUInt64 export_merge_tree_part_max_rows_per_file;
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsString export_merge_tree_part_filename_pattern;
+    extern const SettingsMergeTreePartExportSchemaMismatchMode export_merge_tree_part_schema_mismatch_mode;
 }
 
 namespace
@@ -116,6 +117,11 @@ namespace
     /// destination header = `getSampleBlockNonMaterialized()`, all type bridging is done
     /// by the CAST inside `makeConvertingActions`. No pre-validation, no per-column
     /// lossy/non-lossy classification — restrictions are exactly what INSERT SELECT enforces.
+    ///
+    /// Exception: when `export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'`
+    /// and the source has more columns than the destination, the extra trailing source
+    /// columns (by position) are dropped by a preliminary projection step before the
+    /// positional convert, so `makeConvertingActions` always sees equal-sized inputs.
     void addExportConvertingActions(
         QueryPlan & plan_for_part,
         const IStorage & destination_storage,
@@ -123,10 +129,40 @@ namespace
     {
         const auto destination_header
             = destination_storage.getInMemoryMetadataPtr()->getSampleBlockNonMaterialized();
+        const auto destination_columns = destination_header.getColumnsWithTypeAndName();
+
+        const bool ignore_extra_source_columns_by_position =
+            local_context->getSettingsRef()[Setting::export_merge_tree_part_schema_mismatch_mode]
+                == MergeTreePartExportSchemaMismatchMode::ignore_extra_source_columns_by_position;
+
+        auto source_columns = plan_for_part.getCurrentHeader()->getColumnsWithTypeAndName();
+
+        if (ignore_extra_source_columns_by_position && source_columns.size() > destination_columns.size())
+        {
+            Names kept_names;
+            kept_names.reserve(destination_columns.size());
+            for (size_t i = 0; i < destination_columns.size(); ++i)
+                kept_names.push_back(source_columns[i].name);
+
+            /// `allow_remove_inputs = false` keeps the dropped columns registered as DAG
+            /// inputs (just not as outputs), so `ExpressionActions::execute` still
+            /// recognizes and consumes them from the block instead of passing them through
+            /// unchanged. See the `defaults_dag` merge above for the same pattern.
+            ActionsDAG trim_dag(source_columns);
+            trim_dag.removeUnusedActions(kept_names, false);
+
+            auto trim_step = std::make_unique<ExpressionStep>(
+                plan_for_part.getCurrentHeader(),
+                std::move(trim_dag));
+            trim_step->setStepDescription("Drop source columns beyond destination schema for export");
+            plan_for_part.addStep(std::move(trim_step));
+
+            source_columns = plan_for_part.getCurrentHeader()->getColumnsWithTypeAndName();
+        }
 
         auto dag = ActionsDAG::makeConvertingActions(
-            plan_for_part.getCurrentHeader()->getColumnsWithTypeAndName(),
-            destination_header.getColumnsWithTypeAndName(),
+            source_columns,
+            destination_columns,
             ActionsDAG::MatchColumnsMode::Position,
             local_context);
 

--- a/src/Storages/MergeTree/ExportPartitionUtils.cpp
+++ b/src/Storages/MergeTree/ExportPartitionUtils.cpp
@@ -173,6 +173,8 @@ namespace ExportPartitionUtils
             context_copy->setSetting("output_format_parquet_row_group_size", *manifest.parquet_row_group_size);
         if (manifest.parquet_row_group_size_bytes)
             context_copy->setSetting("output_format_parquet_row_group_size_bytes", *manifest.parquet_row_group_size_bytes);
+        if (manifest.schema_mismatch_mode)
+            context_copy->setSetting("export_merge_tree_part_schema_mismatch_mode", String(magic_enum::enum_name(*manifest.schema_mismatch_mode)));
 
         context_copy->setSetting("max_threads", manifest.max_threads);
         context_copy->setSetting("export_merge_tree_part_file_already_exists_policy", String(magic_enum::enum_name(manifest.file_already_exists_policy)));
@@ -199,11 +201,6 @@ namespace ExportPartitionUtils
         /// scheduled without the opt-in could still apply a lossy cast if the destination
         /// schema drifts to a lossy target between scheduling and execution.
         context_copy->setSetting("export_merge_tree_part_allow_lossy_cast", manifest.allow_lossy_cast);
-
-        /// Same reasoning as above, for the schema column-count mismatch mode: the worker
-        /// re-runs `verifyExportSchemaCastable` per part (via `exportPartToTable`) and must
-        /// honor the initiator's choice regardless of which replica picks up the task.
-        context_copy->setSetting("export_merge_tree_part_schema_mismatch_mode", String(magic_enum::enum_name(manifest.schema_mismatch_mode)));
 
 	    return context_copy;
     }
@@ -762,7 +759,7 @@ namespace ExportPartitionUtils
         const auto destination_sample_block = destination_metadata->getSampleBlockNonMaterialized();
 
         auto source_columns = source_sample_block.getColumnsWithTypeAndName();
-        const auto destination_columns = destination_sample_block.getColumnsWithTypeAndName();
+        const auto & destination_columns = destination_sample_block.getColumnsWithTypeAndName();
 
         /// In `ignore_extra_source_columns_by_position` mode a source with more columns than the destination
         /// is allowed: the extra trailing source columns (by position) are dropped, mirroring
@@ -774,7 +771,15 @@ namespace ExportPartitionUtils
                 == MergeTreePartExportSchemaMismatchMode::ignore_extra_source_columns_by_position;
 
         if (ignore_extra_source_columns_by_position && source_columns.size() > destination_columns.size())
+        {
+            LOG_DEBUG(getLogger("ExportPartitionUtils"),
+                "Source has {} columns while destination has {} columns, "
+                "the {} extra trailing source column(s) will be ignored",
+                source_columns.size(), destination_columns.size(),
+                source_columns.size() - destination_columns.size());
+
             source_columns.resize(destination_columns.size());
+        }
 
         (void) ActionsDAG::makeConvertingActions(
             source_columns,

--- a/src/Storages/MergeTree/ExportPartitionUtils.cpp
+++ b/src/Storages/MergeTree/ExportPartitionUtils.cpp
@@ -173,8 +173,12 @@ namespace ExportPartitionUtils
             context_copy->setSetting("output_format_parquet_row_group_size", *manifest.parquet_row_group_size);
         if (manifest.parquet_row_group_size_bytes)
             context_copy->setSetting("output_format_parquet_row_group_size_bytes", *manifest.parquet_row_group_size_bytes);
-        if (manifest.schema_mismatch_mode)
-            context_copy->setSetting("export_merge_tree_part_schema_mismatch_mode", String(magic_enum::enum_name(*manifest.schema_mismatch_mode)));
+        /// Manifests written before this setting existed have no value here; such tasks were always
+        /// scheduled under the old, strict column-count check, so an absent value must resolve to
+        /// `strict` regardless of the ambient context's setting (which may have since been changed).
+        context_copy->setSetting(
+            "export_merge_tree_part_schema_mismatch_mode",
+            String(magic_enum::enum_name(manifest.schema_mismatch_mode.value_or(MergeTreePartExportSchemaMismatchMode::strict))));
 
         context_copy->setSetting("max_threads", manifest.max_threads);
         context_copy->setSetting("export_merge_tree_part_file_already_exists_policy", String(magic_enum::enum_name(manifest.file_already_exists_policy)));

--- a/src/Storages/MergeTree/ExportPartitionUtils.cpp
+++ b/src/Storages/MergeTree/ExportPartitionUtils.cpp
@@ -83,6 +83,7 @@ namespace ErrorCodes
 namespace Setting
 {
     extern const SettingsBool export_merge_tree_part_allow_lossy_cast;
+    extern const SettingsMergeTreePartExportSchemaMismatchMode export_merge_tree_part_schema_mismatch_mode;
 }
 
 namespace FailPoints
@@ -198,6 +199,11 @@ namespace ExportPartitionUtils
         /// scheduled without the opt-in could still apply a lossy cast if the destination
         /// schema drifts to a lossy target between scheduling and execution.
         context_copy->setSetting("export_merge_tree_part_allow_lossy_cast", manifest.allow_lossy_cast);
+
+        /// Same reasoning as above, for the schema column-count mismatch mode: the worker
+        /// re-runs `verifyExportSchemaCastable` per part (via `exportPartToTable`) and must
+        /// honor the initiator's choice regardless of which replica picks up the task.
+        context_copy->setSetting("export_merge_tree_part_schema_mismatch_mode", String(magic_enum::enum_name(manifest.schema_mismatch_mode)));
 
 	    return context_copy;
     }
@@ -755,8 +761,20 @@ namespace ExportPartitionUtils
 
         const auto destination_sample_block = destination_metadata->getSampleBlockNonMaterialized();
 
-        const auto source_columns = source_sample_block.getColumnsWithTypeAndName();
+        auto source_columns = source_sample_block.getColumnsWithTypeAndName();
         const auto destination_columns = destination_sample_block.getColumnsWithTypeAndName();
+
+        /// In `ignore_extra_source_columns_by_position` mode a source with more columns than the destination
+        /// is allowed: the extra trailing source columns (by position) are dropped, mirroring
+        /// the trimming `ExportPartTask::addExportConvertingActions` applies to the real data.
+        /// The reverse (destination has more columns than source) is always rejected below by
+        /// `makeConvertingActions`, in both modes.
+        const bool ignore_extra_source_columns_by_position =
+            context->getSettingsRef()[Setting::export_merge_tree_part_schema_mismatch_mode]
+                == MergeTreePartExportSchemaMismatchMode::ignore_extra_source_columns_by_position;
+
+        if (ignore_extra_source_columns_by_position && source_columns.size() > destination_columns.size())
+            source_columns.resize(destination_columns.size());
 
         (void) ActionsDAG::makeConvertingActions(
             source_columns,

--- a/src/Storages/MergeTree/ExportPartitionUtils.h
+++ b/src/Storages/MergeTree/ExportPartitionUtils.h
@@ -96,6 +96,13 @@ namespace ExportPartitionUtils
     /// Validates that source columns can be exported into the destination with the
     /// same positional CAST matching as `INSERT INTO dest SELECT * FROM src`. Lossy
     /// casts are rejected unless `export_merge_tree_part_allow_lossy_cast` is set.
+    ///
+    /// By default the source and destination must have the same number of columns.
+    /// If `export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'`, a
+    /// source with more columns than the destination is allowed: the extra trailing
+    /// source columns (by position) are excluded from the comparison here, matching
+    /// what `ExportPartTask::addExportConvertingActions` drops from the actual data.
+    ///
     /// Throws BAD_ARGUMENTS on any violation.
     void verifyExportSchemaCastable(
         const StorageMetadataPtr & source_metadata,

--- a/src/Storages/MergeTree/tests/gtest_export_partition_ordering.cpp
+++ b/src/Storages/MergeTree/tests/gtest_export_partition_ordering.cpp
@@ -1,8 +1,45 @@
 #include <gtest/gtest.h>
+#include <sstream>
 #include <Storages/ExportReplicatedMergeTreePartitionTaskEntry.h>
+#include <Storages/MergeTree/ExportPartitionUtils.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Core/Settings.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/JSON/Stringifier.h>
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsMergeTreePartExportSchemaMismatchMode export_merge_tree_part_schema_mismatch_mode;
+}
+
+namespace
+{
+    ExportReplicatedMergeTreePartitionManifest makeValidManifest()
+    {
+        ExportReplicatedMergeTreePartitionManifest manifest;
+        manifest.transaction_id = "tx1";
+        manifest.query_id = "query1";
+        manifest.partition_id = "2020";
+        manifest.destination_database = "db1";
+        manifest.destination_table = "table1";
+        manifest.source_replica = "r1";
+        manifest.number_of_parts = 1;
+        manifest.create_time = 1000;
+        manifest.task_timeout_seconds = 60;
+        manifest.max_threads = 1;
+        manifest.parallel_formatting = true;
+        manifest.parquet_parallel_encoding = true;
+        manifest.max_bytes_per_file = 1000000;
+        manifest.max_rows_per_file = 1000;
+        manifest.file_already_exists_policy = MergeTreePartExportManifest::FileAlreadyExistsPolicy::error;
+        manifest.filename_pattern = "{part_name}";
+        return manifest;
+    }
+}
 
 class ExportPartitionOrderingTest : public ::testing::Test
 {
@@ -16,6 +53,10 @@ protected:
         , by_create_time(container.get<ExportPartitionTaskEntryTagByCreateTime>())
     {
     }
+};
+
+class ExportPartitionManifestBackCompatTest : public ::testing::Test
+{
 };
 
 TEST_F(ExportPartitionOrderingTest, IterationOrderMatchesCreateTime)
@@ -70,6 +111,64 @@ TEST_F(ExportPartitionOrderingTest, IterationOrderMatchesCreateTime)
     
     ++it;
     EXPECT_EQ(it, by_create_time.end());
+}
+
+
+TEST_F(ExportPartitionManifestBackCompatTest, MissingSchemaMismatchModeParsesAsNullopt)
+{
+    auto manifest = makeValidManifest();
+    manifest.schema_mismatch_mode = MergeTreePartExportSchemaMismatchMode::ignore_extra_source_columns_by_position;
+
+    Poco::JSON::Parser parser;
+    auto json = parser.parse(manifest.toJsonString()).extract<Poco::JSON::Object::Ptr>();
+    json->remove("schema_mismatch_mode");
+    std::ostringstream oss;
+    oss.exceptions(std::ios::failbit);
+    Poco::JSON::Stringifier::stringify(json, oss);
+
+    auto parsed = ExportReplicatedMergeTreePartitionManifest::fromJsonString(oss.str());
+    EXPECT_FALSE(parsed.schema_mismatch_mode.has_value());
+}
+
+TEST_F(ExportPartitionManifestBackCompatTest, SchemaMismatchModeRoundTripsForEveryValue)
+{
+    for (const auto value : magic_enum::enum_values<MergeTreePartExportSchemaMismatchMode>())
+    {
+        auto manifest = makeValidManifest();
+        manifest.schema_mismatch_mode = value;
+
+        auto parsed = ExportReplicatedMergeTreePartitionManifest::fromJsonString(manifest.toJsonString());
+
+        ASSERT_TRUE(parsed.schema_mismatch_mode.has_value()) << "value=" << magic_enum::enum_name(value);
+        EXPECT_EQ(*parsed.schema_mismatch_mode, value) << "value=" << magic_enum::enum_name(value);
+    }
+}
+
+TEST_F(ExportPartitionManifestBackCompatTest, MissingSchemaMismatchModeFallsBackToStrictInWorkerContext)
+{
+    auto manifest = makeValidManifest();
+    ASSERT_FALSE(manifest.schema_mismatch_mode.has_value());
+
+    auto worker_context = ExportPartitionUtils::getContextCopyWithTaskSettings(getContext().context, manifest);
+
+    EXPECT_EQ(
+        worker_context->getSettingsRef()[Setting::export_merge_tree_part_schema_mismatch_mode].value,
+        MergeTreePartExportSchemaMismatchMode::strict);
+}
+
+TEST_F(ExportPartitionManifestBackCompatTest, SchemaMismatchModeAppliedToWorkerContextForEveryValue)
+{
+    for (const auto value : magic_enum::enum_values<MergeTreePartExportSchemaMismatchMode>())
+    {
+        auto manifest = makeValidManifest();
+        manifest.schema_mismatch_mode = value;
+
+        auto worker_context = ExportPartitionUtils::getContextCopyWithTaskSettings(getContext().context, manifest);
+
+        EXPECT_EQ(
+            worker_context->getSettingsRef()[Setting::export_merge_tree_part_schema_mismatch_mode].value,
+            value) << "value=" << magic_enum::enum_name(value);
+    }
 }
 
 }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -229,6 +229,7 @@ namespace Setting
     extern const SettingsBool export_merge_tree_part_throw_on_pending_mutations;
     extern const SettingsBool export_merge_tree_part_throw_on_pending_patch_parts;
     extern const SettingsBool export_merge_tree_part_allow_lossy_cast;
+    extern const SettingsMergeTreePartExportSchemaMismatchMode export_merge_tree_part_schema_mismatch_mode;
     extern const SettingsExportPartitionAllOnError export_merge_tree_partition_all_on_error;
     extern const SettingsString export_merge_tree_part_filename_pattern;
     extern const SettingsBool write_full_path_in_iceberg_metadata;
@@ -8535,6 +8536,7 @@ void StorageReplicatedMergeTree::exportPartitionToTable(const PartitionCommand &
     manifest.filename_pattern = query_context->getSettingsRef()[Setting::export_merge_tree_part_filename_pattern].value;
     manifest.write_full_path_in_iceberg_metadata = query_context->getSettingsRef()[Setting::write_full_path_in_iceberg_metadata];
     manifest.allow_lossy_cast = query_context->getSettingsRef()[Setting::export_merge_tree_part_allow_lossy_cast];
+    manifest.schema_mismatch_mode = query_context->getSettingsRef()[Setting::export_merge_tree_part_schema_mismatch_mode].value;
 
     if (dest_storage->isDataLake())
     {

--- a/tests/integration/test_export_merge_tree_part_to_iceberg/test.py
+++ b/tests/integration/test_export_merge_tree_part_to_iceberg/test.py
@@ -757,6 +757,75 @@ def test_export_part_column_count_mismatch_source_fewer_is_rejected(cluster):
     node.query(f"DROP TABLE IF EXISTS {iceberg}")
 
 
+def test_export_part_source_more_columns_allowed_with_ignore_extra_setting(cluster):
+    """
+    Source has 3 columns (id, year, extra), destination has 2 (id, year).
+    With `export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'`,
+    the export must succeed: the trailing `extra` source column is dropped
+    (matched positionally) and only `id`/`year` land in the destination.
+    """
+    node = cluster.instances["node1"]
+    sfx = unique_suffix()
+    mt = f"mt_ignore_extra_{sfx}"
+    iceberg = f"iceberg_ignore_extra_{sfx}"
+
+    make_mt(node, mt, "id Int32, year Int32, extra String", "year")
+    make_iceberg_s3(node, iceberg, "id Int32, year Int32", "year")
+
+    node.query(f"INSERT INTO {mt} VALUES (1, 2020, 'foo'), (2, 2020, 'bar'), (3, 2020, 'baz')")
+    part_2020 = get_part(node, mt, "2020")
+
+    export_part(
+        node, mt, part_2020, iceberg,
+        extra_settings="export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'",
+    )
+    wait_for_export_part(node, mt, part_2020)
+
+    count = int(node.query(f"SELECT count() FROM {iceberg}").strip())
+    assert count == 3, f"Expected 3 rows in Iceberg table after export, got {count}"
+
+    result = node.query(f"SELECT id, year FROM {iceberg} ORDER BY id").strip()
+    assert result == "1\t2020\n2\t2020\n3\t2020", f"Unexpected data:\n{result}"
+
+    assert_part_log(node, mt, part_2020)
+
+    node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {iceberg}")
+
+
+def test_export_part_column_count_mismatch_source_fewer_still_rejected_with_ignore_extra_setting(cluster):
+    """
+    `ignore_extra_source_columns_by_position` only relaxes the source-has-more-columns
+    direction. Source has 2 columns (id, year), destination has 3 (id, year, extra):
+    the destination cannot be filled from the source, so this must still be
+    rejected synchronously even with the relaxed setting.
+    """
+    node = cluster.instances["node1"]
+    sfx = unique_suffix()
+    mt = f"mt_ignore_extra_fewer_{sfx}"
+    iceberg = f"iceberg_ignore_extra_fewer_{sfx}"
+
+    make_mt(node, mt, "id Int32, year Int32", "year")
+    make_iceberg_s3(node, iceberg, "id Int32, year Int32, extra String", "year")
+
+    node.query(f"INSERT INTO {mt} VALUES (1, 2020), (2, 2020)")
+    part_2020 = get_part(node, mt, "2020")
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt} EXPORT PART '{part_2020}' TO TABLE {iceberg} "
+        f"SETTINGS allow_experimental_export_merge_tree_part = 1, "
+        f"allow_experimental_insert_into_iceberg = 1, "
+        f"export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'"
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH for source<dest column count "
+        f"even with ignore_extra_source_columns_by_position, got: {error!r}"
+    )
+
+    node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {iceberg}")
+
+
 def test_export_part_with_renamed_destination_column(cluster):
     """
     Source has column `id`, destination has the same shape but the column is

--- a/tests/integration/test_export_merge_tree_part_to_iceberg/test.py
+++ b/tests/integration/test_export_merge_tree_part_to_iceberg/test.py
@@ -769,17 +769,17 @@ def test_export_part_source_more_columns_allowed_with_ignore_extra_setting(clust
     mt = f"mt_ignore_extra_{sfx}"
     iceberg = f"iceberg_ignore_extra_{sfx}"
 
-    make_mt(node, mt, "id Int32, year Int32, extra String", "year")
-    make_iceberg_s3(node, iceberg, "id Int32, year Int32", "year")
+    make_mt(node=node, name=mt, columns="id Int32, year Int32, extra String", partition_by="year")
+    make_iceberg_s3(node=node, name=iceberg, columns="id Int32, year Int32", partition_by="year")
 
     node.query(f"INSERT INTO {mt} VALUES (1, 2020, 'foo'), (2, 2020, 'bar'), (3, 2020, 'baz')")
-    part_2020 = get_part(node, mt, "2020")
+    part_2020 = get_part(node=node, table=mt, partition_id="2020")
 
     export_part(
-        node, mt, part_2020, iceberg,
+        node=node, table=mt, part=part_2020, dest=iceberg,
         extra_settings="export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'",
     )
-    wait_for_export_part(node, mt, part_2020)
+    wait_for_export_part(node=node, table=mt, part=part_2020)
 
     count = int(node.query(f"SELECT count() FROM {iceberg}").strip())
     assert count == 3, f"Expected 3 rows in Iceberg table after export, got {count}"
@@ -787,7 +787,7 @@ def test_export_part_source_more_columns_allowed_with_ignore_extra_setting(clust
     result = node.query(f"SELECT id, year FROM {iceberg} ORDER BY id").strip()
     assert result == "1\t2020\n2\t2020\n3\t2020", f"Unexpected data:\n{result}"
 
-    assert_part_log(node, mt, part_2020)
+    assert_part_log(node=node, table=mt, part=part_2020)
 
     node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
     node.query(f"DROP TABLE IF EXISTS {iceberg}")
@@ -805,11 +805,11 @@ def test_export_part_column_count_mismatch_source_fewer_still_rejected_with_igno
     mt = f"mt_ignore_extra_fewer_{sfx}"
     iceberg = f"iceberg_ignore_extra_fewer_{sfx}"
 
-    make_mt(node, mt, "id Int32, year Int32", "year")
-    make_iceberg_s3(node, iceberg, "id Int32, year Int32, extra String", "year")
+    make_mt(node=node, name=mt, columns="id Int32, year Int32", partition_by="year")
+    make_iceberg_s3(node=node, name=iceberg, columns="id Int32, year Int32, extra String", partition_by="year")
 
     node.query(f"INSERT INTO {mt} VALUES (1, 2020), (2, 2020)")
-    part_2020 = get_part(node, mt, "2020")
+    part_2020 = get_part(node=node, table=mt, partition_id="2020")
 
     error = node.query_and_get_error(
         f"ALTER TABLE {mt} EXPORT PART '{part_2020}' TO TABLE {iceberg} "
@@ -821,6 +821,112 @@ def test_export_part_column_count_mismatch_source_fewer_still_rejected_with_igno
         f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH for source<dest column count "
         f"even with ignore_extra_source_columns_by_position, got: {error!r}"
     )
+
+    node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {iceberg}")
+
+
+def test_export_part_with_materialized_column(cluster):
+    node = cluster.instances["node1"]
+    sfx = unique_suffix()
+    mt = f"mt_materialized_{sfx}"
+    iceberg = f"iceberg_materialized_{sfx}"
+
+    make_mt(node=node, name=mt, columns="id Int32, year Int32, doubled Int32 MATERIALIZED id * 2", partition_by="year")
+    make_iceberg_s3(node=node, name=iceberg, columns="id Int32, year Int32, doubled Int32", partition_by="year")
+
+    node.query(f"INSERT INTO {mt} (id, year) VALUES (1, 2020), (2, 2020)")
+    part_2020 = get_part(node=node, table=mt, partition_id="2020")
+
+    export_part(node=node, table=mt, part=part_2020, dest=iceberg)
+    wait_for_export_part(node=node, table=mt, part=part_2020)
+
+    result = node.query(f"SELECT id, year, doubled FROM {iceberg} ORDER BY id").strip()
+    assert result == "1\t2020\t2\n2\t2020\t4", f"Unexpected data:\n{result}"
+
+    assert_part_log(node=node, table=mt, part=part_2020)
+
+    node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {iceberg}")
+
+
+def test_export_part_with_alias_column(cluster):
+    node = cluster.instances["node1"]
+    sfx = unique_suffix()
+    mt = f"mt_alias_{sfx}"
+    iceberg = f"iceberg_alias_{sfx}"
+
+    make_mt(node=node, name=mt, columns="id Int32, year Int32, id_alias Int32 ALIAS id", partition_by="year")
+    make_iceberg_s3(node=node, name=iceberg, columns="id Int32, year Int32, id_alias Int32", partition_by="year")
+
+    node.query(f"INSERT INTO {mt} (id, year) VALUES (1, 2020), (2, 2020)")
+    part_2020 = get_part(node=node, table=mt, partition_id="2020")
+
+    export_part(node=node, table=mt, part=part_2020, dest=iceberg)
+    wait_for_export_part(node=node, table=mt, part=part_2020)
+
+    result = node.query(f"SELECT id, year, id_alias FROM {iceberg} ORDER BY id").strip()
+    assert result == "1\t2020\t1\n2\t2020\t2", f"Unexpected data:\n{result}"
+
+    assert_part_log(node=node, table=mt, part=part_2020)
+
+    node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {iceberg}")
+
+
+def test_export_part_ignore_extra_setting_drops_trailing_alias_column(cluster):
+    node = cluster.instances["node1"]
+    sfx = unique_suffix()
+    mt = f"mt_ignore_extra_alias_{sfx}"
+    iceberg = f"iceberg_ignore_extra_alias_{sfx}"
+
+    make_mt(node=node, name=mt, columns="id Int32, year Int32, extra_alias String ALIAS toString(id)", partition_by="year")
+    make_iceberg_s3(node=node, name=iceberg, columns="id Int32, year Int32", partition_by="year")
+
+    node.query(f"INSERT INTO {mt} (id, year) VALUES (1, 2020), (2, 2020)")
+    part_2020 = get_part(node=node, table=mt, partition_id="2020")
+
+    export_part(
+        node=node, table=mt, part=part_2020, dest=iceberg,
+        extra_settings="export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'",
+    )
+    wait_for_export_part(node=node, table=mt, part=part_2020)
+
+    result = node.query(f"SELECT id, year FROM {iceberg} ORDER BY id").strip()
+    assert result == "1\t2020\n2\t2020", f"Unexpected data:\n{result}"
+
+    assert_part_log(node=node, table=mt, part=part_2020)
+
+    node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {iceberg}")
+
+
+def test_export_part_ignore_extra_setting_kept_alias_depends_on_dropped_column(cluster):
+    node = cluster.instances["node1"]
+    sfx = unique_suffix()
+    mt = f"mt_ignore_extra_dep_{sfx}"
+    iceberg = f"iceberg_ignore_extra_dep_{sfx}"
+
+    make_mt(
+        node=node, name=mt,
+        columns="id Int32, year Int32, computed_alias Int32 ALIAS extra * 2, extra Int32",
+        partition_by="year",
+    )
+    make_iceberg_s3(node=node, name=iceberg, columns="id Int32, year Int32, computed_alias Int32", partition_by="year")
+
+    node.query(f"INSERT INTO {mt} (id, year, extra) VALUES (1, 2020, 5), (2, 2020, 7)")
+    part_2020 = get_part(node=node, table=mt, partition_id="2020")
+
+    export_part(
+        node=node, table=mt, part=part_2020, dest=iceberg,
+        extra_settings="export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'",
+    )
+    wait_for_export_part(node=node, table=mt, part=part_2020)
+
+    result = node.query(f"SELECT id, year, computed_alias FROM {iceberg} ORDER BY id").strip()
+    assert result == "1\t2020\t10\n2\t2020\t14", f"Unexpected data:\n{result}"
+
+    assert_part_log(node=node, table=mt, part=part_2020)
 
     node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
     node.query(f"DROP TABLE IF EXISTS {iceberg}")

--- a/tests/integration/test_export_merge_tree_part_to_iceberg/test.py
+++ b/tests/integration/test_export_merge_tree_part_to_iceberg/test.py
@@ -826,6 +826,82 @@ def test_export_part_column_count_mismatch_source_fewer_still_rejected_with_igno
     node.query(f"DROP TABLE IF EXISTS {iceberg}")
 
 
+def test_export_part_ignore_extra_column_breaks_hybrid_over_source_and_destination(cluster):
+    node = cluster.instances["node1"]
+    sfx = unique_suffix()
+    mt = f"mt_hybrid_extra_{sfx}"
+    iceberg = f"iceberg_hybrid_extra_{sfx}"
+    hybrid = f"hybrid_extra_{sfx}"
+    hybrid_settings = {"allow_experimental_hybrid_table": 1}
+
+    make_mt(node=node, name=mt, columns="id Int32, year Int32", partition_by="(id, year)")
+    make_iceberg_s3(node=node, name=iceberg, columns="id Int32, year Int32", partition_by="(id, year)")
+
+    node.query(f"INSERT INTO {mt} VALUES (1, 2020)")
+
+    node.query(
+        f"""
+        CREATE TABLE {hybrid}
+        ENGINE = Hybrid(
+            remote('node1:9000', currentDatabase(), {mt}), 1,
+            {iceberg}, 0
+        )
+        AS {mt}
+        """,
+        settings=hybrid_settings,
+    )
+    assert node.query(f"SELECT count() FROM {hybrid}", settings=hybrid_settings).strip() == "1"
+
+    node.query(f"ALTER TABLE {mt} ADD COLUMN extra String DEFAULT ''")
+    node.query(f"INSERT INTO {mt} VALUES (2, 2021, 'foo')")
+
+    part = node.query(
+        f"SELECT name FROM system.parts WHERE database = currentDatabase() "
+        f"AND table = '{mt}' AND active ORDER BY name DESC LIMIT 1"
+    ).strip()
+
+    strict_error = node.query_and_get_error(
+        f"ALTER TABLE {mt} EXPORT PART '{part}' TO TABLE {iceberg} "
+        f"SETTINGS allow_experimental_export_merge_tree_part = 1, "
+        f"allow_experimental_insert_into_iceberg = 1"
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in strict_error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH for the strict-mode export "
+        f"after {mt} grew an extra column, got: {strict_error!r}"
+    )
+
+    export_part(
+        node=node, table=mt, part=part, dest=iceberg,
+        extra_settings="export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'",
+    )
+    wait_for_export_part(node=node, table=mt, part=part)
+
+    assert node.query(f"SELECT count() FROM {iceberg}").strip() == "1"
+    assert node.query(f"SELECT id, year FROM {iceberg}").strip() == "2\t2021"
+
+    node.query(f"ALTER TABLE {hybrid} ADD COLUMN extra String DEFAULT ''", settings=hybrid_settings)
+
+    node.query(f"DETACH TABLE {hybrid} SYNC")
+    reattach_error = node.query_and_get_error(f"ATTACH TABLE {hybrid}", settings=hybrid_settings)
+    assert "extra" in reattach_error and "missing column" in reattach_error, (
+        f"Expected reattach of {hybrid} to fail because its own schema now declares "
+        f"'extra' (added above) while the {iceberg} segment is still missing it, "
+        f"got: {reattach_error!r}"
+    )
+
+    # Realign the segment schemas so ATTACH succeeds and `hybrid` can be dropped cleanly below.
+    node.query(
+        f"ALTER TABLE {iceberg} ADD COLUMN extra Nullable(String)",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+    node.query(f"ATTACH TABLE {hybrid}", settings=hybrid_settings)
+    assert node.query(f"SELECT count() FROM {hybrid}", settings=hybrid_settings).strip() == "2"
+
+    node.query(f"DROP TABLE IF EXISTS {hybrid} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {mt} SYNC")
+    node.query(f"DROP TABLE IF EXISTS {iceberg}")
+
+
 def test_export_part_with_materialized_column(cluster):
     node = cluster.instances["node1"]
     sfx = unique_suffix()

--- a/tests/integration/test_export_merge_tree_part_to_object_storage/test.py
+++ b/tests/integration/test_export_merge_tree_part_to_object_storage/test.py
@@ -40,6 +40,24 @@ def create_s3_table(node, s3_table):
     node.query(f"CREATE TABLE {s3_table} (id UInt64, year UInt16) ENGINE = S3(s3_conn, filename='{s3_table}', format=Parquet, partition_strategy='hive') PARTITION BY year")
 
 
+def wait_for_export_part(node, table, part, timeout=60, poll_interval=0.5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        node.query("SYSTEM FLUSH LOGS")
+        count = node.query(
+            f"SELECT count() FROM system.part_log "
+            f"WHERE event_type = 'ExportPart' "
+            f"AND table = '{table}' "
+            f"AND part_name = '{part}'"
+        ).strip()
+        if count != "0":
+            return
+        time.sleep(poll_interval)
+    raise TimeoutError(
+        f"ExportPart event for part {part!r} in table {table!r} did not appear within {timeout}s"
+    )
+
+
 def create_tables_and_insert_data(node, mt_table, s3_table):
     # enable_block_number_column and enable_block_offset_column are needed for patch parts support
     node.query(f"CREATE TABLE {mt_table} (id UInt64, year UInt16) ENGINE = MergeTree() PARTITION BY year ORDER BY tuple() SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1")
@@ -946,3 +964,101 @@ def test_export_part_subcolumn_partition_key_owner_reordered_rejected_even_with_
         f"of `t`/`decoy` swapping positions around the partition key column `t.a`; "
         f"got: {error!r}"
     )
+
+
+def test_export_part_column_count_mismatch_source_more_is_rejected(cluster):
+    node = cluster.instances["node1"]
+
+    postfix = str(uuid.uuid4()).replace("-", "_")
+    mt_table = f"count_more_mt_table_{postfix}"
+    s3_table = f"count_more_s3_table_{postfix}"
+
+    node.query(
+        f"CREATE TABLE {mt_table} (id UInt64, year UInt16, extra String) "
+        f"ENGINE = MergeTree() PARTITION BY year ORDER BY tuple() "
+        f"SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1"
+    )
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020, 'foo'), (2, 2020, 'bar')")
+
+    create_s3_table(node=node, s3_table=s3_table)
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PART '2020_1_1_0' TO TABLE {s3_table}"
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH for source>dest column count, got: {error}"
+    )
+
+    count = int(node.query(f"SELECT count() FROM {s3_table}").strip())
+    assert count == 0, f"Expected 0 rows in destination table after rejected export, got {count}"
+
+    node.query(f"DROP TABLE {mt_table}")
+    node.query(f"DROP TABLE {s3_table}")
+
+
+def test_export_part_column_count_mismatch_source_fewer_is_rejected(cluster):
+    node = cluster.instances["node1"]
+
+    postfix = str(uuid.uuid4()).replace("-", "_")
+    mt_table = f"count_fewer_mt_table_{postfix}"
+    s3_table = f"count_fewer_s3_table_{postfix}"
+
+    node.query(
+        f"CREATE TABLE {mt_table} (id UInt64, year UInt16) "
+        f"ENGINE = MergeTree() PARTITION BY year ORDER BY tuple() "
+        f"SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1"
+    )
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020), (2, 2020)")
+
+    node.query(
+        f"CREATE TABLE {s3_table} (id UInt64, year UInt16, extra String) "
+        f"ENGINE = S3(s3_conn, filename='{s3_table}', format=Parquet, partition_strategy='hive') "
+        f"PARTITION BY year"
+    )
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PART '2020_1_1_0' TO TABLE {s3_table}"
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH for source<dest column count, got: {error}"
+    )
+
+    count = int(node.query(f"SELECT count() FROM {s3_table}").strip())
+    assert count == 0, f"Expected 0 rows in destination table after rejected export, got {count}"
+
+    node.query(f"DROP TABLE {mt_table}")
+    node.query(f"DROP TABLE {s3_table}")
+
+
+def test_export_part_source_more_columns_allowed_with_ignore_extra_setting(cluster):
+    node = cluster.instances["node1"]
+
+    postfix = str(uuid.uuid4()).replace("-", "_")
+    mt_table = f"ignore_extra_mt_table_{postfix}"
+    s3_table = f"ignore_extra_s3_table_{postfix}"
+
+    node.query(
+        f"CREATE TABLE {mt_table} (id UInt64, year UInt16, extra String) "
+        f"ENGINE = MergeTree() PARTITION BY year ORDER BY tuple() "
+        f"SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1"
+    )
+    node.query(
+        f"INSERT INTO {mt_table} VALUES (1, 2020, 'foo'), (2, 2020, 'bar'), (3, 2020, 'baz')"
+    )
+
+    create_s3_table(node=node, s3_table=s3_table)
+
+    node.query(
+        f"ALTER TABLE {mt_table} EXPORT PART '2020_1_1_0' TO TABLE {s3_table} "
+        f"SETTINGS export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'"
+    )
+    wait_for_export_part(node=node, table=mt_table, part="2020_1_1_0")
+
+    count = int(node.query(f"SELECT count() FROM {s3_table}").strip())
+    assert count == 3, f"Expected 3 rows in destination table after export, got {count}"
+
+    result = node.query(f"SELECT id, year FROM {s3_table} ORDER BY id").strip()
+    assert result == "1\t2020\n2\t2020\n3\t2020", f"Unexpected data:\n{result}"
+
+    node.query(f"DROP TABLE {mt_table}")
+    node.query(f"DROP TABLE {s3_table}")

--- a/tests/integration/test_export_replicated_mt_partition_to_iceberg/test.py
+++ b/tests/integration/test_export_replicated_mt_partition_to_iceberg/test.py
@@ -1313,13 +1313,34 @@ def test_export_partition_source_more_columns_allowed_with_ignore_extra_setting(
     mt_table = f"mt_ignore_extra_{uid}"
     iceberg_table = f"iceberg_ignore_extra_{uid}"
 
-    make_rmt(node, mt_table, "id Int64, year Int32, extra String", "year",
-             replica_name="replica1")
+    make_rmt(node=node, name=mt_table, columns="id Int64, year Int32, extra String",
+             partition_by="year", replica_name="replica1")
     node.query(
         f"INSERT INTO {mt_table} VALUES (1, 2020, 'foo'), (2, 2020, 'bar'), (3, 2020, 'baz')"
     )
 
-    make_iceberg_s3(node, iceberg_table, "id Int64, year Int32", partition_by="year")
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id Int64, year Int32", partition_by="year")
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+        },
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH without the setting, got: {error!r}"
+    )
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "export_merge_tree_part_schema_mismatch_mode": "strict",
+        },
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH with schema_mismatch_mode='strict', got: {error!r}"
+    )
 
     node.query(
         f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
@@ -1328,7 +1349,8 @@ def test_export_partition_source_more_columns_allowed_with_ignore_extra_setting(
             "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
         },
     )
-    wait_for_export_status(node, mt_table, iceberg_table, "2020", "COMPLETED")
+    wait_for_export_status(node=node, source_table=mt_table, dest_table=iceberg_table,
+                            partition_id="2020", expected_status="COMPLETED")
 
     count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
     assert count == 3, f"Expected 3 rows in Iceberg table after export, got {count}"
@@ -1350,10 +1372,11 @@ def test_export_partition_column_count_mismatch_source_fewer_still_rejected_with
     mt_table = f"mt_ignore_extra_fewer_{uid}"
     iceberg_table = f"iceberg_ignore_extra_fewer_{uid}"
 
-    make_rmt(node, mt_table, "id Int64, year Int32", "year", replica_name="replica1")
+    make_rmt(node=node, name=mt_table, columns="id Int64, year Int32", partition_by="year",
+             replica_name="replica1")
     node.query(f"INSERT INTO {mt_table} VALUES (1, 2020), (2, 2020)")
 
-    make_iceberg_s3(node, iceberg_table, "id Int64, year Int32, extra String",
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id Int64, year Int32, extra String",
                     partition_by="year")
 
     error = node.query_and_get_error(
@@ -1382,6 +1405,332 @@ def test_export_partition_column_count_mismatch_source_fewer_still_rejected_with
     count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
     assert count == 0, (
         f"Expected 0 rows in Iceberg table after rejected export, got {count}"
+    )
+
+
+def test_export_partition_column_count_mismatch_source_fewer_reports_column_count_error_despite_name_mismatch(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_count_fewer_name_{uid}"
+    iceberg_table = f"iceberg_count_fewer_name_{uid}"
+
+    make_rmt(node=node, name=mt_table, columns="id Int64, year Int32", partition_by="year",
+              replica_name="replica1")
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020), (2, 2020)")
+
+    make_iceberg_s3(node=node, name=iceberg_table, columns="renamed_id Int64, year Int32, extra Int32",
+                    partition_by="year")
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH to take precedence over the 'id'/'renamed_id' "
+        f"name mismatch, got: {error!r}"
+    )
+
+    rows_in_system_view = node.query(
+        f"SELECT count() FROM system.replicated_partition_exports "
+        f"WHERE source_table = '{mt_table}' "
+        f"  AND destination_table = '{iceberg_table}' "
+        f"  AND partition_id = '2020'"
+    ).strip()
+    assert rows_in_system_view == "0", (
+        f"Expected no row in system.replicated_partition_exports after a "
+        f"synchronously-rejected export, got {rows_in_system_view}."
+    )
+
+    count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count == 0, f"Expected 0 rows in Iceberg table after rejected export, got {count}"
+
+
+def test_export_partition_column_count_mismatch_source_fewer_reports_column_count_error_despite_type_mismatch(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_count_fewer_type_{uid}"
+    iceberg_table = f"iceberg_count_fewer_type_{uid}"
+
+    make_rmt(node=node, name=mt_table, columns="id Int64, year Int32", partition_by="year",
+              replica_name="replica1")
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020), (2, 2020)")
+
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id String, year Int32, extra Int32",
+                    partition_by="year")
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH to take precedence over the 'id' "
+        f"type mismatch, got: {error!r}"
+    )
+    assert "INCOMPATIBLE_COLUMNS" not in error, (
+        f"Column-count mismatch must be reported before any per-column cast check, got: {error!r}"
+    )
+
+    rows_in_system_view = node.query(
+        f"SELECT count() FROM system.replicated_partition_exports "
+        f"WHERE source_table = '{mt_table}' "
+        f"  AND destination_table = '{iceberg_table}' "
+        f"  AND partition_id = '2020'"
+    ).strip()
+    assert rows_in_system_view == "0", (
+        f"Expected no row in system.replicated_partition_exports after a "
+        f"synchronously-rejected export, got {rows_in_system_view}."
+    )
+
+    count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count == 0, f"Expected 0 rows in Iceberg table after rejected export, got {count}"
+
+
+def test_export_partition_key_arity_mismatch_is_rejected(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_pkey_arity_{uid}"
+    iceberg_table = f"iceberg_pkey_arity_{uid}"
+
+    make_rmt(node=node, name=mt_table, columns="id Int32, year Int32", partition_by="year",
+              replica_name="replica1")
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020), (2, 2020)")
+
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id Int32, year Int32", partition_by="(year, id)")
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+    assert "BAD_ARGUMENTS" in error, (
+        f"Expected BAD_ARGUMENTS for partition key arity mismatch, got: {error!r}"
+    )
+    assert "partition" in error.lower(), (
+        f"Expected error to mention the partition scheme mismatch, got: {error!r}"
+    )
+
+    count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count == 0, f"Expected 0 rows in Iceberg table after rejected export, got {count}"
+
+
+def test_export_partition_ignore_extra_setting_prefix_contains_different_type_rejected_without_lossy_cast(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_ignore_extra_lossy_reject_{uid}"
+    iceberg_table = f"iceberg_ignore_extra_lossy_reject_{uid}"
+
+    make_rmt(node=node, name=mt_table, columns="id Int64, year Int32, extra String", partition_by="year",
+              replica_name="replica1")
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020, 'foo'), (2, 2020, 'bar')")
+
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id Int32, year Int32", partition_by="year")
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
+        },
+    )
+    assert "INCOMPATIBLE_COLUMNS" in error, (
+        f"Expected INCOMPATIBLE_COLUMNS for the lossy cast on the kept 'id' column, got: {error!r}"
+    )
+    assert "lossy cast" in error, f"Expected 'lossy cast' in error, got: {error!r}"
+
+    count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count == 0, f"Expected 0 rows in Iceberg table after rejected export, got {count}"
+
+
+def test_export_partition_ignore_extra_setting_prefix_contains_different_type_succeeds_with_lossy_cast(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_ignore_extra_lossy_ok_{uid}"
+    iceberg_table = f"iceberg_ignore_extra_lossy_ok_{uid}"
+
+    make_rmt(node=node, name=mt_table, columns="id Int64, year Int32, extra String", partition_by="year",
+              replica_name="replica1")
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020, 'foo'), (2, 2020, 'bar')")
+
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id Int32, year Int32", partition_by="year")
+
+    node.query(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
+            "export_merge_tree_part_allow_lossy_cast": 1,
+        },
+    )
+    wait_for_export_status(node=node, source_table=mt_table, dest_table=iceberg_table,
+                            partition_id="2020", expected_status="COMPLETED")
+
+    result = node.query(
+        f"SELECT id, toTypeName(id), year FROM {iceberg_table} ORDER BY id"
+    ).strip()
+    assert result == "1\tInt32\t2020\n2\tInt32\t2020", f"Unexpected data:\n{result}"
+
+
+def test_export_partition_ignore_extra_setting_prefix_contains_different_name(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_ignore_extra_renamed_{uid}"
+    iceberg_table = f"iceberg_ignore_extra_renamed_{uid}"
+
+    make_rmt(node=node, name=mt_table, columns="id Int64, year Int32, extra String", partition_by="year",
+              replica_name="replica1")
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020, 'foo'), (2, 2020, 'bar'), (3, 2020, 'baz')")
+
+    make_iceberg_s3(node=node, name=iceberg_table, columns="renamed_id Int64, year Int32", partition_by="year")
+
+    node.query(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
+        },
+    )
+    wait_for_export_status(node=node, source_table=mt_table, dest_table=iceberg_table,
+                            partition_id="2020", expected_status="COMPLETED")
+
+    result = node.query(
+        f"SELECT renamed_id, year FROM {iceberg_table} ORDER BY renamed_id"
+    ).strip()
+    assert result == "1\t2020\n2\t2020\n3\t2020", f"Unexpected data:\n{result}"
+
+
+def test_export_partition_ignore_extra_setting_is_noop_when_column_counts_match(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_ignore_extra_noop_{uid}"
+    iceberg_table = f"iceberg_ignore_extra_noop_{uid}"
+
+    make_rmt(node=node, name=mt_table, columns="id Int32, year Int32", partition_by="year",
+              replica_name="replica1")
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020), (2, 2020), (3, 2020)")
+
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id Int32, year Int32", partition_by="year")
+
+    node.query(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
+        },
+    )
+    wait_for_export_status(node=node, source_table=mt_table, dest_table=iceberg_table,
+                            partition_id="2020", expected_status="COMPLETED")
+
+    count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count == 3, f"Expected 3 rows in Iceberg table after export, got {count}"
+
+    result = node.query(f"SELECT id, year FROM {iceberg_table} ORDER BY id").strip()
+    assert result == "1\t2020\n2\t2020\n3\t2020", f"Unexpected data:\n{result}"
+
+
+def test_export_partition_column_count_mismatch_into_table_with_existing_data(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_seed_table = f"mt_existing_data_seed_{uid}"
+    mt_table = f"mt_existing_data_{uid}"
+    iceberg_table = f"iceberg_existing_data_{uid}"
+
+    ignore_extra_settings = {
+        "allow_insert_into_iceberg": 1,
+        "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
+    }
+
+    make_rmt(node=node, name=mt_seed_table, columns="id Int32, year Int32, extra String",
+              partition_by="year", replica_name="replica1")
+    make_rmt(node=node, name=mt_table, columns="id Int32, year Int32, extra String",
+              partition_by="year", replica_name="replica1")
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id Int32, year Int32", partition_by="year")
+
+    node.query(f"INSERT INTO {mt_seed_table} VALUES (100, 2020, 'x'), (101, 2021, 'y')")
+    node.query(
+        f"ALTER TABLE {mt_seed_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings=ignore_extra_settings,
+    )
+    wait_for_export_status(node=node, source_table=mt_seed_table, dest_table=iceberg_table,
+                            partition_id="2020", expected_status="COMPLETED")
+    node.query(
+        f"ALTER TABLE {mt_seed_table} EXPORT PARTITION ID '2021' TO TABLE {iceberg_table}",
+        settings=ignore_extra_settings,
+    )
+    wait_for_export_status(node=node, source_table=mt_seed_table, dest_table=iceberg_table,
+                            partition_id="2021", expected_status="COMPLETED")
+
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020, 'a'), (2, 2020, 'b')")
+    node.query(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings=ignore_extra_settings,
+    )
+    wait_for_export_status(node=node, source_table=mt_table, dest_table=iceberg_table,
+                            partition_id="2020", expected_status="COMPLETED")
+
+    count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count == 4, f"Expected 4 rows (2 pre-existing + 2 exported), got {count}"
+
+    result = node.query(f"SELECT id, year FROM {iceberg_table} ORDER BY id").strip()
+    assert result == "1\t2020\n2\t2020\n100\t2020\n101\t2021", (
+        f"Unexpected data after exporting into a table with pre-existing rows:\n{result}"
+    )
+
+
+def test_export_partition_column_count_mismatch_into_partition_that_already_has_data(cluster):
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_repeat_partition_{uid}"
+    iceberg_table = f"iceberg_repeat_partition_{uid}"
+
+    ignore_extra_settings = {
+        "allow_insert_into_iceberg": 1,
+        "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
+    }
+
+    make_rmt(node=node, name=mt_table, columns="id Int32, year Int32, extra String",
+              partition_by="year", replica_name="replica1")
+    make_iceberg_s3(node=node, name=iceberg_table, columns="id Int32, year Int32", partition_by="year")
+
+    node.query(f"SYSTEM STOP MERGES {mt_table}")
+
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020, 'a'), (2, 2020, 'b')")
+    node.query(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings=ignore_extra_settings,
+    )
+    wait_for_export_status(node=node, source_table=mt_table, dest_table=iceberg_table,
+                            partition_id="2020", expected_status="COMPLETED")
+
+    count_after_first = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count_after_first == 2, (
+        f"Expected 2 rows after first export, got {count_after_first}"
+    )
+
+    node.query(f"INSERT INTO {mt_table} VALUES (3, 2020, 'c'), (4, 2020, 'd')")
+    node.query(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={**ignore_extra_settings, "export_merge_tree_partition_force_export": 1},
+    )
+    wait_for_export_status(node=node, source_table=mt_table, dest_table=iceberg_table,
+                            partition_id="2020", expected_status="COMPLETED")
+
+    count_after_second = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count_after_second == 6, (
+        f"Expected 6 rows (2 original + 2 duplicated by the forced re-export + 2 new) "
+        f"after re-exporting an already-populated partition, got {count_after_second}"
+    )
+
+    result = node.query(f"SELECT id, year FROM {iceberg_table} ORDER BY id").strip()
+    assert result == "1\t2020\n1\t2020\n2\t2020\n2\t2020\n3\t2020\n4\t2020", (
+        f"Unexpected data after two exports of the same partition:\n{result}"
     )
 
 

--- a/tests/integration/test_export_replicated_mt_partition_to_iceberg/test.py
+++ b/tests/integration/test_export_replicated_mt_partition_to_iceberg/test.py
@@ -1300,6 +1300,91 @@ def test_export_partition_column_count_mismatch_source_fewer_is_rejected(cluster
     )
 
 
+def test_export_partition_source_more_columns_allowed_with_ignore_extra_setting(cluster):
+    """
+    Source has 3 columns (id, year, extra), destination has 2 (id, year).
+    With `export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'`,
+    the export must succeed: the trailing `extra` source column is dropped
+    (matched positionally) and only `id`/`year` land in the destination.
+    """
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_ignore_extra_{uid}"
+    iceberg_table = f"iceberg_ignore_extra_{uid}"
+
+    make_rmt(node, mt_table, "id Int64, year Int32, extra String", "year",
+             replica_name="replica1")
+    node.query(
+        f"INSERT INTO {mt_table} VALUES (1, 2020, 'foo'), (2, 2020, 'bar'), (3, 2020, 'baz')"
+    )
+
+    make_iceberg_s3(node, iceberg_table, "id Int64, year Int32", partition_by="year")
+
+    node.query(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
+        },
+    )
+    wait_for_export_status(node, mt_table, iceberg_table, "2020", "COMPLETED")
+
+    count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count == 3, f"Expected 3 rows in Iceberg table after export, got {count}"
+
+    result = node.query(f"SELECT id, year FROM {iceberg_table} ORDER BY id").strip()
+    assert result == "1\t2020\n2\t2020\n3\t2020", f"Unexpected data:\n{result}"
+
+
+def test_export_partition_column_count_mismatch_source_fewer_still_rejected_with_ignore_extra_setting(cluster):
+    """
+    `ignore_extra_source_columns_by_position` only relaxes the source-has-more-columns
+    direction. Source has 2 columns (id, year), destination has 3 (id, year, extra):
+    the destination cannot be filled from the source, so this must still be
+    rejected synchronously even with the relaxed setting.
+    """
+    node = cluster.instances["replica1"]
+
+    uid = unique_suffix()
+    mt_table = f"mt_ignore_extra_fewer_{uid}"
+    iceberg_table = f"iceberg_ignore_extra_fewer_{uid}"
+
+    make_rmt(node, mt_table, "id Int64, year Int32", "year", replica_name="replica1")
+    node.query(f"INSERT INTO {mt_table} VALUES (1, 2020), (2, 2020)")
+
+    make_iceberg_s3(node, iceberg_table, "id Int64, year Int32, extra String",
+                    partition_by="year")
+
+    error = node.query_and_get_error(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {iceberg_table}",
+        settings={
+            "allow_insert_into_iceberg": 1,
+            "export_merge_tree_part_schema_mismatch_mode": "ignore_extra_source_columns_by_position",
+        },
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in error, (
+        f"Expected NUMBER_OF_COLUMNS_DOESNT_MATCH for source<dest column count "
+        f"even with ignore_extra_source_columns_by_position, got: {error!r}"
+    )
+
+    rows_in_system_view = node.query(
+        f"SELECT count() FROM system.replicated_partition_exports "
+        f"WHERE source_table = '{mt_table}' "
+        f"  AND destination_table = '{iceberg_table}' "
+        f"  AND partition_id = '2020'"
+    ).strip()
+    assert rows_in_system_view == "0", (
+        f"Expected no row in system.replicated_partition_exports after a "
+        f"synchronously-rejected export, got {rows_in_system_view}."
+    )
+
+    count = int(node.query(f"SELECT count() FROM {iceberg_table}").strip())
+    assert count == 0, (
+        f"Expected 0 rows in Iceberg table after rejected export, got {count}"
+    )
+
+
 def test_export_partition_with_renamed_destination_column(cluster):
     """
     Source has column `id`, destination has the same shape but the column is

--- a/tests/integration/test_export_replicated_mt_partition_to_object_storage/test.py
+++ b/tests/integration/test_export_replicated_mt_partition_to_object_storage/test.py
@@ -7,6 +7,7 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 from helpers.export_partition_helpers import (
+    make_rmt,
     wait_for_exception_count,
     wait_for_export_status,
     wait_for_export_to_start,
@@ -1941,3 +1942,40 @@ def test_export_partition_multi_column_partition_key_success_all(cluster):
 
     result = node.query(f"SELECT a, b, c, val FROM {s3_table} ORDER BY val").strip()
     assert result == "1\t2\t3\tx\n4\t5\t6\ty", f"Unexpected exported data:\n{result}"
+
+
+def test_export_partition_schema_mismatch_mode_honored_by_non_initiating_replica(cluster):
+    replica1 = cluster.instances["replica1"]
+    replica2 = cluster.instances["replica2"]
+
+    postfix = str(uuid.uuid4()).replace("-", "_")
+    mt_table = f"schema_mode_cross_replica_mt_{postfix}"
+    s3_table = f"schema_mode_cross_replica_s3_{postfix}"
+
+    make_rmt(node=replica1, name=mt_table, columns="id UInt64, year UInt16, extra String",
+             partition_by="year", replica_name="replica1")
+    make_rmt(node=replica2, name=mt_table, columns="id UInt64, year UInt16, extra String",
+             partition_by="year", replica_name="replica2")
+    replica1.query(f"INSERT INTO {mt_table} VALUES (1, 2020, 'foo'), (2, 2020, 'bar'), (3, 2020, 'baz')")
+    replica2.query(f"SYSTEM SYNC REPLICA {mt_table}")
+
+    create_s3_table(node=replica1, s3_table=s3_table)
+    create_s3_table(node=replica2, s3_table=s3_table)
+
+    replica1.query(f"SYSTEM STOP MOVES {mt_table}")
+
+    replica1.query(
+        f"ALTER TABLE {mt_table} EXPORT PARTITION ID '2020' TO TABLE {s3_table}"
+        f" SETTINGS export_merge_tree_part_schema_mismatch_mode = 'ignore_extra_source_columns_by_position'"
+    )
+
+    wait_for_export_status(node=replica1, source_table=mt_table, dest_table=s3_table,
+                            partition_id="2020", expected_status="COMPLETED", timeout=60)
+
+    count = int(replica1.query(f"SELECT count() FROM {s3_table}").strip())
+    assert count == 3, f"Expected 3 rows in destination table after export, got {count}"
+
+    result = replica1.query(f"SELECT id, year FROM {s3_table} ORDER BY id").strip()
+    assert result == "1\t2020\n2\t2020\n3\t2020", f"Unexpected data:\n{result}"
+
+    replica1.query(f"SYSTEM START MOVES {mt_table}")


### PR DESCRIPTION
Closes: https://github.com/Altinity/ClickHouse/issues/1717

Problem. `EXPORT PART/EXPORT PARTITION` matched source and destination columns positionally, exactly like `INSERT INTO dest SELECT * FROM` src, and required the column count to match exactly. This is unnecessarily strict for a common
  real scenario: a MergeTree table's schema grows over time (new trailing columns added), but older partitions still need to be exported to an external table (Iceberg/object storage) whose schema was fixed when it was created. Such exports were rejected outright with `NUMBER_OF_COLUMNS_DOESNT_MATCH`, with no way to just drop the newer columns and export the rest.

  Solution. Added the export_merge_tree_part_schema_mismatch_mode setting (default strict, preserving the old behavior). The new ignore_extra_source_columns_by_position mode allows the source to have more columns than the destination: the extra trailing source columns (by declared/readable position, the same order `INSERT SELECT` uses) are dropped, both at synchronous validation time (verifyExportSchemaCastable, so a real mismatch still fails immediately at `ALTER TABLE ... EXPORT` time) and at actual data-export time (`ExportPartTask::addExportConvertingActions`, via a projection step before the existing positional CAST). The reverse direction — destination has more columns than source — is still always rejected in both modes.

  Known follow-up. Ignored columns are still fully read and decompressed from disk before being discarded in the projection step, so no I/O is saved. Skipping the read up front isn't safe as a naive truncation: a kept
  ALIAS/MATERIALIZED column can legally forward-reference an ignored one, so it would need a real dependency-graph walk instead. Left as a possible future optimization

### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Added the export_merge_tree_part_schema_mismatch_mode setting. With ignore_extra_source_columns_by_position (default: strict), EXPORT PART/EXPORT PARTITION allows a source table with extra trailing columns — they are simply
  ignored instead of failing with NUMBER_OF_COLUMNS_DOESNT_MATCH.


### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
