### PR TITLE
Antalya 26.6 Backport of #106281, #111483 - Restrict local object access only for user files path

### DIFF
--- a/src/Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.cpp
@@ -18,6 +18,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int FILE_DOESNT_EXIST;
+    extern const int CANNOT_RMDIR;
 }
 
 namespace
@@ -216,17 +217,17 @@ void MetadataStorageFromPlainObjectStorageTransaction::unlinkFile(const std::str
 
 void MetadataStorageFromPlainObjectStorageTransaction::removeDirectory(const std::string & path)
 {
-    for (auto it = metadata_storage.iterateDirectory(path); it->isValid(); it->next())
-    {
-        metadata_storage.object_storage->removeObjectIfExists(StoredObject(it->path()));
-        objects_to_remove.push_back(StoredObject(it->path()));
-    }
+    if (auto it = metadata_storage.iterateDirectory(path); it->isValid())
+        throw Exception(ErrorCodes::CANNOT_RMDIR, "Directory '{}' is not empty", path);
+
+    /// Plain object storage has no directory marker objects, so nothing else to remove.
 }
 
 void MetadataStorageFromPlainObjectStorageTransaction::removeRecursive(const std::string & path, const ShouldRemoveObjectsPredicate & /*should_remove_objects*/)
 {
     /// TODO: Implement recursive listing.
-    removeDirectory(path);
+    for (auto it = metadata_storage.iterateDirectory(path); it->isValid(); it->next())
+        unlinkFile(it->path(), /*if_exists=*/true, /*should_remove_objects=*/true);
 }
 
 ObjectStorageKey MetadataStorageFromPlainObjectStorageTransaction::generateObjectKeyForPath(const std::string & path)

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.cpp
@@ -217,17 +217,20 @@ void MetadataStorageFromPlainObjectStorageTransaction::unlinkFile(const std::str
 
 void MetadataStorageFromPlainObjectStorageTransaction::removeDirectory(const std::string & path)
 {
-    if (auto it = metadata_storage.iterateDirectory(path); it->isValid())
-        throw Exception(ErrorCodes::CANNOT_RMDIR, "Directory '{}' is not empty", path);
-
-    /// Plain object storage has no directory marker objects, so nothing else to remove.
+    if (metadata_storage.iterateDirectory(path)->isValid())
+        throw Exception(ErrorCodes::CANNOT_RMDIR, "Cannot remove non-empty directory {} on {}", path, object_storage->getName());
 }
 
-void MetadataStorageFromPlainObjectStorageTransaction::removeRecursive(const std::string & path, const ShouldRemoveObjectsPredicate & /*should_remove_objects*/)
+void MetadataStorageFromPlainObjectStorageTransaction::removeRecursive(const std::string & path, const ShouldRemoveObjectsPredicate & should_remove_objects)
 {
-    /// TODO: Implement recursive listing.
     for (auto it = metadata_storage.iterateDirectory(path); it->isValid(); it->next())
-        unlinkFile(it->path(), /*if_exists=*/true, /*should_remove_objects=*/true);
+    {
+        const auto & child = it->path();
+        if (metadata_storage.existsFile(child))
+            unlinkFile(child, /*if_exists=*/true, /*should_remove_objects=*/true);
+        else
+            removeRecursive(child, should_remove_objects);
+    }
 }
 
 ObjectStorageKey MetadataStorageFromPlainObjectStorageTransaction::generateObjectKeyForPath(const std::string & path)

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -38,6 +38,7 @@ namespace ErrorCodes
     extern const int CANNOT_RMDIR;
     extern const int READONLY;
     extern const int FAULT_INJECTED;
+    extern const int PATH_ACCESS_DENIED;
 }
 
 LocalObjectStorage::LocalObjectStorage(LocalObjectStorageSettings settings_)
@@ -53,9 +54,41 @@ LocalObjectStorage::LocalObjectStorage(LocalObjectStorageSettings settings_)
         fs::create_directories(settings.key_prefix);
 }
 
+String resolvePathRelativelyToBase(const String & path, const String & base_path)
+{
+    auto configured_base = fs::path(base_path).lexically_normal();
+
+    auto is_inside = [&](const String & candidate)
+    {
+        return fileOrSymlinkPathStartsWith(candidate, configured_base.string())
+            && pathStartsWith(candidate, configured_base.string());
+    };
+
+    if (is_inside(path))
+        return path;
+
+    auto combined = (configured_base / path).lexically_normal().string();
+    if (is_inside(combined))
+        return combined;
+
+    auto path_canonical = fs::weakly_canonical(fs::path(path).lexically_normal());
+    throw Exception(
+        ErrorCodes::PATH_ACCESS_DENIED,
+        "Path `{}` which was canonicalized to `{}` is outside the table path directory : `{}`",
+        path,
+        path_canonical.string(),
+        configured_base.string());
+}
+
+String LocalObjectStorage::resolvePathRelativelyToKeyPrefix(const String & path) const
+{
+    return resolvePathRelativelyToBase(path, settings.key_prefix);
+}
+
 bool LocalObjectStorage::exists(const StoredObject & object) const
 {
-    return fs::exists(object.remote_path);
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(object.remote_path);
+    return fs::exists(resolved_path);
 }
 
 ReadSettings LocalObjectStorage::patchSettings(const ReadSettings & read_settings) const
