### PR TITLE
26.3 Stable backport of #109051: Respect use_client_time_zone for string datetime literals parsed on the server

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -13,6 +13,8 @@
 #include <Common/Config/ConfigProcessor.h>
 #include <Common/Config/getClientConfigPath.h>
 #include <Common/CurrentThread.h>
+#include <Common/DateLUT.h>
+#include <Common/DateLUTImpl.h>
 #include <Common/QueryScope.h>
 #include <Common/Exception.h>
 #include <Common/TerminalSize.h>
@@ -512,6 +514,13 @@ void Client::connect()
     UInt64 server_version_major = 0;
     UInt64 server_version_minor = 0;
     UInt64 server_version_patch = 0;
+
+    /// Capture the client local time zone before the branch below may switch the process default
+    /// to the server time zone. `serverTimezoneInstance()` reads the process default directly and
+    /// ignores `session_timezone`; `instance()` would fold in an explicit `--session_timezone` and
+    /// cache the wrong zone. `connect()` can run again on reconnect, so only capture once.
+    if (client_local_timezone.empty())
+        client_local_timezone = DateLUT::serverTimezoneInstance().getTimeZone();
 
     if (hosts_and_ports.empty())
     {

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -144,6 +144,8 @@ namespace Setting
     extern const SettingsFloatAuto promql_evaluation_time;
     extern const SettingsBool into_outfile_create_parent_directories;
     extern const SettingsBool ignore_format_null_for_explain;
+    extern const SettingsBool use_client_time_zone;
+    extern const SettingsTimezone session_timezone;
 }
 
 namespace ErrorCodes
