### PR TITLE
Antalya-26.6 - community pr: upload test artifacts  upon job failure

### DIFF
--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -81,6 +81,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Config Workflow' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-config_workflow
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   fast_test:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
     needs: [config_workflow]
@@ -122,6 +138,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Fast test' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-fast_test
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   build_amd_debug:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -177,6 +209,22 @@ jobs:
         with:
           name: DEB_AMD_DEBUG
           path: ci/tmp/*.deb
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_amd_debug
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   build_amd_asan_ubsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -240,6 +288,22 @@ jobs:
           name: DEB_AMD_ASAN_UBSAN
           path: ci/tmp/*.deb
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_amd_asan_ubsan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   build_amd_binary:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [config_workflow, fast_test]
@@ -287,6 +351,22 @@ jobs:
         with:
           name: CH_AMD_BINARY
           path: ci/tmp/build/programs/self-extracting/clickhouse
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_amd_binary
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   build_arm_debug:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -343,6 +423,22 @@ jobs:
           name: DEB_ARM_DEBUG
           path: ci/tmp/*.deb
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_arm_debug
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   build_arm_asan_ubsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [config_workflow, fast_test]
@@ -397,6 +493,22 @@ jobs:
         with:
           name: DEB_ARM_ASAN_UBSAN
           path: ci/tmp/*.deb
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_arm_asan_ubsan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   build_arm_ubsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -453,6 +565,22 @@ jobs:
           name: DEB_ARM_UBSAN
           path: ci/tmp/*.deb
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_arm_ubsan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   build_arm_binary:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [config_workflow, fast_test]
@@ -500,6 +628,22 @@ jobs:
         with:
           name: CH_ARM_BIN
           path: ci/tmp/build/programs/self-extracting/clickhouse
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_arm_binary
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   build_amd_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -563,6 +707,22 @@ jobs:
           name: DEB_AMD_TSAN
           path: ci/tmp/*.deb
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_amd_tsan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   build_amd_msan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [config_workflow, fast_test]
@@ -625,6 +785,22 @@ jobs:
           name: DEB_AMD_MSAN
           path: ci/tmp/*.deb
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_amd_msan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   build_arm_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [config_workflow, fast_test]
@@ -680,6 +856,22 @@ jobs:
           name: DEB_ARM_TSAN
           path: ci/tmp/*.deb
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_arm_tsan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   build_arm_msan:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [config_workflow, fast_test]
@@ -734,6 +926,22 @@ jobs:
         with:
           name: DEB_ARM_MSAN
           path: ci/tmp/*.deb
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_arm_msan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   build_amd_release:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
@@ -804,6 +1012,22 @@ jobs:
           name: TGZ_AMD_RELEASE
           path: ci/tmp/*64.tgz*
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_amd_release
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   build_arm_release:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder]
     needs: [config_workflow, fast_test]
@@ -873,6 +1097,22 @@ jobs:
           name: TGZ_ARM_RELEASE
           path: ci/tmp/*64.tgz*
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-build_arm_release
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   quick_functional_tests:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [build_amd_debug, config_workflow, fast_test]
@@ -920,6 +1160,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Quick functional tests' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-quick_functional_tests
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_asan_ubsan_distributed_plan_parallel_1_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -969,6 +1225,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_asan_ubsan, distributed plan, parallel, 1/2)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_asan_ubsan_distributed_plan_parallel_1_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_asan_ubsan_distributed_plan_parallel_2_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_asan_ubsan, build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1016,6 +1288,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_asan_ubsan, distributed plan, parallel, 2/2)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_asan_ubsan_distributed_plan_parallel_2_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_1_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 32g]
@@ -1065,6 +1353,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_asan_ubsan, db disk, distributed plan, sequential, 1/2)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_1_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_2_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 32g]
     needs: [build_amd_asan_ubsan, build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1112,6 +1416,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_asan_ubsan, db disk, distributed plan, sequential, 2/2)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_asan_ubsan_db_disk_distributed_plan_sequential_2_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_debug_parallel:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -1161,6 +1481,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_debug, parallel)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_debug_parallel
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_debug_sequential:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1208,6 +1544,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_debug, sequential)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_debug_sequential
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_tsan_parallel_1_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
@@ -1257,6 +1609,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_tsan, parallel, 1/2)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_tsan_parallel_1_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_tsan_parallel_2_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
     needs: [build_amd_debug, build_amd_tsan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1304,6 +1672,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_tsan, parallel, 2/2)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_tsan_parallel_2_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_tsan_sequential_1_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -1353,6 +1737,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_tsan, sequential, 1/2)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_tsan_sequential_1_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_tsan_sequential_2_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [build_amd_debug, build_amd_tsan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1400,6 +1800,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_tsan, sequential, 2/2)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_tsan_sequential_2_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_msan_wasmedge_parallel_1_4:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -1449,6 +1865,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_msan, WasmEdge, parallel, 1/4)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_msan_wasmedge_parallel_1_4
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_msan_wasmedge_parallel_2_4:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [build_amd_debug, build_amd_msan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1496,6 +1928,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_msan, WasmEdge, parallel, 2/4)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_msan_wasmedge_parallel_2_4
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_msan_wasmedge_parallel_3_4:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -1545,6 +1993,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_msan, WasmEdge, parallel, 3/4)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_msan_wasmedge_parallel_3_4
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_msan_wasmedge_parallel_4_4:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [build_amd_debug, build_amd_msan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1592,6 +2056,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_msan, WasmEdge, parallel, 4/4)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_msan_wasmedge_parallel_4_4
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_msan_wasmedge_sequential_1_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 32g]
@@ -1641,6 +2121,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_msan, WasmEdge, sequential, 1/2)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_msan_wasmedge_sequential_1_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_msan_wasmedge_sequential_2_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 32g]
     needs: [build_amd_debug, build_amd_msan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1688,6 +2184,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_msan, WasmEdge, sequential, 2/2)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_msan_wasmedge_sequential_2_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_debug_distributed_plan_s3_storage_parallel:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -1737,6 +2249,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_debug, distributed plan, s3 storage, parallel)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_debug_distributed_plan_s3_storage_parallel
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_debug_distributed_plan_s3_storage_sequential:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
     needs: [build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1784,6 +2312,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_debug, distributed plan, s3 storage, sequential)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_debug_distributed_plan_s3_storage_sequential
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_tsan_s3_storage_parallel_1_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -1833,6 +2377,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_tsan, s3 storage, parallel, 1/2)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_tsan_s3_storage_parallel_1_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_tsan_s3_storage_parallel_2_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_tsan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1880,6 +2440,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_tsan, s3 storage, parallel, 2/2)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_tsan_s3_storage_parallel_2_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_amd_tsan_s3_storage_sequential_1_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 32g]
@@ -1929,6 +2505,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_tsan, s3 storage, sequential, 1/2)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_tsan_s3_storage_sequential_1_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_amd_tsan_s3_storage_sequential_2_2:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 32g]
     needs: [build_amd_debug, build_amd_tsan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -1976,6 +2568,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_tsan, s3 storage, sequential, 2/2)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_amd_tsan_s3_storage_sequential_2_2
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   stateless_tests_arm_binary_parallel:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64, 16c]
@@ -2025,6 +2633,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (arm_binary, parallel)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_arm_binary_parallel
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   stateless_tests_arm_binary_sequential:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64]
     needs: [build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2072,6 +2696,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (arm_binary, sequential)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-stateless_tests_arm_binary_sequential
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_1_8:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -2121,6 +2761,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, old analyzer, 1/8)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_asan_ubsan_db_disk_old_analyzer_1_8
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_2_8:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_asan_ubsan, build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2168,6 +2824,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, old analyzer, 2/8)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_asan_ubsan_db_disk_old_analyzer_2_8
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_3_8:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -2217,6 +2889,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, old analyzer, 3/8)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_asan_ubsan_db_disk_old_analyzer_3_8
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_4_8:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_asan_ubsan, build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2264,6 +2952,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, old analyzer, 4/8)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_asan_ubsan_db_disk_old_analyzer_4_8
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_5_8:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -2313,6 +3017,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, old analyzer, 5/8)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_asan_ubsan_db_disk_old_analyzer_5_8
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_6_8:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_asan_ubsan, build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2360,6 +3080,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, old analyzer, 6/8)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_asan_ubsan_db_disk_old_analyzer_6_8
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_7_8:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -2409,6 +3145,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, old analyzer, 7/8)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_asan_ubsan_db_disk_old_analyzer_7_8
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_asan_ubsan_db_disk_old_analyzer_8_8:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_asan_ubsan, build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2456,6 +3208,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_asan_ubsan, db disk, old analyzer, 8/8)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_asan_ubsan_db_disk_old_analyzer_8_8
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_arm_binary_distributed_plan_1_4:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64, 16c]
@@ -2505,6 +3273,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (arm_binary, distributed plan, 1/4)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_arm_binary_distributed_plan_1_4
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_arm_binary_distributed_plan_2_4:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64, 16c]
     needs: [build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2552,6 +3336,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (arm_binary, distributed plan, 2/4)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_arm_binary_distributed_plan_2_4
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_arm_binary_distributed_plan_3_4:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64, 16c]
@@ -2601,6 +3401,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (arm_binary, distributed plan, 3/4)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_arm_binary_distributed_plan_3_4
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_arm_binary_distributed_plan_4_4:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64, 16c]
     needs: [build_amd_debug, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2648,6 +3464,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (arm_binary, distributed plan, 4/4)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_arm_binary_distributed_plan_4_4
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_tsan_1_6:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -2697,6 +3529,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_tsan, 1/6)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_tsan_1_6
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_tsan_2_6:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_tsan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2744,6 +3592,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_tsan, 2/6)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_tsan_2_6
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_tsan_3_6:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -2793,6 +3657,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_tsan, 3/6)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_tsan_3_6
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_tsan_4_6:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_tsan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2840,6 +3720,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_tsan, 4/6)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_tsan_4_6
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_tsan_5_6:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -2889,6 +3785,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_tsan, 5/6)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_tsan_5_6
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_tsan_6_6:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_tsan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -2936,6 +3848,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_tsan, 6/6)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_tsan_6_6
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_msan_1_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -2985,6 +3913,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 1/10)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_1_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_msan_2_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_msan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -3032,6 +3976,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 2/10)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_2_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_msan_3_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -3081,6 +4041,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 3/10)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_3_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_msan_4_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_msan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -3128,6 +4104,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 4/10)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_4_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_msan_5_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -3177,6 +4169,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 5/10)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_5_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_msan_6_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_msan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -3224,6 +4232,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 6/10)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_6_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_msan_7_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -3273,6 +4297,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 7/10)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_7_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_msan_8_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_msan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -3320,6 +4360,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 8/10)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_8_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   integration_tests_amd_msan_9_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
@@ -3369,6 +4425,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 9/10)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_9_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   integration_tests_amd_msan_10_10:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester, 16c]
     needs: [build_amd_debug, build_amd_msan, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -3416,6 +4488,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Integration tests (amd_msan, 10/10)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-integration_tests_amd_msan_10_10
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   unit_tests_asan_ubsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
@@ -3465,6 +4553,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Unit tests (asan_ubsan)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-unit_tests_asan_ubsan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   unit_tests_tsan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
     needs: [build_amd_tsan, config_workflow, fast_test]
@@ -3512,6 +4616,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Unit tests (tsan)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-unit_tests_tsan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   unit_tests_msan:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
@@ -3561,6 +4681,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Unit tests (msan)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-unit_tests_msan
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   unit_tests_asan_ubsan_function_prop_fuzzer:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
     needs: [build_amd_asan_ubsan, config_workflow, fast_test]
@@ -3608,6 +4744,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Unit tests (asan_ubsan, function_prop_fuzzer)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-unit_tests_asan_ubsan_function_prop_fuzzer
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   unit_tests_tsan_function_prop_fuzzer:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
@@ -3657,6 +4809,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Unit tests (tsan, function_prop_fuzzer)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-unit_tests_tsan_function_prop_fuzzer
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   unit_tests_msan_function_prop_fuzzer:
     runs-on: [self-hosted, altinity-on-demand, altinity-builder, 64g]
     needs: [build_amd_msan, config_workflow, fast_test]
@@ -3704,6 +4872,22 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Unit tests (msan, function_prop_fuzzer)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-unit_tests_msan_function_prop_fuzzer
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 
   install_packages_amd_release:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester]
@@ -3774,6 +4958,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Install packages (amd_release)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-install_packages_amd_release
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   install_packages_arm_release:
     runs-on: [self-hosted, altinity-on-demand, altinity-func-tester-aarch64]
     needs: [build_amd_debug, build_arm_binary, build_arm_release, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -3843,6 +5043,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Install packages (arm_release)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-install_packages_arm_release
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   compatibility_check_amd_release:
     runs-on: [self-hosted, altinity-on-demand, altinity-style-checker]
     needs: [build_amd_debug, build_amd_release, build_arm_binary, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -3891,6 +5107,22 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Compatibility check (amd_release)' --workflow "Community PR" --ci --timestamp
 
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-compatibility_check_amd_release
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
+
   compatibility_check_arm_release:
     runs-on: [self-hosted, altinity-on-demand, altinity-style-checker-aarch64]
     needs: [build_amd_debug, build_arm_binary, build_arm_release, config_workflow, fast_test, stateless_tests_amd_debug_parallel, stateless_tests_arm_binary_parallel]
@@ -3938,3 +5170,19 @@ jobs:
         run: |
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Compatibility check (arm_release)' --workflow "Community PR" --ci --timestamp
+
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-compatibility_check_arm_release
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -180,7 +180,7 @@ jobs:
         run: |
           . {ENV_SETUP_SCRIPT}
           PYTHONUNBUFFERED=1 python3 -m praktika run '{JOB_NAME}' --workflow "{WORKFLOW_NAME}" --ci --timestamp
-{UPLOADS_GITHUB}\
+{UPLOADS_GITHUB}{FAILURE_REPORT_UPLOAD}\
 """
 
         TEMPLATE_SETUP_ENV_SECRETS = """\
@@ -239,6 +239,24 @@ jobs:
         with:
           name: {NAME}
           path: {PATH}
+"""
+
+        TEMPLATE_GH_UPLOAD_FAILURE_REPORT = """
+      - name: Upload failure report artifact
+        if: failure()
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: failure-{JOB_NAME_NORMALIZED}
+          path: |
+            ci/tmp/result_*.json
+            ci/tmp/test_result.txt
+            ci/tmp/pytest*.jsonl
+            ci/tmp/gtest.json
+            ci/tmp/logs.tar.gz
+            ci/tmp/configs.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14
 """
 
         TEMPLATE_GH_DOWNLOAD = """
@@ -430,6 +448,14 @@ class PullRequestPushYamlGen:
                     )
                 )
 
+            failure_report_upload = ""
+            if self.workflow_config.name == "Community PR":
+                failure_report_upload = (
+                    YamlGenerator.Templates.TEMPLATE_GH_UPLOAD_FAILURE_REPORT.format(
+                        JOB_NAME_NORMALIZED=job_name_normalized
+                    )
+                )
+
             job_item = YamlGenerator.Templates.TEMPLATE_JOB_0.format(
                 JOB_NAME_NORMALIZED=job_name_normalized,
                 IF_EXPRESSION=if_expression,
@@ -446,6 +472,7 @@ class PullRequestPushYamlGen:
                 JOB_ADDONS="".join(job_addons),
                 DOWNLOADS_GITHUB="\n".join(downloads_github),
                 UPLOADS_GITHUB="\n".join(uploads_github),
+                FAILURE_REPORT_UPLOAD=failure_report_upload,
                 PYTHON=Settings.PYTHON_INTERPRETER,
                 WORKFLOW_JOB_FILE=Settings.WORKFLOW_JOB_FILE,
                 WORKFLOW_STATUS_FILE=Settings.WORKFLOW_STATUS_FILE,


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Expose test failure reasons to external contributors by uploading test artifacts when a job fails.

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