@@ -230,8 +263,9 @@ std::unique_ptr<ReadBufferFromFileBase> LocalObjectStorage::readObject( /// NOLI
     bool /* use_external_buffer */,
     bool /* restrict_seek */) const
 {
-    LOG_TEST(log, "Read object: {}", object.remote_path);
-    auto buf = createReadBufferFromFileBase(object.remote_path, patchSettings(read_settings), read_hint);
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(object.remote_path);
+    LOG_TEST(log, "Read object: {}", resolved_path);
+    auto buf = createReadBufferFromFileBase(resolved_path, patchSettings(read_settings), read_hint);
 
     if (read_settings.remote_fs_settings.enable_blob_storage_log)
     {
@@ -240,7 +274,7 @@ std::unique_ptr<ReadBufferFromFileBase> LocalObjectStorage::readObject( /// NOLI
         {
             blob_storage_log->local_path = object.local_path;
             return std::make_unique<ReadBufferFromFileWithLogging>(
-                std::move(buf), object.remote_path, settings.key_prefix, std::move(blob_storage_log));
+                std::move(buf), resolved_path, settings.key_prefix, std::move(blob_storage_log));
         }
     }
 
@@ -259,18 +293,19 @@ std::unique_ptr<WriteBufferFromFileBase> LocalObjectStorage::writeObject( /// NO
     if (mode != WriteMode::Rewrite)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "LocalObjectStorage doesn't support append to files");
 
-    LOG_TEST(log, "Write object: {}", object.remote_path);
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(object.remote_path);
+    LOG_TEST(log, "Write object: {}", resolved_path);
 
     /// Unlike real blob storage, in local fs we cannot create a file with non-existing prefix.
     /// So let's create it.
-    fs::create_directories(fs::path(object.remote_path).parent_path());
+    fs::create_directories(fs::path(resolved_path).parent_path());
 
     auto blob_storage_log = BlobStorageLogWriter::create(settings.disk_name);
     if (blob_storage_log)
         blob_storage_log->local_path = object.local_path;
 
     return std::make_unique<WriteBufferFromFileWithLogging>(
-        object.remote_path,
+        resolved_path,
         buf_size,
         settings.key_prefix,
         std::move(blob_storage_log));
@@ -279,6 +314,7 @@ std::unique_ptr<WriteBufferFromFileBase> LocalObjectStorage::writeObject( /// NO
 void LocalObjectStorage::removeObject(const StoredObject & object) const
 {
     throwIfReadonly();
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(object.remote_path);
 
     /// For local object storage files are actually removed when "metadata" is removed.
     if (!exists(object))
@@ -290,7 +326,7 @@ void LocalObjectStorage::removeObject(const StoredObject & object) const
     Int32 error_code = 0;
     String error_message;
 
-    if (0 != unlink(object.remote_path.data()))
+    if (0 != unlink(resolved_path.data()))
     {
         error_code = errno;
         error_message = errnoToString();
@@ -300,14 +336,14 @@ void LocalObjectStorage::removeObject(const StoredObject & object) const
             blob_storage_log->addEvent(
                 BlobStorageLogElement::EventType::Delete,
                 /* bucket */ settings.key_prefix,
-                /* remote_path */ object.remote_path,
+                /* remote_path */ resolved_path,
                 /* local_path */ object.local_path,
                 /* data_size */ object.bytes_size,
                 elapsed,
                 error_code,
                 error_message);
 
-        ErrnoException::throwFromPath(ErrorCodes::CANNOT_UNLINK, object.remote_path, "Cannot unlink file {}", object.remote_path);
+        ErrnoException::throwFromPath(ErrorCodes::CANNOT_UNLINK, resolved_path, "Cannot unlink file {}", resolved_path);
     }
 
     auto elapsed = watch.elapsedMicroseconds();
@@ -316,15 +352,14 @@ void LocalObjectStorage::removeObject(const StoredObject & object) const
         blob_storage_log->addEvent(
             BlobStorageLogElement::EventType::Delete,
             /* bucket */ settings.key_prefix,
-            /* remote_path */ object.remote_path,
+            /* remote_path */ resolved_path,
             /* local_path */ object.local_path,
             /* data_size */ object.bytes_size,
             elapsed,
             error_code,
             error_message);
 
-    /// Remove empty directories.
-    fs::path dir = fs::path(object.remote_path).parent_path();
+    fs::path dir = fs::path(resolved_path).parent_path();
     fs::path root = fs::weakly_canonical(settings.key_prefix);
     while (dir.has_parent_path() && dir.has_relative_path() && dir != root && pathStartsWith(dir, root))
     {
@@ -352,9 +387,7 @@ void LocalObjectStorage::removeObjects(const StoredObjects & objects) const
 
 void LocalObjectStorage::removeObjectIfExists(const StoredObject & object)
 {
-    throwIfReadonly();
-    if (exists(object))
-        removeObject(object);
+    removeObject(object);
 
     fiu_do_on(FailPoints::local_object_storage_network_error_during_remove, {
         throw Exception(ErrorCodes::FAULT_INJECTED, "Injected error after remove object {}", object.remote_path);
@@ -378,16 +411,50 @@ bool isVanishedEntryError(const std::error_code & error)
 {
     return error == std::errc::no_such_file_or_directory || error == std::errc::not_a_directory;
 }
+
+/// Best-effort metadata stat for a path that has ALREADY been validated against
+/// the key prefix. Uses the non-throwing `error_code` overloads and tolerates the
+/// concurrent-disappearance class (see `isVanishedEntryError`), returning an empty
+/// optional for a vanished entry. Every other error is propagated.
+std::optional<ObjectMetadata> tryStatResolvedPath(const std::string & resolved_path)
+{
+    ObjectMetadata object_metadata;
+
+    std::error_code error;
+    auto time = fs::last_write_time(resolved_path, error);
+    if (error)
+    {
+        if (isVanishedEntryError(error))
+            return {};
+        throw fs::filesystem_error("Got unexpected error while getting last write time", resolved_path, error);
+    }
+
+    object_metadata.size_bytes = fs::file_size(resolved_path, error);
+    if (error)
+    {
+        /// The entry may vanish between the two stat calls (concurrent removal),
+        /// or a parent path component may be concurrently replaced by a file.
+        if (isVanishedEntryError(error))
+            return {};
+        throw fs::filesystem_error("Got unexpected error while getting file size", resolved_path, error);
+    }
+
+    object_metadata.etag = std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count());
+    object_metadata.last_modified = Poco::Timestamp::fromEpochTime(
+        std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
+    return object_metadata;
+}
 }
 
 ObjectMetadata LocalObjectStorage::getObjectMetadata(const std::string & path, bool) const
 {
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(path);
     ObjectMetadata object_metadata;
-    LOG_TEST(log, "Getting metadata for path: {}", path);
+    LOG_TEST(log, "Getting metadata for path: {}", resolved_path);
 
-    auto time = fs::last_write_time(path);
+    auto time = fs::last_write_time(resolved_path);
 
-    object_metadata.size_bytes = fs::file_size(path);
+    object_metadata.size_bytes = fs::file_size(resolved_path);
     object_metadata.etag = std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count());
     object_metadata.last_modified = Poco::Timestamp::fromEpochTime(
         std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
@@ -396,32 +463,9 @@ ObjectMetadata LocalObjectStorage::getObjectMetadata(const std::string & path, b
 
 std::optional<ObjectMetadata> LocalObjectStorage::tryGetObjectMetadata(const std::string & path, bool) const
 {
-    ObjectMetadata object_metadata;
-    LOG_TEST(log, "Getting metadata for path: {}", path);
-
-    std::error_code error;
-    auto time = fs::last_write_time(path, error);
-    if (error)
-    {
-        if (isVanishedEntryError(error))
-            return {};
-        throw fs::filesystem_error("Got unexpected error while getting last write time", path, error);
-    }
-
-    object_metadata.size_bytes = fs::file_size(path, error);
-    if (error)
-    {
-        /// The entry may vanish between the two stat calls (concurrent removal),
-        /// or a parent path component may be concurrently replaced by a file.
-        if (isVanishedEntryError(error))
-            return {};
-        throw fs::filesystem_error("Got unexpected error while getting file size", path, error);
-    }
-
-    object_metadata.etag = std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count());
-    object_metadata.last_modified = Poco::Timestamp::fromEpochTime(
-        std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch()).count());
-    return object_metadata;
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(path);
+    LOG_TEST(log, "Getting metadata for path: {}", resolved_path);
+    return tryStatResolvedPath(resolved_path);
 }
 
 void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t/* max_keys */) const
@@ -438,7 +482,8 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
             "Path contains an embedded NUL byte", path,
             std::make_error_code(std::errc::invalid_argument));
 
-    if (!fs::exists(path) || !fs::is_directory(path))
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(path);
+    if (!fs::exists(resolved_path) || !fs::is_directory(resolved_path))
         return;
 
     /// Listing is a best-effort snapshot driven with the non-throwing
@@ -465,7 +510,7 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
     /// opened, so an invalid path (e.g. a NUL-truncated argument) fails fast on
     /// the per-entry stat instead of recursing.
     std::vector<fs::path> pending_dirs;
-    pending_dirs.emplace_back(path);
+    pending_dirs.emplace_back(resolved_path);
 
     while (!pending_dirs.empty())
     {
@@ -509,7 +554,14 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
             }
             else
             {
-                if (auto metadata = tryGetObjectMetadata(entry_path, /*with_tags=*/ false))
+                /// `entry_path` is produced by descending the already-validated
+                /// `resolved_path` and the walk never follows symlinks, so it is
+                /// guaranteed to be under the key prefix. Stat it directly instead
+                /// of routing through `tryGetObjectMetadata`, whose per-entry
+                /// re-resolution (`fs::relative` / `fs::weakly_canonical`) uses
+                /// throwing filesystem primitives that abort the whole listing
+                /// when a churned entry vanishes mid-resolution.
+                if (auto metadata = tryStatResolvedPath(entry_path))
                     children.emplace_back(std::make_shared<RelativePathWithMetadata>(entry_path, std::move(*metadata)));
             }
 
@@ -527,9 +579,10 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
 
 bool LocalObjectStorage::existsOrHasAnyChild(const std::string & path) const
 {
+    auto resolved_path = resolvePathRelativelyToKeyPrefix(path);
     /// Unlike real object storage, existence of a prefix path can be checked by
     /// just checking existence of this prefix directly, so simple exists is enough here.
-    return exists(StoredObject(path));
+    return exists(StoredObject(resolved_path));
 }
 
 void LocalObjectStorage::copyObject( // NOLINT

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h
@@ -95,10 +95,12 @@ private:
     void removeObjects(const StoredObjects &  objects) const;
 
     void throwIfReadonly() const;
+    String resolvePathRelativelyToKeyPrefix(const String & path) const;
 
     LocalObjectStorageSettings settings;
     LoggerPtr log;
     std::string description;
 };
 
+String resolvePathRelativelyToBase(const String & path, const String & base_path);
 }

--- a/src/Disks/tests/gtest_metadata_plain_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_disk.cpp
@@ -1,0 +1,182 @@
+#include <Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h>
+#include <Disks/DiskObjectStorage/MetadataStorages/Plain/MetadataStorageFromPlainObjectStorage.h>
+#include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
+#include <Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h>
+#include <Disks/DiskObjectStorage/ObjectStorages/StoredObject.h>
+#include <Disks/DiskCommitTransactionOptions.h>
+#include <Disks/WriteMode.h>
+
+#include <Common/Exception.h>
+#include <Common/ObjectStorageKey.h>
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+using namespace DB;
+
+class MetadataPlainDiskTest : public testing::Test
+{
+public:
+    std::shared_ptr<IMetadataStorage> getMetadataStorage(const std::string & key_prefix, size_t object_metadata_cache_size = 0)
+    {
+        if (!active_metadatas.contains(key_prefix))
+            createStorage(key_prefix, object_metadata_cache_size);
+
+        return active_metadatas.at(key_prefix);
+    }
+    std::shared_ptr<IObjectStorage> getObjectStorage(const std::string & key_prefix)
+    {
+        if (!active_object_storages.contains(key_prefix))
+            createStorage(key_prefix, /*object_metadata_cache_size=*/0);
+
+        return active_object_storages.at(key_prefix);
+    }
+    void TearDown() override
+    {
+        for (const auto & [_, metadata] : active_metadatas)
+            metadata->shutdown();
+
+        for (const auto & [_, object_storage] : active_object_storages)
+        {
+            object_storage->shutdown();
+            fs::remove_all(object_storage->getCommonKeyPrefix());
+        }
+    }
+private:
+    void createStorage(const std::string & key_prefix, size_t object_metadata_cache_size)
+    {
+        fs::remove_all("./" + key_prefix);
+        LocalObjectStorageSettings settings("test", "./" + key_prefix, /*read_only_=*/false);
+        auto object_storage = std::make_shared<LocalObjectStorage>(std::move(settings));
+        auto metadata_storage = std::make_shared<MetadataStorageFromPlainObjectStorage>(object_storage, /*storage_path_prefix_=*/"", object_metadata_cache_size);
+        active_metadatas.emplace(key_prefix, metadata_storage);
+        active_object_storages.emplace(key_prefix, object_storage);
+    }
+
+    std::unordered_map<std::string, std::shared_ptr<IMetadataStorage>> active_metadatas;
+    std::unordered_map<std::string, std::shared_ptr<IObjectStorage>> active_object_storages;
+};
+
+static void writeFile(
+    const std::shared_ptr<IMetadataStorage> & metadata,
+    const std::shared_ptr<IObjectStorage> & object_storage,
+    const std::string & path,
+    const std::string & data)
+{
+    auto tx = metadata->createTransaction();
+    StoredObject object(tx->generateObjectKeyForPath(path).serialize());
+    auto buffer = object_storage->writeObject(object, WriteMode::Rewrite);
+    buffer->write(data.data(), data.size());
+    buffer->preFinalize();
+    buffer->finalize();
+    tx->commit(NoCommitOptions{});
+}
+
+static std::vector<std::string> listAllBlobs(const std::shared_ptr<IObjectStorage> & object_storage)
+{
+    std::vector<std::string> result;
+
+    const auto & prefix = object_storage->getCommonKeyPrefix();
+    if (!fs::exists(prefix))
+        return result;
+
+    for (const auto & entry : fs::recursive_directory_iterator(prefix))
+        if (entry.is_regular_file())
+            result.push_back(entry.path().string());
+
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+TEST_F(MetadataPlainDiskTest, RemoveDirectoryNonEmpty)
+{
+    auto metadata = getMetadataStorage("RemoveDirectoryNonEmpty");
+    auto object_storage = getObjectStorage("RemoveDirectoryNonEmpty");
+
+    writeFile(metadata, object_storage, "part_id/file1.txt", "content1");
+    writeFile(metadata, object_storage, "part_id/file2.bin", "content2");
+    writeFile(metadata, object_storage, "part_id/file3.dat", "content3");
+    ASSERT_EQ(listAllBlobs(object_storage).size(), 3u);
+    ASSERT_TRUE(metadata->existsFile("part_id/file1.txt"));
+
+    {
+        auto tx = metadata->createTransaction();
+        EXPECT_ANY_THROW(tx->removeDirectory("part_id"));
+    }
+
+    EXPECT_TRUE(metadata->existsFile("part_id/file1.txt"));
+    EXPECT_TRUE(metadata->existsFile("part_id/file2.bin"));
+    EXPECT_TRUE(metadata->existsFile("part_id/file3.dat"));
+    EXPECT_EQ(listAllBlobs(object_storage).size(), 3u);
+}
+
+TEST_F(MetadataPlainDiskTest, RemoveRecursive)
+{
+    auto metadata = getMetadataStorage("RemoveRecursive");
+    auto object_storage = getObjectStorage("RemoveRecursive");
+
+    writeFile(metadata, object_storage, "uuid-12345/checksums.txt", "abc");
+    writeFile(metadata, object_storage, "uuid-12345/columns.txt", "def");
+    writeFile(metadata, object_storage, "uuid-12345/data.bin", "ghi");
+    ASSERT_EQ(listAllBlobs(object_storage).size(), 3u);
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->removeRecursive("uuid-12345", {});
+        tx->commit(NoCommitOptions{});
+    }
+
+    EXPECT_FALSE(metadata->existsFile("uuid-12345/checksums.txt"));
+    EXPECT_FALSE(metadata->existsFile("uuid-12345/columns.txt"));
+    EXPECT_FALSE(metadata->existsFile("uuid-12345/data.bin"));
+    EXPECT_TRUE(listAllBlobs(object_storage).empty());
+}
+
+TEST_F(MetadataPlainDiskTest, UnlinkFile)
+{
+    auto metadata = getMetadataStorage("UnlinkFile");
+    auto object_storage = getObjectStorage("UnlinkFile");
+
+    writeFile(metadata, object_storage, "some/path/file.txt", "hello");
+    ASSERT_TRUE(metadata->existsFile("some/path/file.txt"));
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->unlinkFile("some/path/file.txt", /*if_exists=*/false, /*should_remove_objects=*/true);
+        tx->commit(NoCommitOptions{});
+    }
+
+    EXPECT_FALSE(metadata->existsFile("some/path/file.txt"));
+    EXPECT_TRUE(listAllBlobs(object_storage).empty());
+}
+
+TEST_F(MetadataPlainDiskTest, RemoveDirectoryNonExistent)
+{
+    auto metadata = getMetadataStorage("RemoveDirectoryNonExistent");
+
+    {
+        auto tx = metadata->createTransaction();
+        EXPECT_NO_THROW(tx->removeDirectory("nonexistent_dir"));
+    }
+}
+
+TEST_F(MetadataPlainDiskTest, RemoveRecursiveInvalidatesObjectMetadataCache)
+{
+    auto metadata = getMetadataStorage("RemoveRecursiveInvalidatesObjectMetadataCache", /*object_metadata_cache_size=*/1024 * 1024);
+    auto object_storage = getObjectStorage("RemoveRecursiveInvalidatesObjectMetadataCache");
+
+    writeFile(metadata, object_storage, "part_id/file.txt", "12345");
+    ASSERT_EQ(metadata->getFileSize("part_id/file.txt"), 5u);
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->removeRecursive("part_id", {});
+        tx->commit(NoCommitOptions{});
+    }
+
+    EXPECT_FALSE(metadata->getFileSizeIfExists("part_id/file.txt").has_value());
+    EXPECT_FALSE(metadata->existsFile("part_id/file.txt"));
+    EXPECT_TRUE(listAllBlobs(object_storage).empty());
+}

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -415,9 +415,10 @@ private:
         if (object_storage->getType() == ObjectStorageType::Local)
         {
             auto user_files_path = local_context->getUserFilesPath();
-            if (!fileOrSymlinkPathStartsWith(this->getPathForRead().path, user_files_path))
+            const auto & table_path = this->getPathForRead().path;
+            if (!fileOrSymlinkPathStartsWith(table_path, user_files_path) || !pathStartsWith(table_path, user_files_path))
                 throw Exception(
-                    ErrorCodes::PATH_ACCESS_DENIED, "File path {} is not inside {}", this->getPathForRead().path, user_files_path);
+                    ErrorCodes::PATH_ACCESS_DENIED, "File path {} is not inside {}", table_path, user_files_path);
         }
     }
 

