### PR TITLE
Antalya 25.8 - fix config url for report job

### DIFF
--- a/.github/actions/create_workflow_report/action.yml
+++ b/.github/actions/create_workflow_report/action.yml
@@ -16,7 +16,10 @@ runs:
         FINAL: ${{ inputs.final }}
       shell: bash
       run: |
-        pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.0.3 jinja2==3.1.5
+        # Newer runners have these deps preinstalled; only install on Ubuntu 22.
+        if [[ -f /etc/os-release ]] && . /etc/os-release && [[ "$VERSION_ID" == "22.04" ]]; then
+          pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.0.3 jinja2==3.1.5
+        fi
 
         CMD="python3 .github/actions/create_workflow_report/create_workflow_report.py"
         ARGS="--actions-run-url $ACTIONS_RUN_URL --known-fails --cves --pr-number $PR_NUMBER"

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -756,15 +756,15 @@ def get_new_fails_this_pr(
 
 
 def _workflow_config_s3_url(pr_number: int, commit_sha: str, ref_name: str) -> str:
+    # Uploads use a double slash before config_workflow in the S3 key.
     if pr_number == 0:
-        # REF uploads use a double slash before config_workflow in the S3 key.
         return (
             f"https://{S3_BUCKET}.s3.amazonaws.com/REFs/{ref_name}/{commit_sha}/"
             "/config_workflow/workflow_config_masterci.json"
         )
     return (
         f"https://{S3_BUCKET}.s3.amazonaws.com/PRs/{pr_number}/{commit_sha}/"
-        "config_workflow/workflow_config_pr.json"
+        "/config_workflow/workflow_config_pr.json"
     )
 
 

--- a/.github/actions/create_workflow_report/workflow_report_hook.sh
+++ b/.github/actions/create_workflow_report/workflow_report_hook.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This script is for generating preview reports when invoked as a post-hook from a praktika job
-pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.0.3 jinja2==3.1.5
+# Newer runners have these deps preinstalled; only install on Ubuntu 22.
+if [[ -f /etc/os-release ]] && . /etc/os-release && [[ "$VERSION_ID" == "22.04" ]]; then
+  pip install clickhouse-driver==0.2.8 numpy==1.26.4 pandas==2.0.3 jinja2==3.1.5
+fi
 ARGS="--mark-preview --known-fails --cves --actions-run-url $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --pr-number $PR_NUMBER"
 CMD="python3 .github/actions/create_workflow_report/create_workflow_report.py"
 $CMD $ARGS


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Antalya-25.8 has an extra / in the CI config url that was missed in the backport

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