@@ -2377,6 +2379,16 @@ void ClientBase::processParsedSingleQuery(
             connect();
 
         applySettingsFromServerIfNeeded(); // after connect() and applySettingsFromQuery()
+
+        /// With `use_client_time_zone`, DateTime string literals must be interpreted in the client time
+        /// zone. The client parses synchronous INSERT literals itself, but literals interpreted server-side
+        /// (asynchronous INSERT, SELECT) rely on `session_timezone`. Seed it with the client time zone unless
+        /// the user set `session_timezone` explicitly. This is transient (reverted with the other query
+        /// settings below), so it tracks per-query `use_client_time_zone` changes in both directions.
+        if (!client_local_timezone.empty()
+            && client_context->getSettingsRef()[Setting::use_client_time_zone]
+            && !client_context->getSettingsRef().isChanged("session_timezone"))
+            client_context->setSetting("session_timezone", client_local_timezone);
 
         ASTPtr input_function;
         const auto * insert = parsed_query->as<ASTInsertQuery>();

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -315,6 +315,11 @@ protected:
     ContextMutablePtr global_context;
     ContextMutablePtr client_context;
 
+    /// The client local time zone, captured on the first connect() before it may switch the
+    /// process default to the server time zone. Used to seed `session_timezone` per query when
+    /// `use_client_time_zone` is set, so server-side literal parsing matches the client side.
+    String client_local_timezone;
+
     String default_database;
     String query_id;
     Int32 suggestion_limit;

--- a/tests/queries/0_stateless/04401_async_insert_use_client_time_zone.reference
+++ b/tests/queries/0_stateless/04401_async_insert_use_client_time_zone.reference
@@ -1,0 +1,7 @@
+flag_async	1500036000
+flag_sync	1500036000
+reset_default_async	1500036000
+set_async	1500036000
+set_sync	1500036000
+settings_async	1500036000
+reset_async matches server tz	1

--- a/tests/queries/0_stateless/04401_async_insert_use_client_time_zone.sh
+++ b/tests/queries/0_stateless/04401_async_insert_use_client_time_zone.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-random-settings
+# ^ no-random-settings: the runner must not inject a randomized `session_timezone`; an explicit
+#   `session_timezone` (even empty) is an intentional user override and disables the client-time-zone
+#   propagation this test exercises.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# With use_client_time_zone=1, a DateTime string literal must be interpreted in the client time zone
+# regardless of whether the INSERT is synchronous or asynchronous. The async path parses the VALUES
+# block on the server, so the client has to propagate its local time zone as session_timezone, and it
+# must do so for every query (not only at connect time), tracking use_client_time_zone changes in both
+# directions. America/Hermosillo is a fixed UTC-7 zone (no DST), so 2017-07-14 05:40:00 there is the
+# stable instant 1500036000.
+
+TZC="env TZ=America/Hermosillo ${CLICKHOUSE_CLIENT}"
+
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${CLICKHOUSE_DATABASE}.dt (a DateTime, kind String) ENGINE = Memory"
+
+# use_client_time_zone via the command line flag (async and sync).
+$TZC --use_client_time_zone=1 -q \
+  "INSERT INTO ${CLICKHOUSE_DATABASE}.dt SETTINGS async_insert = 1, wait_for_async_insert = 1 VALUES ('2017-07-14 05:40:00', 'flag_async')"
+$TZC --use_client_time_zone=1 -q \
+  "INSERT INTO ${CLICKHOUSE_DATABASE}.dt SETTINGS async_insert = 0 VALUES ('2017-07-14 05:40:00', 'flag_sync')"
+
+# use_client_time_zone turned on mid-session with SET, on an already-open connection.
+$TZC -mn -q "
+SET use_client_time_zone = 1;
+INSERT INTO ${CLICKHOUSE_DATABASE}.dt SETTINGS async_insert = 1, wait_for_async_insert = 1 VALUES ('2017-07-14 05:40:00', 'set_async');
+INSERT INTO ${CLICKHOUSE_DATABASE}.dt SETTINGS async_insert = 0 VALUES ('2017-07-14 05:40:00', 'set_sync');
+"
+
+# use_client_time_zone set only per query via SETTINGS, without the command line flag.
+$TZC -q \
+  "INSERT INTO ${CLICKHOUSE_DATABASE}.dt SETTINGS use_client_time_zone = 1, async_insert = 1, wait_for_async_insert = 1 VALUES ('2017-07-14 05:40:00', 'settings_async')"
+
+# Starting with an explicit --session_timezone override and then clearing it with
+# SET session_timezone = DEFAULT must fall back to the client time zone, not to the override value.
+$TZC --use_client_time_zone=1 --session_timezone=UTC -mn -q "
+SET session_timezone = DEFAULT;
+INSERT INTO ${CLICKHOUSE_DATABASE}.dt SETTINGS async_insert = 1, wait_for_async_insert = 1 VALUES ('2017-07-14 05:40:00', 'reset_default_async');
+"
+
+# All of the above interpret the literal in the client time zone: 2017-07-14 05:40:00 = 1500036000.
+${CLICKHOUSE_CLIENT} -q "SELECT kind, toUnixTimestamp(a) FROM ${CLICKHOUSE_DATABASE}.dt ORDER BY kind"
+
+# Turning use_client_time_zone back off must restore server-side parsing (the stored instant no longer
+# depends on the client time zone). The exact value depends on the server time zone, so compare it with
+# a plain default insert instead of hard-coding it.
+$TZC -q \
+  "INSERT INTO ${CLICKHOUSE_DATABASE}.dt SETTINGS async_insert = 1, wait_for_async_insert = 1 VALUES ('2017-07-14 05:40:00', 'server_ref')"
+$TZC --use_client_time_zone=1 -mn -q "
+SET use_client_time_zone = 0;
+INSERT INTO ${CLICKHOUSE_DATABASE}.dt SETTINGS async_insert = 1, wait_for_async_insert = 1 VALUES ('2017-07-14 05:40:00', 'reset_async');
+"
+${CLICKHOUSE_CLIENT} -q "
+SELECT 'reset_async matches server tz', (
+    (SELECT toUnixTimestamp(a) FROM ${CLICKHOUSE_DATABASE}.dt WHERE kind = 'reset_async')
+    = (SELECT toUnixTimestamp(a) FROM ${CLICKHOUSE_DATABASE}.dt WHERE kind = 'server_ref'))
+"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_DATABASE}.dt"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fixed `use_client_time_zone` being ignored for `DateTime`/`DateTime64` string literals interpreted on the server (asynchronous `INSERT`, `SELECT` literals). The client now propagates its local time zone as `session_timezone` when `use_client_time_zone` is enabled, so server-side parsing matches the synchronous `INSERT` path. (https://github.com/ClickHouse/ClickHouse/pull/109051 by @groeneai)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