--- a/src/Storages/ObjectStorage/Local/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Local/Configuration.cpp
@@ -19,6 +19,7 @@ namespace Setting
 namespace ErrorCodes
 {
 extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+extern const int BAD_ARGUMENTS;
 }
 
 void LocalStorageParsedArguments::fromNamedCollection(const NamedCollection & collection, ContextPtr)
@@ -40,6 +41,26 @@ void LocalStorageParsedArguments::fromDisk(DiskPtr disk, ASTs & args, ContextPtr
     if (parsing_result.structure.has_value())
         structure = *parsing_result.structure;
     path_suffix = parsing_result.path_suffix;
+}
+
+ObjectStoragePtr StorageLocalConfiguration::createObjectStorage(
+    ContextPtr context, bool /* is_readonly */, CredentialsConfigurationCallback /*refresh_credentials_callback*/)
+{
+    String path_prefix;
+    if (context->getApplicationType() == Context::ApplicationType::LOCAL)
+    {
+        path_prefix = "/";
+    }
+    else
+    {
+        chassert(context->getApplicationType() == Context::ApplicationType::SERVER);
+        path_prefix = context->getUserFilesPath();
+        if (path_prefix.empty())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "User files path is not properly set, cannot use LocalObjectStorage in this server configuration at all");
+    }
+    return std::make_shared<LocalObjectStorage>(LocalObjectStorageSettings(disk_name, path_prefix, /* read_only */ false));
 }
 
 void LocalStorageParsedArguments::fromAST(ASTs & args, ContextPtr context, bool with_structure)

