### PR TITLE
Antalya-26.6 - fix integration test fails being hidden in report

### DIFF
--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -382,9 +382,18 @@ def get_prs_in_release_dataframe(
 
 def _checks_latest_test_status_cte(commit_sha: str, branch_name: str) -> str:
     """
-    Shared filtering for gh-data.checks: anchor time excludes stateless teardown checks
-    (Stateless% + test_name not matching ^[0-9]{5}); keep rows with check_start_time
-    >= anchor so main + teardown phases are included.
+    Shared filtering for gh-data.checks: anchor time selects the latest result batch
+    per check_name.
+
+    Rows that must not set the anchor (but are still kept if their time is >= anchor):
+    - Stateless teardown: check_name LIKE 'Stateless%' AND test_name not matching ^[0-9]{5}
+    - Empty test_name: CIDB job-level parent rows
+    - Pre/Post Hooks: praktika phases with their own stopwatches; Post Hooks always runs
+      after tests and would otherwise become the sole surviving batch, hiding all FAILs
+
+    Keep rows with check_start_time >= anchor so the latest main batch and any later
+    teardown/hook rows are included. Earlier batches (failed attempts before a rerun
+    uploaded a newer uniform timestamp) are dropped.
     """
     return f"""WITH checks_with_anchor AS (
             SELECT
@@ -396,7 +405,12 @@ def _checks_latest_test_status_cte(commit_sha: str, branch_name: str) -> str:
                 check_start_time,
                 maxIf(
                     check_start_time,
-                    NOT (check_name LIKE 'Stateless%' AND NOT match(test_name, '^[0-9]{{5}}'))
+                    test_name != ''
+                    AND test_name NOT IN ('Pre Hooks', 'Post Hooks')
+                    AND NOT (
+                        check_name LIKE 'Stateless%'
+                        AND NOT match(test_name, '^[0-9]{{5}}')
+                    )
                 ) OVER (PARTITION BY check_name) AS latest_check_start_time
             FROM `gh-data`.checks
             WHERE commit_sha = '{commit_sha}' AND head_ref = '{branch_name}'

--- a/.github/actions/create_workflow_report/test_report_queries.py
+++ b/.github/actions/create_workflow_report/test_report_queries.py
@@ -12,6 +12,20 @@ Requires ``testflows`` and ``clickhouse_driver``. Run:
 
 Set ``CHECKS_DATABASE_HOST``, ``CLICKHOUSE_TEST_STAT_LOGIN``,
 ``CLICKHOUSE_TEST_STAT_PASSWORD``.
+
+To capture ``expect`` for a commit:
+
+  python3 -c "
+  import os
+  from clickhouse_driver import Client
+  from create_workflow_report import get_checks_fails
+  c = Client(host=os.environ['CHECKS_DATABASE_HOST'],
+             user=os.environ['CLICKHOUSE_TEST_STAT_LOGIN'],
+             password=os.environ['CLICKHOUSE_TEST_STAT_PASSWORD'],
+             port=9440, secure='y', verify=False, settings={'use_numpy': True})
+  df = get_checks_fails(c, 'COMMIT_SHA', 'HEAD_REF')
+  print(repr(tuple(sorted(df['test_name'].tolist()))))
+  "
 """
 
 import os
@@ -30,7 +44,7 @@ def check_result_matches_expect(df: pd.DataFrame, expect: list[str]) -> None:
     actual = set(df["test_name"].tolist()) if not df.empty else set()
     required = set(expect)
     if actual != required:
-        fail(f"test_name mismatch: got {sorted(actual)}; required {sorted(required)}")
+        fail(f"test results mismatch: got {sorted(actual)}; expected {sorted(required)}")
 
 
 @TestOutline(Scenario)
@@ -83,6 +97,25 @@ def check_result_matches_expect(df: pd.DataFrame, expect: list[str]) -> None:
             "51762a72207f3d4bcee51a0a78912a8b2cbb1bb5",
             "antalya-25.8",
             (),
+        ),
+        # Post Hooks (later stopwatch) used to set the check_start_time anchor and hide
+        # Integration FAILs, e.g. AzureQueue on https://github.com/Altinity/ClickHouse/pull/2107.
+        (
+            "integration_fail_hidden_by_post_hooks_anchor",
+            "6185add695010b15869b3dc1bcb9c417621b36bc",
+            "bump/antalya-26.6/26.6.2.81",
+            (
+                "00071_merge_tree_optimize_aio",
+                "01167_isolation_hermitage",
+                "01509_parallel_quorum_insert_no_replicas_long",
+                "03752_attach_as_replicated_transaction_metadata",
+                "04033_tpc_ds_q20",
+                "04033_tpc_ds_q39",
+                "04033_tpc_ds_q58",
+                "04033_tpc_ds_q71",
+                "Unknown error",
+                "test_storage_s3_queue/test_0.py::test_move_after_processing[another_bucket-AzureQueue]",
+            ),
         ),
     ],
 )


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)

Update the report CTE to properly exclude Pre Hooks and Post Hooks results from anchor calculation.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
