### PR TITLE
Antalya-26.3 - fix manually triggered flaky backport wf

### DIFF
--- a/.github/workflows/flaky_fix_sync.yml
+++ b/.github/workflows/flaky_fix_sync.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: 'master'
+      branches:
+        description: 'Comma-separated target branches (default: the branch this workflow is run from)'
+        required: false
+        type: string
+        default: ''
       create_pr:
         description: 'Cherry-pick missing commits and open a backport PR'
         required: false
@@ -37,7 +42,12 @@ jobs:
       - id: set_branches
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "branches=[\"${{ github.ref_name }}\"]" >> $GITHUB_OUTPUT
+            BRANCHES="${{ inputs.branches }}"
+            if [ -z "$BRANCHES" ]; then
+              BRANCHES="${{ github.ref_name }}"
+            fi
+            JSON=$(echo "$BRANCHES" | tr ',' '\n' | jq -Rsc 'split("\n") | map(gsub("^\\s+|\\s+$";"") | select(length > 0))')
+            echo "branches=$JSON" >> $GITHUB_OUTPUT
           else
             echo "branches=[\"antalya-26.3\", \"stable-26.3\", \"antalya-26.6\"]" >> $GITHUB_OUTPUT
           fi
@@ -97,7 +107,8 @@ jobs:
 
   backport:
     needs: [check, setup]
-    if: ${{ always() && !cancelled() && (github.event_name == 'schedule' || github.event.inputs.create_pr == true) }}
+    # inputs.create_pr is a real boolean; github.event.inputs.create_pr is the string "true"/"false".
+    if: ${{ always() && !cancelled() && (github.event_name == 'schedule' || inputs.create_pr) }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