--- a/src/Storages/ObjectStorage/Local/Configuration.h
+++ b/src/Storages/ObjectStorage/Local/Configuration.h
@@ -75,15 +75,7 @@ public:
     String getDataSourceDescription() const override { return ""; }
     StorageObjectStorageQuerySettings getQuerySettings(const ContextPtr &) const override;
 
-    ObjectStoragePtr createObjectStorage(ContextPtr, bool /* is_readonly */, CredentialsConfigurationCallback /*refresh_credentials_callback*/) override
-    {
-        /// `is_readonly` is set to true by the table-engine layer on ATTACH (server restart, DETACH/ATTACH)
-        /// to suppress side effects in `createObjectStorage`, like creating a container on remote object storage.
-        /// For the local filesystem there is no such initialization side effect to suppress, and
-        /// propagating the flag would permanently disable all subsequent writes via `throwIfReadonly`.
-        /// S3 and HDFS configurations also ignore this parameter for the same reason.
-        return std::make_shared<LocalObjectStorage>(LocalObjectStorageSettings(disk_name, "/", /* read_only */ false));
-    }
+    ObjectStoragePtr createObjectStorage(ContextPtr context, bool is_readonly, CredentialsConfigurationCallback refresh_credentials_callback) override;
 
     void addStructureAndFormatToArgsIfNeeded(ASTs &, const String &, const String &, ContextPtr, bool) override { }
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_local_path_traversal.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_local_path_traversal.py
@@ -1,0 +1,297 @@
+"""
+IcebergLocal path traversal: a manifest entry that uses ../ to escape user_files
+must be blocked with PATH_ACCESS_DENIED, not silently followed.
+"""
+import json
+import os
+import re
+import shutil
+import tempfile
+
+import avro.datafile
+import avro.io
+
+from helpers.iceberg_utils import get_uuid_str
+
+NOCACHE = {
+    "use_iceberg_metadata_files_cache": False,
+    "use_parquet_metadata_cache": False,
+}
+
+
+def _prepare_table_then_corrupt_manifest(
+    instance, table_name, table_path, malicious_path_func, file_format_override=None
+):
+    """Create a valid IcebergLocal table, then rewrite the manifest so that
+    `data_file.file_path` points outside `user_files`."""
+    instance.query(
+        f"CREATE TABLE {table_name} (c0 Int) ENGINE = IcebergLocal('{table_path}/', 'Parquet');",
+        settings={"allow_insert_into_iceberg": 1, **NOCACHE},
+    )
+    instance.query(
+        f"INSERT INTO {table_name} VALUES (42)",
+        settings={"allow_insert_into_iceberg": 1, **NOCACHE},
+    )
+    result = instance.query(f"SELECT c0 FROM {table_name}", settings=NOCACHE)
+    assert result.strip() == "42"
+    instance.query(f"DROP TABLE {table_name}")
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        host_path = os.path.join(temp_dir, table_name)
+        os.makedirs(host_path, exist_ok=True)
+        _download_table_from_container(instance, table_path, host_path)
+
+        _, manifest_paths = _get_manifest_paths_from_chain(host_path, table_path)
+        assert manifest_paths, "No manifest_path in manifest-list"
+
+        for rel_path in manifest_paths:
+            local_manifest = os.path.join(host_path, rel_path)
+            assert os.path.isfile(local_manifest), f"Manifest not found: {local_manifest}"
+
+            _modify_avro_file(local_manifest, ["data_file", "file_path"], malicious_path_func)
+            if file_format_override is not None:
+                _modify_avro_file(
+                    local_manifest,
+                    ["data_file", "file_format"],
+                    lambda _: file_format_override,
+                )
+
+            instance.copy_file_to_container(local_manifest, f"{table_path}/{rel_path}")
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _download_table_from_container(instance, table_path, host_path):
+    for remote_file in instance.get_files_list_in_container(table_path):
+        rel = os.path.relpath(remote_file, table_path)
+        local_path = os.path.join(host_path, rel)
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        if instance.file_exists_in_container(remote_file):
+            instance.copy_file_from_container(remote_file, local_path)
+
+
+def _to_relative_path(path, table_path):
+    """Strip `table_path` prefix from an absolute path, returning a relative path."""
+    if not path or not path.startswith("/"):
+        return path
+    base = table_path.rstrip("/")
+    if path == base or path.startswith(base + "/"):
+        return path[len(base):].lstrip("/")
+    return path
+
+
+def _get_manifest_paths_from_chain(host_path, table_path, content_filter=None):
+    """Follow metadata.json -> manifest-list -> manifest_path(s).
+    Returns (manifest_list_rel, [manifest_rel, ...]).
+
+    In Iceberg v2 each manifest-list entry carries a ``content`` field
+    (0 = data, 1 = deletes).  Pass *content_filter* to keep only entries
+    with that value; ``None`` (default) returns all manifests."""
+    metadata_dir = os.path.join(host_path, "metadata")
+    version_hint_path = os.path.join(metadata_dir, "version-hint.text")
+    if os.path.isfile(version_hint_path):
+        with open(version_hint_path) as f:
+            version = f.read().strip()
+        metadata_file = os.path.join(metadata_dir, f"v{version}.metadata.json")
+    else:
+        meta_files = _find_files(metadata_dir, ".metadata.json")
+        if not meta_files:
+            raise RuntimeError("No metadata.json found")
+
+        def version_key(p):
+            m = re.match(r"v(\d+)", os.path.basename(p), re.IGNORECASE)
+            return int(m.group(1)) if m else 0
+
+        metadata_file = max(meta_files, key=version_key)
+
+    with open(metadata_file) as f:
+        data = json.load(f)
+    snap_id = data.get("current-snapshot-id")
+    if not snap_id:
+        raise RuntimeError("No current-snapshot-id in metadata")
+    snapshot = next((s for s in data.get("snapshots", []) if s.get("snapshot-id") == snap_id), None)
+    if not snapshot:
+        raise RuntimeError(f"Snapshot {snap_id} not found")
+    ml = snapshot.get("manifest-list")
+    if not ml:
+        raise RuntimeError("Snapshot has no manifest-list")
+
+    ml_rel = _to_relative_path(ml, table_path)
+    ml_local = os.path.join(host_path, ml_rel)
+    if not os.path.isfile(ml_local):
+        raise RuntimeError(f"Manifest list file not found: {ml_local}")
+
+    manifest_paths = []
+    with open(ml_local, "rb") as f:
+        reader = avro.datafile.DataFileReader(f, avro.io.DatumReader())
+        for record in reader:
+            if "manifest_path" not in record:
+                continue
+            if content_filter is not None and record.get("content") != content_filter:
+                continue
+            manifest_paths.append(_to_relative_path(record["manifest_path"], table_path))
+        reader.close()
+
+    return ml_rel, manifest_paths
+
+
+def _modify_avro_file(avro_path, field_path, modifier_func):
+    """Read an Avro file, apply `modifier_func` to the field at `field_path`
+    in every record, and write the file back."""
+    with open(avro_path, "rb") as f:
+        reader = avro.datafile.DataFileReader(f, avro.io.DatumReader())
+        schema = reader.datum_reader.writers_schema
+        metadata = dict(reader.meta)
+        records = list(reader)
+        reader.close()
+
+    for record in records:
+        obj = record
+        for key in field_path[:-1]:
+            if obj is None or key not in obj:
+                break
+            obj = obj[key]
+        else:
+            if obj and field_path[-1] in obj:
+                obj[field_path[-1]] = modifier_func(obj[field_path[-1]])
+
+    with open(avro_path, "wb") as f:
+        writer = avro.datafile.DataFileWriter(f, avro.io.DatumWriter(), schema)
+        for key, value in metadata.items():
+            if not key.startswith("avro."):
+                writer.set_meta(key, value)
+        for record in records:
+            writer.append(record)
+        writer.close()
+
+
+def _find_files(directory, suffix):
+    result = []
+    for root, _, files in os.walk(directory):
+        for f in files:
+            if f.endswith(suffix):
+                result.append(os.path.join(root, f))
+    return result
+
+
+def _assert_delete_path_access_denied(error):
+    assert "PATH_ACCESS_DENIED" in error, f"Expected PATH_ACCESS_DENIED, got: {error}"
+
+
+
+def test_local_iceberg_path_traversal(started_cluster_iceberg_no_spark):
+    """Manifest entry with ../../../../../../../etc/passwd as data_file.file_path
+    (format RAWBLOB) must be rejected with PATH_ACCESS_DENIED.
+
+    If the error message instead shows 'No such file or directory'
+    or any other error, the security check is broken: the engine attempted
+    to open and read the file instead of blocking the path early."""
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_local_iceberg_path_traversal" + get_uuid_str()
+    table_path = f"/var/lib/clickhouse/user_files/iceberg_data/default/{table_name}"
+
+    _prepare_table_then_corrupt_manifest(
+        instance,
+        table_name,
+        table_path,
+        lambda _: f"{table_path}/../../../../../../../etc/passwd",
+        file_format_override="RAWBLOB",
+    )
+
+    path_for_query = f"/var/lib/clickhouse/user_files/iceberg_data/default/{table_name}"
+    error = instance.query_and_get_error(
+        f"SELECT * FROM icebergLocal(local, path = '{path_for_query}', format='RawBLOB')",
+        settings=NOCACHE,
+    )
+    _assert_delete_path_access_denied(error)
+
+
+def _corrupt_delete_manifest_and_query(instance, test_name, modify_manifest_fn):
+    """Create an IcebergLocal table with position deletes, apply
+    *modify_manifest_fn(local_manifest_path, table_path)* to every
+    delete manifest, and return the error string from a SELECT."""
+    table_name = test_name + get_uuid_str()
+    table_path = f"/var/lib/clickhouse/user_files/iceberg_data/default/{table_name}"
+
+    instance.query(
+        f"CREATE TABLE {table_name} (c0 Int) ENGINE = IcebergLocal('{table_path}/', 'Parquet');",
+        settings={"allow_insert_into_iceberg": 1, **NOCACHE},
+    )
+    instance.query(
+        f"INSERT INTO {table_name} VALUES (1), (2), (3)",
+        settings={"allow_insert_into_iceberg": 1, **NOCACHE},
+    )
+    instance.query(
+        f"DELETE FROM {table_name} WHERE c0 = 1",
+        settings={"allow_insert_into_iceberg": 1, **NOCACHE},
+    )
+    result = instance.query(
+        f"SELECT c0 FROM {table_name} ORDER BY c0", settings=NOCACHE
+    )
+    assert result.strip() == "2\n3"
+    instance.query(f"DROP TABLE {table_name}")
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        host_path = os.path.join(temp_dir, table_name)
+        os.makedirs(host_path, exist_ok=True)
+        _download_table_from_container(instance, table_path, host_path)
+
+        _, delete_manifest_paths = _get_manifest_paths_from_chain(
+            host_path, table_path, content_filter=1
+        )
+        assert delete_manifest_paths, "No delete manifest found after DELETE FROM"
+
+        for rel_path in delete_manifest_paths:
+            local_manifest = os.path.join(host_path, rel_path)
+            assert os.path.isfile(local_manifest), f"Not found: {local_manifest}"
+            modify_manifest_fn(local_manifest, table_path)
+            instance.copy_file_to_container(
+                local_manifest, f"{table_path}/{rel_path}"
+            )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return instance.query_and_get_error(
+        f"SELECT * FROM icebergLocal(local, path = '{table_path}/')",
+        settings=NOCACHE,
+    )
+
+def test_local_iceberg_delete_file_path_traversal(started_cluster_iceberg_no_spark):
+    """Position-delete file_path with ../ must be rejected via
+    validateDeleteFilePaths (not LocalPathValidatingIterator)."""
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+
+    def corrupt(manifest, table_path):
+        _modify_avro_file(
+            manifest,
+            ["data_file", "file_path"],
+            lambda _: f"{table_path}/../../../../../../../etc/passwd",
+        )
+
+    _assert_delete_path_access_denied(
+        _corrupt_delete_manifest_and_query(instance, "test_local_iceberg_path_traversal", corrupt)
+    )
+
+
+def test_local_iceberg_equality_delete_file_path_traversal(
+    started_cluster_iceberg_no_spark,
+):
+    """Equality-delete file_path with ../ must be rejected via
+    validateDeleteFilePaths.  Patches the delete manifest to look like
+    an equality delete (content=2, equality_ids=[1])."""
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+
+    def corrupt(manifest, table_path):
+        _modify_avro_file(manifest, ["data_file", "content"], lambda _: 2)
+        _modify_avro_file(manifest, ["data_file", "equality_ids"], lambda _: [1])
+        _modify_avro_file(
+            manifest,
+            ["data_file", "file_path"],
+            lambda _: f"{table_path}/../../../../../../../etc/passwd",
+        )
+
+    _assert_delete_path_access_denied(
+        _corrupt_delete_manifest_and_query(instance, "test_local_iceberg_path_traversal", corrupt)
+    )

