### PR TITLE
Add CAS regression jobs to the Antalya 26.6 pipeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,6 +47,7 @@ Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
 - [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
 - [ ] <!---ci_regression_alter--> Alter (1.5h)
 - [ ] <!---ci_regression_benchmark--> Benchmark (30m)
+- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
 - [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
 - [x] <!---ci_regression_iceberg--> Iceberg (2h)
 - [ ] <!---ci_regression_ldap--> LDAP (1h)

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -532,3 +532,62 @@ jobs:
       regression_args: --aws-s3-access-key {{AWS_ACCESS_KEY}} --aws-s3-key-id {{AWS_KEY_ID}} --aws-s3-uri https://s3.{{AWS_REGION}}.amazonaws.com/{{AWS_BUCKET}}/data/ --gcs-key-id {{GCS_KEY_ID}} --gcs-key-secret {{GCS_KEY_SECRET}} --gcs-uri {{GCS_URI}}
       extra_args: ${{ matrix.STORAGE != 'local' && format('--with-{0}', matrix.STORAGE) || '' }}
     secrets: inherit
+
+  # CAS (content-addressed storage) is only available in Antalya builds >= 26.6.
+  # These jobs run the suites that support the `--cas` flag with a content-addressed
+  # disk as the default MergeTree storage. Gated on the Antalya version so they are
+  # never scheduled on upstream release builds where the `cas` metadata type does
+  # not exist.
+  CAS:
+    if: |
+      contains(fromJson(inputs.workflow_config).workflow_config.custom_data.version.string, 'antalya') &&
+      (
+        fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs[0] == null ||
+        contains(fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs, 'cas')
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        SUITE: [aggregate_functions, alter, atomic_insert, engines, lightweight_delete, selects]
+    uses: ./.github/workflows/regression-reusable-suite.yml
+    with:
+      ref: ${{ inputs.commit }}
+      workflow_config: ${{ inputs.workflow_config }}
+      suite_name: ${{ matrix.SUITE }}
+      suite_executable: regression.py
+      output_format: new-fails
+      flags: --with-analyzer
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+      runner_arch: ${{ inputs.arch }}
+      runner_type: ${{ inputs.runner_type }}
+      build_sha: ${{ inputs.build_sha }}
+      set_commit_status: true
+      job_name: cas_${{ matrix.SUITE }}
+      regression_args: --cas
+    secrets: inherit
+
+  TieredStorageCAS:
+    if: |
+      contains(fromJson(inputs.workflow_config).workflow_config.custom_data.version.string, 'antalya') &&
+      (
+        fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs[0] == null ||
+        contains(fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs, 'tiered_storage') ||
+        contains(fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs, 'cas')
+      )
+    uses: ./.github/workflows/regression-reusable-suite.yml
+    with:
+      ref: ${{ inputs.commit }}
+      workflow_config: ${{ inputs.workflow_config }}
+      suite_name: tiered_storage
+      suite_executable: regression.py
+      output_format: new-fails
+      flags: --with-analyzer
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+      runner_arch: ${{ inputs.arch }}
+      runner_type: ${{ inputs.runner_type }}
+      storage_path: /with_cas
+      build_sha: ${{ inputs.build_sha }}
+      set_commit_status: true
+      job_name: tiered_storage_cas
+      regression_args: --with-cas
+    secrets: inherit


### PR DESCRIPTION
Bring the CAS-supported `clickhouse-regression` suites into the Antalya 26.6 regression pipeline (`.github/workflows/regression.yml`).

CAS (content-addressed storage) uses the `cas` metadata storage type, which only exists in Antalya builds >= 26.6, so all of the new jobs are gated on the Antalya version string and are never scheduled on upstream release builds.

Two jobs are added:
- `CAS`: a matrix over the six suites that support the `--cas` flag (`aggregate_functions`, `alter`, `atomic_insert`, `engines`, `lightweight_delete`, `selects`), each run with a content-addressed disk as the default `MergeTree` storage (`regression_args: --cas`).
- `TieredStorageCAS`: runs the `tiered_storage` suite with the content-addressed external/slow tier (`regression_args: --with-cas`).

Both jobs honor the `ci_regression_jobs` filter (identifier `cas`), and a matching `<!---ci_regression_cas-->` checkbox is added to the PR template so the CAS suites can be selected individually. `TieredStorageCAS` also runs when either `tiered_storage` or `cas` is selected.

The six `--cas` suites and `tiered_storage`'s `--with-cas` flag are available on the `release` branch of `Altinity/clickhouse-regression`, which is the ref this pipeline checks out.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
...

Made with [Cursor](https://cursor.com)