### PR TITLE
Antalya 25.8 Backport of #95203: S3Queue auxiliary Zookeeper support

### DIFF
--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -110,6 +110,9 @@ Default value: `keep`.
 ### `keeper_path` {#keeper_path}
 
 The path in ZooKeeper can be specified as a table engine setting or default path can be formed from the global configuration-provided path and table UUID.
+Absolute values (starting with `/`) are used as-is, while relative values are appended to `s3queue_default_zookeeper_path`.
+To target an auxiliary ZooKeeper cluster, prefix the value with the configured name, for example `analytics_keeper:/clickhouse/queue/orders`.
+The name must exist in `<auxiliary_zookeepers>`, otherwise the engine reports `Unknown auxiliary ZooKeeper name ...`.
 Possible values:
 
 - String.

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -1,4 +1,5 @@
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h>
+#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
 #include <Common/SipHash.h>
 #include <Common/CurrentThread.h>
 #include <Common/DNSResolver.h>
@@ -30,11 +31,6 @@ namespace ErrorCodes
 
 namespace
 {
-    zkutil::ZooKeeperPtr getZooKeeper()
-    {
-        return Context::getGlobalContextInstance()->getZooKeeper();
-    }
-
     time_t now()
     {
         return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
@@ -126,6 +122,7 @@ ObjectStorageQueueIFileMetadata::NodeMetadata ObjectStorageQueueIFileMetadata::N
 
 ObjectStorageQueueIFileMetadata::ObjectStorageQueueIFileMetadata(
     const std::string & path_,
+    const std::string & zookeeper_name_,
     const std::string & processing_node_path_,
     const std::string & processed_node_path_,
     const std::string & failed_node_path_,
@@ -135,6 +132,7 @@ ObjectStorageQueueIFileMetadata::ObjectStorageQueueIFileMetadata(
     bool use_persistent_processing_nodes_,
     LoggerPtr log_)
     : path(path_)
+    , zookeeper_name(zookeeper_name_)
     , node_name(getNodeName(path_))
     , file_status(file_status_)
     , max_loading_retries(max_loading_retries_)
@@ -168,7 +166,7 @@ ObjectStorageQueueIFileMetadata::~ObjectStorageQueueIFileMetadata()
         LOG_TEST(log, "Removing processing node in destructor for file: {}", path);
         try
         {
-            auto zk_client = getZooKeeper();
+            auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
 
             Coordination::Requests requests;
             requests.push_back(zkutil::makeCheckRequest(processing_node_id_path, processing_id_version.value()));
@@ -350,7 +348,7 @@ void ObjectStorageQueueIFileMetadata::resetProcessing()
     prepareResetProcessingRequests(requests);
 
     Coordination::Responses responses;
-    const auto zk_client = getZooKeeper();
+    const auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
     const auto code = zk_client->tryMulti(requests, responses);
     if (code == Coordination::Error::ZOK)
         return;
@@ -493,7 +491,7 @@ void ObjectStorageQueueIFileMetadata::prepareFailedRequestsImpl(
     /// the number of already done retries in trySetProcessing.
 
     auto retrieable_failed_node_path = failed_node_path + ".retriable";
-    auto zk_client = getZooKeeper();
+    auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
 
     /// Extract the number of already done retries from node_hash.retriable node if it exists.
     Coordination::Stat retriable_failed_node_stat;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.h
@@ -54,6 +54,7 @@ public:
 
     explicit ObjectStorageQueueIFileMetadata(
         const std::string & path_,
+        const std::string & zookeeper_name_,
         const std::string & processing_node_path_,
         const std::string & processed_node_path_,
         const std::string & failed_node_path_,
@@ -143,6 +144,7 @@ protected:
     void prepareFailedRequestsImpl(Coordination::Requests & requests, bool retriable);
 
     const std::string path;
+    const std::string zookeeper_name;
     const std::string node_name;
     const FileStatusPtr file_status;
     const size_t max_loading_retries;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -70,11 +70,6 @@ namespace
         pcg64 rng(randomSeed());
         return min + rng() % (max - min + 1);
     }
-
-    zkutil::ZooKeeperPtr getZooKeeper()
-    {
-        return Context::getGlobalContextInstance()->getZooKeeper();
-    }
 }
 
 class ObjectStorageQueueMetadata::LocalFileStatuses
@@ -129,6 +124,7 @@ private:
 
 ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
     ObjectStorageType storage_type_,
+    const std::string & zookeeper_name_,
     const fs::path & zookeeper_path_,
     const ObjectStorageQueueTableMetadata & table_metadata_,
     size_t cleanup_interval_min_ms_,
@@ -139,6 +135,7 @@ ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
     : table_metadata(table_metadata_)
     , storage_type(storage_type_)
     , mode(table_metadata.getMode())
+    , zookeeper_name(zookeeper_name_)
     , zookeeper_path(zookeeper_path_)
     , keeper_multiread_batch_size(keeper_multiread_batch_size_)
     , cleanup_interval_min_ms(cleanup_interval_min_ms_)
@@ -146,7 +143,10 @@ ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
     , use_persistent_processing_nodes(use_persistent_processing_nodes_)
     , persistent_processing_node_ttl_seconds(persistent_processing_nodes_ttl_seconds_)
     , buckets_num(table_metadata_.getBucketsNum())
-    , log(getLogger("StorageObjectStorageQueue(" + zookeeper_path_.string() + ")"))
+    , log(getLogger(fmt::format(
+        "StorageObjectStorageQueue({}{})",
+        zookeeper_name_ == zkutil::DEFAULT_ZOOKEEPER_NAME ? "" : zookeeper_name_ + ":",
+        zookeeper_path_.string())))
     , local_file_statuses(std::make_shared<LocalFileStatuses>())
 {
     LOG_TRACE(
@@ -158,6 +158,13 @@ ObjectStorageQueueMetadata::ObjectStorageQueueMetadata(
 ObjectStorageQueueMetadata::~ObjectStorageQueueMetadata()
 {
     shutdown();
+}
+
+zkutil::ZooKeeperPtr ObjectStorageQueueMetadata::getZooKeeper(LoggerPtr /* log */, const String & zookeeper_name)
+{
+    // Keep the log parameter to match upstream signature; not used in this build.
+    auto context = Context::getGlobalContextInstance();
+    return context->getDefaultOrAuxiliaryZooKeeper(zookeeper_name);
 }
 
 void ObjectStorageQueueMetadata::startup()
@@ -214,6 +221,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 table_metadata.loading_retries,
                 *metadata_ref_count,
                 use_persistent_processing_nodes,
+                zookeeper_name,
                 log);
         case ObjectStorageQueueMode::UNORDERED:
             return std::make_shared<ObjectStorageQueueUnorderedFileMetadata>(
@@ -223,6 +231,7 @@ ObjectStorageQueueMetadata::FileMetadataPtr ObjectStorageQueueMetadata::getFileM
                 table_metadata.loading_retries,
                 *metadata_ref_count,
                 use_persistent_processing_nodes,
+                zookeeper_name,
                 log);
     }
 }
@@ -240,7 +249,7 @@ ObjectStorageQueueMetadata::Bucket ObjectStorageQueueMetadata::getBucketForPath(
 ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr
 ObjectStorageQueueMetadata::tryAcquireBucket(const Bucket & bucket, const Processor & processor)
 {
-    return ObjectStorageQueueOrderedFileMetadata::tryAcquireBucket(zookeeper_path, bucket, processor, log);
+    return ObjectStorageQueueOrderedFileMetadata::tryAcquireBucket(zookeeper_path, bucket, processor, zookeeper_name, log);
 }
 
 void ObjectStorageQueueMetadata::alterSettings(const SettingsChanges & changes, const ContextPtr & context)
@@ -250,7 +259,7 @@ void ObjectStorageQueueMetadata::alterSettings(const SettingsChanges & changes, 
 
     const fs::path alter_settings_lock_path = zookeeper_path / "alter_settings_lock";
     zkutil::EphemeralNodeHolder::Ptr alter_settings_lock;
-    auto zookeeper = getZooKeeper();
+    auto zookeeper = getZooKeeper(log, zookeeper_name);
 
     if (is_initial_query)
     {
@@ -393,12 +402,17 @@ void ObjectStorageQueueMetadata::migrateToBucketsInKeeper(size_t value)
 {
     chassert(table_metadata.buckets == 0 || table_metadata.buckets == 1);
     chassert(buckets_num == 1, "Buckets: " + toString(buckets_num));
-    ObjectStorageQueueOrderedFileMetadata::migrateToBuckets(zookeeper_path, value, /* prev_value */table_metadata.buckets);
+    ObjectStorageQueueOrderedFileMetadata::migrateToBuckets(
+        zookeeper_path,
+        value,
+        /* prev_value */table_metadata.buckets,
+        zookeeper_name);
     buckets_num = value;
     table_metadata.buckets = value;
 }
 
 ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
+    const String & zookeeper_name,
     const fs::path & zookeeper_path,
     const ObjectStorageQueueSettings & settings,
     const ColumnsDescription & columns,
@@ -429,7 +443,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
     }
 
     const auto table_metadata_path = zookeeper_path / "metadata";
-    auto zookeeper = getZooKeeper();
+    auto zookeeper = getZooKeeper(log, zookeeper_name);
     bool warned = false;
     zookeeper->createAncestors(zookeeper_path);
 
@@ -491,6 +505,7 @@ ObjectStorageQueueTableMetadata ObjectStorageQueueMetadata::syncWithKeeper(
                 table_metadata.loading_retries,
                 noop,
                 /* use_persistent_processing_nodes */false, /// Processing nodes will not be created.
+                zookeeper_name,
                 log).prepareProcessedAtStartRequests(requests, zookeeper);
         }
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -55,6 +55,7 @@ public:
 
     ObjectStorageQueueMetadata(
         ObjectStorageType storage_type_,
+        const std::string & zookeeper_name_,
         const fs::path & zookeeper_path_,
         const ObjectStorageQueueTableMetadata & table_metadata_,
         size_t cleanup_interval_min_ms_,
@@ -79,6 +80,7 @@ public:
     /// what is in keeper (for example, processing_threads_num is adjustable,
     /// because its default depends on the CPU cores on the server);
     static ObjectStorageQueueTableMetadata syncWithKeeper(
+        const String & zookeeper_name,
         const fs::path & zookeeper_path,
         const ObjectStorageQueueSettings & settings,
         const ColumnsDescription & columns,
@@ -147,6 +149,11 @@ public:
     ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr
     tryAcquireBucket(const Bucket & bucket, const Processor & processor);
 
+    const String & getZooKeeperName() const { return zookeeper_name; }
+    zkutil::ZooKeeperPtr getZooKeeper() const { return getZooKeeper(log, zookeeper_name); }
+    // Keep log parameter to match upstream signature; may be unused in this build.
+    static zkutil::ZooKeeperPtr getZooKeeper(LoggerPtr log, const String & zookeeper_name);
+
     /// Set local ref count for metadata.
     void setMetadataRefCount(std::atomic<size_t> & ref_count_) { chassert(!metadata_ref_count); metadata_ref_count = &ref_count_; }
 
@@ -173,6 +180,7 @@ private:
     ObjectStorageQueueTableMetadata table_metadata;
     const ObjectStorageType storage_type;
     const ObjectStorageQueueMode mode;
+    const std::string zookeeper_name;
     const fs::path zookeeper_path;
     const size_t keeper_multiread_batch_size;
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.cpp
@@ -2,6 +2,7 @@
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
+#include <Common/ZooKeeper/ZooKeeper.h>
 
 namespace CurrentMetrics
 {
@@ -12,6 +13,15 @@ namespace CurrentMetrics
 
 namespace DB
 {
+namespace
+{
+std::string makeMetadataKey(const std::string & zookeeper_name, const std::string & zookeeper_path)
+{
+    if (zookeeper_name == zkutil::DEFAULT_ZOOKEEPER_NAME)
+        return zookeeper_path;
+    return zookeeper_name + ":" + zookeeper_path;
+}
+}
 
 namespace ErrorCodes
 {
@@ -135,16 +145,18 @@ ObjectStorageQueueMetadataFactory & ObjectStorageQueueMetadataFactory::instance(
 }
 
 ObjectStorageQueueMetadataFactory::FilesMetadataPtr ObjectStorageQueueMetadataFactory::getOrCreate(
+    const std::string & zookeeper_name,
     const std::string & zookeeper_path,
     ObjectStorageQueueMetadataPtr metadata,
     const StorageID & storage_id,
     bool & created_new_metadata)
 {
     std::lock_guard lock(mutex);
-    auto it = metadata_by_path.find(zookeeper_path);
+    const auto metadata_key = makeMetadataKey(zookeeper_name, zookeeper_path);
+    auto it = metadata_by_path.find(metadata_key);
     if (it == metadata_by_path.end())
     {
-        it = metadata_by_path.emplace(zookeeper_path, std::move(metadata)).first;
+        it = metadata_by_path.emplace(metadata_key, std::move(metadata)).first;
         it->second.metadata->setMetadataRefCount(*it->second.ref_count);
     }
     else
@@ -161,16 +173,18 @@ ObjectStorageQueueMetadataFactory::FilesMetadataPtr ObjectStorageQueueMetadataFa
 }
 
 void ObjectStorageQueueMetadataFactory::remove(
+    const std::string & zookeeper_name,
     const std::string & zookeeper_path,
     const StorageID & storage_id,
     bool is_drop,
     bool keep_data_in_keeper)
 {
     std::lock_guard lock(mutex);
-    auto it = metadata_by_path.find(zookeeper_path);
+    const auto metadata_key = makeMetadataKey(zookeeper_name, zookeeper_path);
+    auto it = metadata_by_path.find(metadata_key);
 
     if (it == metadata_by_path.end())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Metadata with zookeeper path {} does not exist", zookeeper_path);
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Metadata with zookeeper path {} does not exist", metadata_key);
 
     *it->second.ref_count -= 1;
 

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadataFactory.h
@@ -51,6 +51,7 @@ public:
     /// Get a metadata instance if exists, otherwise create a new one.
     /// Registers table in keeper in persistent node.
     FilesMetadataPtr getOrCreate(
+        const std::string & zookeeper_name,
         const std::string & zookeeper_path,
         ObjectStorageQueueMetadataPtr metadata,
         const StorageID & storage_id,
@@ -60,6 +61,7 @@ public:
     /// Metadata will be removed when ref count becomes zero.
     /// Unregisters table in keeper from persistent node.
     void remove(
+        const std::string & zookeeper_name,
         const std::string & zookeeper_path,
         const StorageID & storage_id,
         bool is_drop,

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.cpp
@@ -1,4 +1,5 @@
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h>
+#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
 #include <Common/SipHash.h>
 #include <Common/getRandomASCIIString.h>
 #include <Common/logger_useful.h>
@@ -46,10 +47,6 @@ namespace
         return getProcessedPathWithoutBucket(zk_path);
     }
 
-    zkutil::ZooKeeperPtr getZooKeeper()
-    {
-        return Context::getGlobalContextInstance()->getZooKeeper();
-    }
 }
 
 ObjectStorageQueueOrderedFileMetadata::BucketHolder::BucketHolder(
@@ -58,12 +55,14 @@ ObjectStorageQueueOrderedFileMetadata::BucketHolder::BucketHolder(
     const std::string & bucket_lock_path_,
     const std::string & bucket_lock_id_path_,
     zkutil::ZooKeeperPtr zk_client_,
+    const std::string & zookeeper_name_,
     LoggerPtr log_)
     : bucket_info(std::make_shared<BucketInfo>(BucketInfo{
         .bucket = bucket_,
         .bucket_version = bucket_version_,
         .bucket_lock_path = bucket_lock_path_,
-        .bucket_lock_id_path = bucket_lock_id_path_}))
+        .bucket_lock_id_path = bucket_lock_id_path_,
+        .zookeeper_name = zookeeper_name_}))
     , zk_client(zk_client_)
     , log(log_)
 {
@@ -125,9 +124,11 @@ ObjectStorageQueueOrderedFileMetadata::ObjectStorageQueueOrderedFileMetadata(
     size_t max_loading_retries_,
     std::atomic<size_t> & metadata_ref_count_,
     bool use_persistent_processing_nodes_,
+    const std::string & zookeeper_name_,
     LoggerPtr log_)
     : ObjectStorageQueueIFileMetadata(
         path_,
+        zookeeper_name_,
         /* processing_node_path */zk_path_ / getProcessingNodesPath(use_persistent_processing_nodes_) / getNodeName(path_),
         /* processed_node_path */getProcessedPath(zk_path_, path_, buckets_num_),
         /* failed_node_path */zk_path_ / "failed" / getNodeName(path_),
@@ -194,9 +195,10 @@ ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr ObjectStorageQueueOrdered
     const std::filesystem::path & zk_path,
     const Bucket & bucket,
     const Processor & processor,
+    const std::string & zookeeper_name_,
     LoggerPtr log_)
 {
-    const auto zk_client = getZooKeeper();
+    const auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log_, zookeeper_name_);
     const auto create_if_not_exists_enabled = zk_client->isFeatureEnabled(DB::KeeperFeatureFlag::CREATE_IF_NOT_EXISTS);
 
     const auto bucket_path = zk_path / "buckets" / toString(bucket);
@@ -248,6 +250,7 @@ ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr ObjectStorageQueueOrdered
                 bucket_lock_path,
                 bucket_lock_id_path,
                 zk_client,
+                zookeeper_name_,
                 log_);
         }
 
@@ -274,7 +277,7 @@ ObjectStorageQueueOrderedFileMetadata::BucketHolderPtr ObjectStorageQueueOrdered
 
 std::pair<bool, ObjectStorageQueueIFileMetadata::FileStatus::State> ObjectStorageQueueOrderedFileMetadata::setProcessingImpl()
 {
-    const auto zk_client = getZooKeeper();
+    const auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
     processing_id = node_metadata.processing_id = getRandomASCIIString(10);
     auto processor_info = getProcessorInfo(processing_id.value());
 
@@ -498,14 +501,18 @@ void ObjectStorageQueueOrderedFileMetadata::prepareProcessedRequests(
 
 void ObjectStorageQueueOrderedFileMetadata::prepareProcessedRequestsImpl(Coordination::Requests & requests)
 {
-    const auto zk_client = getZooKeeper();
+    const auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
     prepareProcessedRequests(requests, zk_client, processed_node_path, /* ignore_if_exists */false);
 }
 
-void ObjectStorageQueueOrderedFileMetadata::migrateToBuckets(const std::string & zk_path, size_t value, size_t prev_value)
+void ObjectStorageQueueOrderedFileMetadata::migrateToBuckets(
+    const std::string & zk_path,
+    size_t value,
+    size_t prev_value,
+    const std::string & zookeeper_name_)
 {
-    auto zk_client = getZooKeeper();
     const auto log = getLogger("ObjectStorageQueueOrderedFileMetadata");
+    auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name_);
     const size_t retries = 1000;
     Coordination::Error code = Coordination::Error::ZOK;
 
@@ -564,7 +571,7 @@ void ObjectStorageQueueOrderedFileMetadata::migrateToBuckets(const std::string &
             if (try_num < retries)
             {
                 LOG_TRACE(log, "Keeper session expired while updating buckets in keeper, will retry");
-                zk_client = getZooKeeper();
+                zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name_);
                 continue;
             }
             else
@@ -614,9 +621,10 @@ void ObjectStorageQueueOrderedFileMetadata::filterOutProcessedAndFailed(
     std::vector<std::string> & paths,
     const std::filesystem::path & zk_path_,
     size_t buckets_num,
+    const std::string & zookeeper_name_,
     LoggerPtr log_)
 {
-    const auto zk_client = getZooKeeper();
+    const auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log_, zookeeper_name_);
     const bool use_buckets_for_processing = buckets_num > 1;
 
     buckets_num = std::max<size_t>(buckets_num, 1);

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueOrderedFileMetadata.h
@@ -20,6 +20,7 @@ public:
         int bucket_version;
         std::string bucket_lock_path;
         std::string bucket_lock_id_path;
+        std::string zookeeper_name;
     };
     using BucketInfoPtr = std::shared_ptr<const BucketInfo>;
 
@@ -32,6 +33,7 @@ public:
         size_t max_loading_retries_,
         std::atomic<size_t> & metadata_ref_count_,
         bool use_persistent_processing_nodes_,
+        const std::string & zookeeper_name_,
         LoggerPtr log_);
 
     struct BucketHolder;
@@ -44,19 +46,25 @@ public:
         const std::filesystem::path & zk_path,
         const Bucket & bucket,
         const Processor & processor,
+        const std::string & zookeeper_name_,
         LoggerPtr log_);
 
     static ObjectStorageQueueOrderedFileMetadata::Bucket getBucketForPath(const std::string & path, size_t buckets_num);
 
     static std::vector<std::string> getMetadataPaths(size_t buckets_num);
 
-    static void migrateToBuckets(const std::string & zk_path, size_t value, size_t prev_value);
+    static void migrateToBuckets(
+        const std::string & zk_path,
+        size_t value,
+        size_t prev_value,
+        const std::string & zookeeper_name_);
 
     /// Return vector of indexes of filtered paths.
     static void filterOutProcessedAndFailed(
         std::vector<std::string> & paths,
         const std::filesystem::path & zk_path_,
         size_t buckets_num,
+        const std::string & zookeeper_name_,
         LoggerPtr log);
 
     void prepareProcessedAtStartRequests(
@@ -98,6 +106,7 @@ struct ObjectStorageQueueOrderedFileMetadata::BucketHolder : private boost::nonc
         const std::string & bucket_lock_path_,
         const std::string & bucket_lock_id_path_,
         zkutil::ZooKeeperPtr zk_client_,
+        const std::string & zookeeper_name_,
         LoggerPtr log_);
 
     ~BucketHolder();

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -246,7 +246,7 @@ ObjectStorageQueueSource::FileIterator::next()
                 }
 
                 Coordination::Responses responses;
-                auto zk_client = Context::getGlobalContextInstance()->getZooKeeper();
+                auto zk_client = metadata->getZooKeeper();
                 auto code = zk_client->tryMulti(requests, responses);
                 if (code == Coordination::Error::ZOK)
                 {
@@ -351,10 +351,11 @@ void ObjectStorageQueueSource::FileIterator::filterProcessableFiles(Source::Obje
     if (enable_hash_ring_filtering && mode == ObjectStorageQueueMode::UNORDERED)
         metadata->filterOutForProcessor(paths, storage_id);
 
+    const auto & zookeeper_name = metadata->getZooKeeperName();
     if (mode == ObjectStorageQueueMode::UNORDERED)
-        ObjectStorageQueueUnorderedFileMetadata::filterOutProcessedAndFailed(paths, metadata->getPath(), log);
+        ObjectStorageQueueUnorderedFileMetadata::filterOutProcessedAndFailed(paths, metadata->getPath(), zookeeper_name, log);
     else
-        ObjectStorageQueueOrderedFileMetadata::filterOutProcessedAndFailed(paths, metadata->getPath(), metadata->getBucketsNum(), log);
+        ObjectStorageQueueOrderedFileMetadata::filterOutProcessedAndFailed(paths, metadata->getPath(), metadata->getBucketsNum(), zookeeper_name, log);
 
     std::unordered_set<std::string> paths_set;
     std::ranges::move(paths, std::inserter(paths_set, paths_set.end()));
@@ -1271,7 +1272,7 @@ void ObjectStorageQueueSource::commit(bool insert_succeeded, const std::string &
         object_storage->removeObjectsIfExist(successful_objects);
     }
 
-    auto zk_client = getContext()->getZooKeeper();
+    auto zk_client = files_metadata->getZooKeeper();
     Coordination::Responses responses;
     auto code = zk_client->tryMulti(requests, responses);
     if (code != Coordination::Error::ZOK)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.cpp
@@ -1,4 +1,5 @@
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h>
+#include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
 #include <Common/getRandomASCIIString.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Interpreters/Context.h>
@@ -10,15 +11,6 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-namespace
-{
-    zkutil::ZooKeeperPtr getZooKeeper()
-    {
-        return Context::getGlobalContextInstance()->getZooKeeper();
-    }
-
-}
-
 ObjectStorageQueueUnorderedFileMetadata::ObjectStorageQueueUnorderedFileMetadata(
     const std::filesystem::path & zk_path,
     const std::string & path_,
@@ -26,9 +18,11 @@ ObjectStorageQueueUnorderedFileMetadata::ObjectStorageQueueUnorderedFileMetadata
     size_t max_loading_retries_,
     std::atomic<size_t> & metadata_ref_count_,
     bool use_persistent_processing_nodes_,
+    const std::string & zookeeper_name_,
     LoggerPtr log_)
     : ObjectStorageQueueIFileMetadata(
         path_,
+        zookeeper_name_,
         /* processing_node_path */zk_path / getProcessingNodesPath(use_persistent_processing_nodes_) / getNodeName(path_),
         /* processed_node_path */zk_path / "processed" / getNodeName(path_),
         /* failed_node_path */zk_path / "failed" / getNodeName(path_),
@@ -43,7 +37,7 @@ ObjectStorageQueueUnorderedFileMetadata::ObjectStorageQueueUnorderedFileMetadata
 ObjectStorageQueueUnorderedFileMetadata::SetProcessingResponseIndexes
 ObjectStorageQueueUnorderedFileMetadata::prepareProcessingRequestsImpl(Coordination::Requests & requests)
 {
-    const auto zk_client = getZooKeeper();
+    const auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
 
     processing_id = node_metadata.processing_id = getRandomASCIIString(10);
     const auto processor_info = getProcessorInfo(processing_id.value());
@@ -89,7 +83,7 @@ ObjectStorageQueueUnorderedFileMetadata::prepareProcessingRequestsImpl(Coordinat
 
 std::pair<bool, ObjectStorageQueueIFileMetadata::FileStatus::State> ObjectStorageQueueUnorderedFileMetadata::setProcessingImpl()
 {
-    const auto zk_client = getZooKeeper();
+    const auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
     const size_t max_num_tries = 1000;
     Coordination::Error code;
     for (size_t i = 0; i < max_num_tries; ++i)
@@ -156,7 +150,10 @@ void ObjectStorageQueueUnorderedFileMetadata::prepareProcessedRequestsImpl(Coord
 }
 
 void ObjectStorageQueueUnorderedFileMetadata::filterOutProcessedAndFailed(
-    std::vector<std::string> & paths, const std::filesystem::path & zk_path_, LoggerPtr log_)
+    std::vector<std::string> & paths,
+    const std::filesystem::path & zk_path_,
+    const std::string & zookeeper_name_,
+    LoggerPtr log_)
 {
     std::vector<std::string> check_paths;
     for (const auto & path : paths)
@@ -166,7 +163,7 @@ void ObjectStorageQueueUnorderedFileMetadata::filterOutProcessedAndFailed(
         check_paths.push_back(zk_path_ / "failed" / node_name);
     }
 
-    auto zk_client = getZooKeeper();
+    auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log_, zookeeper_name_);
     auto responses = zk_client->tryGet(check_paths);
 
     auto check_code = [&](auto code, const std::string & path)

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueUnorderedFileMetadata.h
@@ -18,6 +18,7 @@ public:
         size_t max_loading_retries_,
         std::atomic<size_t> & metadata_ref_count_,
         bool use_persistent_processing_nodes_,
+        const std::string & zookeeper_name_,
         LoggerPtr log_);
 
     static std::vector<std::string> getMetadataPaths() { return {"processed", "failed", "processing", "persistent_processing"}; }
@@ -26,6 +27,7 @@ public:
     static void filterOutProcessedAndFailed(
         std::vector<std::string> & paths,
         const std::filesystem::path & zk_path_,
+        const std::string & zookeeper_name_,
         LoggerPtr log_);
 
     void prepareProcessedAtStartRequests(

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -188,7 +188,8 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     , WithContext(context_)
     , type(configuration_->getType())
     , engine_name(engine_args->engine->name)
-    , zk_path(chooseZooKeeperPath(getContext(), table_id_, context_->getSettingsRef(), *queue_settings_))
+    , zookeeper_name()
+    , zk_path()
     , enable_logging_to_queue_log((*queue_settings_)[ObjectStorageQueueSetting::enable_logging_to_queue_log])
     , polling_min_timeout_ms((*queue_settings_)[ObjectStorageQueueSetting::polling_min_timeout_ms])
     , polling_max_timeout_ms((*queue_settings_)[ObjectStorageQueueSetting::polling_max_timeout_ms])
@@ -245,15 +246,30 @@ StorageObjectStorageQueue::StorageObjectStorageQueue(
     setVirtuals(VirtualColumnUtils::getVirtualsForFileLikeStorage(storage_metadata.columns));
     setInMemoryMetadata(storage_metadata);
 
+    zk_path = chooseZooKeeperPath(
+        getContext(),
+        table_id_,
+        context_->getSettingsRef(),
+        *queue_settings_,
+        UUIDHelpers::Nil,
+        &zookeeper_name);
     LOG_INFO(log, "Using zookeeper path: {}", zk_path.string());
 
     auto table_metadata = ObjectStorageQueueMetadata::syncWithKeeper(
-        zk_path, *queue_settings_, storage_metadata.getColumns(), configuration_->getFormat(), context_, is_attach, log);
+        zookeeper_name,
+        zk_path,
+        *queue_settings_,
+        storage_metadata.getColumns(),
+        configuration_->getFormat(),
+        context_,
+        is_attach,
+        log);
 
     ObjectStorageType storage_type = engine_name == "S3Queue" ? ObjectStorageType::S3 : ObjectStorageType::Azure;
 
     temp_metadata = std::make_unique<ObjectStorageQueueMetadata>(
         storage_type,
+        zookeeper_name,
         zk_path,
         std::move(table_metadata),
         (*queue_settings_)[ObjectStorageQueueSetting::cleanup_interval_min_ms],
@@ -282,6 +298,7 @@ void StorageObjectStorageQueue::startup()
     /// Create a persistent node for the table under /registry node.
     bool created_new_metadata = false;
     files_metadata = ObjectStorageQueueMetadataFactory::instance().getOrCreate(
+        zookeeper_name,
         zk_path,
         std::move(temp_metadata),
         getStorageID(),
@@ -296,6 +313,7 @@ void StorageObjectStorageQueue::startup()
             /// if it was just created by us (created_new_metadata == true)
             /// and if /registry is empty (no table was concurrently created).
             ObjectStorageQueueMetadataFactory::instance().remove(
+                zookeeper_name,
                 zk_path,
                 getStorageID(),
                 /* is_drop */created_new_metadata,
@@ -362,7 +380,7 @@ void StorageObjectStorageQueue::shutdown(bool is_drop)
             tryLogCurrentException(log);
         }
 
-        ObjectStorageQueueMetadataFactory::instance().remove(zk_path, getStorageID(), is_drop, keep_data_in_keeper);
+        ObjectStorageQueueMetadataFactory::instance().remove(zookeeper_name, zk_path, getStorageID(), is_drop, keep_data_in_keeper);
 
         files_metadata.reset();
     }
@@ -1227,7 +1245,7 @@ void StorageObjectStorageQueue::alter(
 
 zkutil::ZooKeeperPtr StorageObjectStorageQueue::getZooKeeper() const
 {
-    return getContext()->getZooKeeper();
+    return getContext()->getDefaultOrAuxiliaryZooKeeper(zookeeper_name);
 }
 
 const ObjectStorageQueueTableMetadata & StorageObjectStorageQueue::getTableMetadata() const
@@ -1280,7 +1298,10 @@ ObjectStorageQueueSettings StorageObjectStorageQueue::getSettings() const
     const auto & table_metadata = getTableMetadata();
     settings[ObjectStorageQueueSetting::mode] = table_metadata.mode;
     settings[ObjectStorageQueueSetting::after_processing] = table_metadata.after_processing;
-    settings[ObjectStorageQueueSetting::keeper_path] = zk_path;
+    if (zookeeper_name == zkutil::DEFAULT_ZOOKEEPER_NAME)
+        settings[ObjectStorageQueueSetting::keeper_path] = zk_path.string();
+    else
+        settings[ObjectStorageQueueSetting::keeper_path] = zookeeper_name + ":" + zk_path.string();
     settings[ObjectStorageQueueSetting::loading_retries] = table_metadata.loading_retries;
     settings[ObjectStorageQueueSetting::processing_threads_num] = table_metadata.processing_threads_num;
     settings[ObjectStorageQueueSetting::parallel_inserts] = table_metadata.parallel_inserts;
@@ -1331,7 +1352,8 @@ String StorageObjectStorageQueue::chooseZooKeeperPath(
     const StorageID & table_id,
     const Settings & settings,
     const ObjectStorageQueueSettings & queue_settings,
-    UUID database_uuid)
+    UUID database_uuid,
+    String * result_zookeeper_name)
 {
     /// keeper_path setting can be set explicitly by the user in the CREATE query, or filled in registerQueueStorage.cpp.
     /// We also use keeper_path to determine whether we move it between databases, since the default path contains UUID of the database.
@@ -1343,12 +1365,34 @@ String StorageObjectStorageQueue::chooseZooKeeperPath(
     std::string result_zk_path;
     if (queue_settings[ObjectStorageQueueSetting::keeper_path].changed)
     {
-        /// We do not add table uuid here on purpose.
-        result_zk_path = fs::path(zk_path_prefix) / queue_settings[ObjectStorageQueueSetting::keeper_path].value;
+        String configured_path = queue_settings[ObjectStorageQueueSetting::keeper_path].value;
 
-        Macros::MacroExpansionInfo info;
-        info.table_id.uuid = table_id.uuid;
-        result_zk_path = context_->getMacros()->expand(result_zk_path, info);
+        const auto first_slash = configured_path.find('/');
+        const auto first_colon = configured_path.find(':');
+        const bool has_keeper_prefix = first_colon != String::npos && (first_slash == String::npos || first_colon < first_slash);
+
+        String keeper_name;
+        String keeper_path = configured_path;
+        if (has_keeper_prefix)
+        {
+            keeper_name = configured_path.substr(0, first_colon);
+            keeper_path = configured_path.substr(first_colon + 1);
+            if (keeper_name.empty())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "ZooKeeper path should start with '/' or '<auxiliary_zookeeper_name>:/'");
+        }
+
+        const bool starts_with_slash = !keeper_path.empty() && keeper_path.front() == '/';
+
+        if (starts_with_slash)
+            result_zk_path = configured_path;
+        else
+        {
+            const auto prefixed_path = (fs::path(zk_path_prefix) / keeper_path).string();
+            if (has_keeper_prefix)
+                result_zk_path = keeper_name + ":" + prefixed_path;
+            else
+                result_zk_path = prefixed_path;
+        }
     }
     else
     {
@@ -1357,6 +1401,16 @@ String StorageObjectStorageQueue::chooseZooKeeperPath(
 
         result_zk_path = fs::path(zk_path_prefix) / toString(database_uuid) / toString(table_id.uuid);
     }
+
+    if (context_ && result_zk_path.find('{') != String::npos)
+    {
+        Macros::MacroExpansionInfo info;
+        info.table_id = table_id;
+        result_zk_path = context_->getMacros()->expand(result_zk_path, info);
+    }
+
+    if (result_zookeeper_name)
+        *result_zookeeper_name = zkutil::extractZooKeeperName(result_zk_path);
     return zkutil::extractZooKeeperPath(result_zk_path, true);
 }
 

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -77,7 +77,8 @@ public:
         const StorageID & table_id,
         const Settings & settings,
         const ObjectStorageQueueSettings & queue_settings,
-        UUID database_uuid = UUIDHelpers::Nil);
+        UUID database_uuid = UUIDHelpers::Nil,
+        String * result_zookeeper_name = nullptr);
 
     static constexpr auto engine_names = {"S3Queue", "AzureQueue"};
 
@@ -92,7 +93,8 @@ private:
 
     ObjectStorageType type;
     const std::string engine_name;
-    const fs::path zk_path;
+    std::string zookeeper_name;
+    fs::path zk_path;
     const bool enable_logging_to_queue_log;
     mutable std::mutex mutex;
     UInt64 polling_min_timeout_ms TSA_GUARDED_BY(mutex);

--- a/tests/integration/test_storage_s3_queue/configs/zookeeper.xml
+++ b/tests/integration/test_storage_s3_queue/configs/zookeeper.xml
@@ -13,4 +13,20 @@
             <port>2181</port>
         </node>
     </zookeeper>
+    <auxiliary_zookeepers>
+        <zookeeper2>
+            <node index="1">
+                <host>zoo1</host>
+                <port>2181</port>
+            </node>
+            <node index="2">
+                <host>zoo2</host>
+                <port>2181</port>
+            </node>
+            <node index="3">
+                <host>zoo3</host>
+                <port>2181</port>
+            </node>
+        </zookeeper2>
+    </auxiliary_zookeepers>
 </clickhouse>

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -25,6 +25,7 @@ from helpers.s3_queue_common import (
 )
 
 AVAILABLE_MODES = ["unordered", "ordered"]
+AUXILIARY_ZOOKEEPER_NAME = "zookeeper2"
 
 
 @pytest.fixture(autouse=True)
@@ -334,6 +335,83 @@ def test_direct_select_file(started_cluster, mode):
             list(map(int, l.split()))
             for l in node.query(f"SELECT * FROM {table_name}_4").splitlines()
         ] == []
+
+
+@pytest.mark.parametrize("engine_name", ["S3Queue", "AzureQueue"])
+def test_auxiliary_zookeeper_keeper_path(started_cluster, engine_name):
+    node = started_cluster.instances["instance"]
+    table_name = f"aux_keeper_{engine_name.lower()}_{generate_random_string()}"
+    dst_table_name = f"{table_name}_dst"
+    files_path = f"{table_name}_data"
+    files_num = 3
+    row_num = 2
+    keeper_suffix = f"/clickhouse/test_{table_name}"
+    keeper_path_with_aux = f"{AUXILIARY_ZOOKEEPER_NAME}:{keeper_suffix}"
+
+    storage = "s3" if engine_name == "S3Queue" else "azure"
+    total_values = generate_random_files(
+        started_cluster, files_path, files_num, row_num=row_num, storage=storage
+    )
+
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        "ordered",
+        files_path,
+        additional_settings={"keeper_path": keeper_path_with_aux},
+        engine_name=engine_name,
+    )
+    create_mv(node, table_name, dst_table_name)
+
+    expected_count = files_num * row_num
+    for _ in range(60):
+        if int(node.query(f"SELECT count() FROM {dst_table_name}")) == expected_count:
+            break
+        time.sleep(1)
+    assert int(node.query(f"SELECT count() FROM {dst_table_name}")) == expected_count
+
+    show_create = node.query(f"SHOW CREATE TABLE {table_name}")
+    assert keeper_path_with_aux in show_create
+
+    settings_table = (
+        "system.s3_queue_settings"
+        if engine_name == "S3Queue"
+        else "system.azure_queue_settings"
+    )
+    keeper_setting = node.query(
+        f"SELECT value FROM {settings_table} WHERE table = '{table_name}' AND name = 'keeper_path'"
+    ).strip()
+    assert keeper_setting == keeper_path_with_aux
+
+    assert int(node.query(f"SELECT uniq(_path) FROM {dst_table_name}")) == files_num
+    assert sorted(
+        [
+            list(map(int, l.split()))
+            for l in node.query(
+                f"SELECT column1, column2, column3 FROM {dst_table_name} ORDER BY column1, column2, column3"
+            ).splitlines()
+        ]
+    ) == sorted(total_values, key=lambda x: (x[0], x[1], x[2]))
+
+
+def test_auxiliary_zookeeper_missing_configuration(started_cluster):
+    node = started_cluster.instances["instance"]
+    table_name = f"aux_keeper_missing_{generate_random_string()}"
+    files_path = f"{table_name}_data"
+    keeper_path = f"unknown_keeper:/clickhouse/test_{table_name}"
+
+    error = create_table(
+        started_cluster,
+        node,
+        table_name,
+        "unordered",
+        files_path,
+        additional_settings={"keeper_path": keeper_path},
+        expect_error=True,
+    )
+
+    assert "Unknown auxiliary ZooKeeper name" in error
 
 
 @pytest.mark.parametrize("mode", AVAILABLE_MODES)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Same as https://github.com/Altinity/ClickHouse/pull/1357, but for Antalya 25.8


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
S3Queue auxiliary Zookeeper support using keeper_path setting from s3Queue (https://github.com/ClickHouse/ClickHouse/pull/95203 by @lesandie)