--- a/tests/integration/test_storage_iceberg_with_spark/test_manifest_data_path_security.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_manifest_data_path_security.py
@@ -1,0 +1,199 @@
+import json
+import os
+import tempfile
+
+from helpers.iceberg_utils import (
+    get_uuid_str,
+    default_upload_directory,
+)
+
+
+def patch_manifest_data_path(instance, table_dir, new_data_path):
+    """
+    Reads Iceberg metadata from the container, finds the manifest file,
+    does a binary find-and-replace of the data file path inside it,
+    preserving all Avro metadata (partition-spec, schema, etc.).
+
+    Returns the original data file path so the caller can copy it to new_data_path.
+    """
+    import avro.datafile
+    import avro.io
+
+    metadata_dir = os.path.join(table_dir, "metadata")
+
+    # 1. Find the latest metadata json (version-hint.text -> vN.metadata.json)
+    version_hint = instance.exec_in_container(
+        ["cat", os.path.join(metadata_dir, "version-hint.text")]
+    ).strip()
+    metadata_json_path = os.path.join(metadata_dir, f"v{version_hint}.metadata.json")
+    metadata_json_str = instance.exec_in_container(["cat", metadata_json_path])
+    metadata = json.loads(metadata_json_str)
+
+    # 2. Find current snapshot's manifest-list path
+    current_snapshot_id = metadata["current-snapshot-id"]
+    snapshot = next(s for s in metadata["snapshots"] if s["snapshot-id"] == current_snapshot_id)
+    manifest_list_path = snapshot["manifest-list"]
+
+    # 3. Download manifest-list (Avro) from container to read manifest path
+    manifest_list_local = tempfile.mktemp(suffix=".avro")
+    instance.copy_file_from_container(manifest_list_path, manifest_list_local)
+
+    with open(manifest_list_local, "rb") as f:
+        reader = avro.datafile.DataFileReader(f, avro.io.DatumReader())
+        manifest_entries = list(reader)
+        reader.close()
+
+    assert len(manifest_entries) > 0, "Expected at least one manifest entry"
+    manifest_path = manifest_entries[0]["manifest_path"]
+
+    # 4. Download the manifest file (Avro) — read records to get original path
+    manifest_local = tempfile.mktemp(suffix=".avro")
+    instance.copy_file_from_container(manifest_path, manifest_local)
+
+    with open(manifest_local, "rb") as f:
+        reader = avro.datafile.DataFileReader(f, avro.io.DatumReader())
+        records = list(reader)
+        reader.close()
+
+    assert len(records) > 0, "Expected at least one record in manifest"
+    original_data_path = records[0]["data_file"]["file_path"]
+
+    # 5. Patch the manifest using the avro library: read with DataFileReader,
+    #    then write back with DataFileWriter, copying all file-level metadata
+    #    (partition-spec, schema, etc.) from the original file.
+    with open(manifest_local, "rb") as f:
+        reader = avro.datafile.DataFileReader(f, avro.io.DatumReader())
+        writer_schema = reader.datum_reader.writers_schema
+        file_meta = dict(reader.meta)  # preserves partition-spec, schema, etc.
+        codec = reader.codec
+        all_records = list(reader)
+        reader.close()
+
+    for record in all_records:
+        record["data_file"]["file_path"] = new_data_path
+
+    patched_manifest_local = tempfile.mktemp(suffix=".avro")
+    with open(patched_manifest_local, "wb") as f:
+        writer = avro.datafile.DataFileWriter(f, avro.io.DatumWriter(), writer_schema, codec=codec)
+        # Copy all non-standard metadata from original (partition-spec, schema, etc.)
+        for key, value in file_meta.items():
+            if key not in ("avro.schema", "avro.codec"):
+                writer.set_meta(key, value)
+        for record in all_records:
+            writer.append(record)
+        writer.flush()
+        writer.close()
+
+    # 6. Upload patched manifest to the container (overwrite)
+    instance.copy_file_to_container(patched_manifest_local, manifest_path)
+
+    # Cleanup temp files
+    os.unlink(manifest_list_local)
+    os.unlink(manifest_local)
+    os.unlink(patched_manifest_local)
+
+    return original_data_path
+
+
+def test_manifest_data_path_outside_user_files(started_cluster_iceberg_with_spark):
+    """
+    Test that ClickHouse rejects reading an Iceberg table when the manifest
+    entry points to a data file outside user_files directory via path traversal.
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = "test_manifest_path_security_" + get_uuid_str()
+
+    spark.sql(
+        f"CREATE TABLE {TABLE_NAME} (id bigint, data string) USING iceberg "
+        f"TBLPROPERTIES ('format-version' = '2')"
+    )
+    spark.sql(f"INSERT INTO {TABLE_NAME} VALUES (1, 'hello')")
+
+    table_dir = f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}"
+    default_upload_directory(
+        started_cluster_iceberg_with_spark,
+        "local",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    evil_dir = "/tmp/evil_data"
+    evil_data_path = "/var/lib/clickhouse/user_files/../../../../tmp/evil_data/data.parquet"
+
+    original_data_path = patch_manifest_data_path(instance, table_dir, evil_data_path)
+    assert original_data_path is not None, "Could not find original data file path in manifest"
+
+    instance.exec_in_container(["bash", "-c", f"mkdir -p {evil_dir}"])
+    instance.exec_in_container(["bash", "-c", f"cp {original_data_path} {evil_data_path}"])
+
+    create_sql = (
+        f"DROP TABLE IF EXISTS {TABLE_NAME};\n"
+        f"CREATE TABLE {TABLE_NAME} "
+        f"ENGINE=IcebergLocal(local, path = '{table_dir}', format='Parquet')"
+    )
+    instance.query(create_sql)
+
+    error = instance.query_and_get_error(f"SELECT * FROM {TABLE_NAME}")
+    assert "PATH_ACCESS_DENIED" in error, (
+        f"Expected PATH_ACCESS_DENIED but got: {error}"
+    )
+
+
+def test_manifest_data_path_symlink_escape(started_cluster_iceberg_with_spark):
+    """
+    Test that ClickHouse rejects reading an Iceberg table when the manifest
+    entry uses a symlink inside user_files that points outside.
+
+    A path like <user_files>/allowed_link/file where allowed_link -> /tmp
+    passes a purely lexical check (lexically_normal / lexically_relative)
+    but accesses data outside user_files via symlink resolution.
+    The check must use weakly_canonical (or equivalent) to catch this.
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = "test_symlink_escape_" + get_uuid_str()
+
+    spark.sql(
+        f"CREATE TABLE {TABLE_NAME} (id bigint, data string) USING iceberg "
+        f"TBLPROPERTIES ('format-version' = '2')"
+    )
+    spark.sql(f"INSERT INTO {TABLE_NAME} VALUES (1, 'hello')")
+
+    table_dir = f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}"
+    default_upload_directory(
+        started_cluster_iceberg_with_spark,
+        "local",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+        f"/iceberg_data/default/{TABLE_NAME}/",
+    )
+
+    evil_dir = "/tmp/symlink_evil_data"
+    evil_data_path = f"{evil_dir}/data.parquet"
+
+    original_data_path = patch_manifest_data_path(
+        instance, table_dir,
+        # This path looks valid lexically — it's inside user_files —
+        # but allowed_link is a symlink to /tmp/symlink_evil_data
+        "/var/lib/clickhouse/user_files/allowed_link/data.parquet"
+    )
+    assert original_data_path is not None, "Could not find original data file path in manifest"
+
+    instance.exec_in_container(["bash", "-c", f"mkdir -p {evil_dir}"])
+    instance.exec_in_container(["bash", "-c", f"cp {original_data_path} {evil_data_path}"])
+    instance.exec_in_container([
+        "bash", "-c",
+        f"ln -sfn {evil_dir} /var/lib/clickhouse/user_files/allowed_link"
+    ])
+
+    create_sql = (
+        f"DROP TABLE IF EXISTS {TABLE_NAME};\n"
+        f"CREATE TABLE {TABLE_NAME} "
+        f"ENGINE=IcebergLocal(local, path = '{table_dir}', format='Parquet')"
+    )
+    instance.query(create_sql)
+
+    error = instance.query_and_get_error(f"SELECT * FROM {TABLE_NAME}")
+    assert "PATH_ACCESS_DENIED" in error, (
+        f"Expected PATH_ACCESS_DENIED but got: {error}"
+    )


### PR DESCRIPTION
In order for the changes to apply cleanly, 106281 was pulled before 111483.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix wrong logic of MetadataStorageFromPlainObjectStorageTransaction::removeDirectory (https://github.com/ClickHouse/ClickHouse/pull/106281 by @RinChanNOWWW)
Restrict local object access only for user files path (https://github.com/ClickHouse/ClickHouse/pull/111483 by @scanhex12)

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
