### PR TITLE
Antalya 26.6 - Use new euro mirror for test datasets

### DIFF
--- a/.github/actions/runner_setup/action.yml
+++ b/.github/actions/runner_setup/action.yml
@@ -3,6 +3,13 @@ description: Setup environment
 runs:
   using: "composite"
   steps:
+    - name: Configure docker proxy and dataset mirror host
+      shell: bash
+      run: |
+          proxy_host=dockerhub-proxy.dockerhub-proxy-zone
+          if ! timeout 5 getent ahostsv4 "$proxy_host" >/dev/null; then
+            echo "65.108.242.32 $proxy_host" | sudo tee -a /etc/hosts
+          fi
     - name: Setup zram
       shell: bash
       run: |

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 import os
+import socket
 import sys
 from pathlib import Path
 from typing import List, Tuple
@@ -169,12 +170,21 @@ def get_run_command(
     else:
         run_script = "/repo/tests/docker_scripts/stress_runner.sh"
 
+    # Nested docker does not inherit the runner /etc/hosts. 
+    # --network=host would expose minio and azurite
+    proxy_host = "dockerhub-proxy.dockerhub-proxy-zone"
+    try:
+        proxy_ip = socket.getaddrinfo(proxy_host, None)[0][4][0]
+    except OSError as e:
+        raise RuntimeError(f"Could not resolve {proxy_host} on the runner") from e
+
     cmd = (
         "docker run --cap-add=SYS_PTRACE "
         # For dmesg and sysctl
         "--privileged "
         # azurite-rs (in-process Azure Blob Storage emulator) needs many fds under parallel load
         "--ulimit nofile=1048576:1048576 "
+        f"--add-host={proxy_host}:{proxy_ip} "
         # a static link, don't use S3_URL or S3_DOWNLOAD
         "-e S3_URL='https://s3.amazonaws.com/clickhouse-datasets' "
         "--tmpfs /tmp/clickhouse:mode=1777 "

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -170,13 +170,16 @@ def get_run_command(
     else:
         run_script = "/repo/tests/docker_scripts/stress_runner.sh"
 
-    # Nested docker does not inherit the runner /etc/hosts. 
-    # --network=host would expose minio and azurite
+    # Nested docker does not inherit the runner /etc/hosts.
+    # --network=host would expose minio and azurite. Skip --add-host when the
+    # name is unknown (CI Tests e2e / local) rather than failing the job.
     proxy_host = "dockerhub-proxy.dockerhub-proxy-zone"
+    add_host = ""
     try:
         proxy_ip = socket.getaddrinfo(proxy_host, None)[0][4][0]
-    except OSError as e:
-        raise RuntimeError(f"Could not resolve {proxy_host} on the runner") from e
+        add_host = f"--add-host={proxy_host}:{proxy_ip} "
+    except OSError:
+        logging.info("Could not resolve %s; not passing --add-host", proxy_host)
 
     cmd = (
         "docker run --cap-add=SYS_PTRACE "
@@ -184,7 +187,7 @@ def get_run_command(
         "--privileged "
         # azurite-rs (in-process Azure Blob Storage emulator) needs many fds under parallel load
         "--ulimit nofile=1048576:1048576 "
-        f"--add-host={proxy_host}:{proxy_ip} "
+        f"{add_host}"
         # a static link, don't use S3_URL or S3_DOWNLOAD
         "-e S3_URL='https://s3.amazonaws.com/clickhouse-datasets' "
         "--tmpfs /tmp/clickhouse:mode=1777 "

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shlex
+import socket
 import sys
 import traceback
 from pathlib import Path
@@ -446,6 +447,18 @@ class Runner:
             )
             from_root = "root" in docker_settings
             settings = [s for s in docker_settings if s.startswith("-")]
+            # NOTE (strtgbb): FT/integration docker is not --network=host, so
+            # the runner /etc/hosts mapping for the web-disk proxy is invisible
+            # inside the container. Resolve on the host and pass --add-host.
+            # Skip if the name is not configured on this runner (e.g. CI Tests).
+            _proxy_host = "dockerhub-proxy.dockerhub-proxy-zone"
+            try:
+                _proxy_ip = socket.getaddrinfo(_proxy_host, None)[0][4][0]
+                settings.append(f"--add-host={_proxy_host}:{_proxy_ip}")
+            except OSError as e:
+                print(
+                    f"NOTE: skipping --add-host for {_proxy_host}: {e}"
+                )
             if ":" in job.run_in_docker:
                 docker_name, docker_tag = job.run_in_docker.split(":")
                 print(

--- a/tests/docker_scripts/create.sql
+++ b/tests/docker_scripts/create.sql
@@ -141,7 +141,7 @@ SAMPLE BY intHash32(UserID)
 SETTINGS
     table_disk = 1,
     disk = disk(type = cache, path = 'filesystem_caches/stateful/', max_size = '4G',
-    disk = disk(type = web, endpoint = 'https://clickhouse-datasets-web.s3.us-east-1.amazonaws.com/store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/'));
+    disk = disk(type = web, endpoint = 'http://dockerhub-proxy.dockerhub-proxy-zone:6000/datasets-web/store/78e/78ebf6a1-d987-4579-b3ec-00c1a087b1f3/'));
 
 CREATE TABLE datasets.visits_v1
 (
@@ -334,4 +334,4 @@ SAMPLE BY intHash32(UserID)
 SETTINGS
     table_disk = 1,
     disk = disk(type = cache, path = 'filesystem_caches/stateful/', max_size = '4G',
-    disk = disk(type = web, endpoint = 'https://clickhouse-datasets-web.s3.us-east-1.amazonaws.com/store/513/5131f834-711f-4168-98a5-968b691a104b/'));
+    disk = disk(type = web, endpoint = 'http://dockerhub-proxy.dockerhub-proxy-zone:6000/datasets-web/store/513/5131f834-711f-4168-98a5-968b691a104b/'));

--- a/tests/docker_scripts/create_tpcds.sh
+++ b/tests/docker_scripts/create_tpcds.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 INIT_SQL="$REPO_ROOT/tests/benchmarks/tpc-ds/init.sql"
-S3_BASE="https://tpc-ds-sf1.s3.amazonaws.com"
+S3_BASE="http://dockerhub-proxy.dockerhub-proxy-zone:6000/tpc-ds-sf1"
 
 clickhouse-client --query "CREATE DATABASE IF NOT EXISTS tpcds"
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -563,7 +563,10 @@ class ClickHouseCluster:
         with_dolor=False,
     ):
         for param in list(os.environ.keys()):
-            logging.debug("ENV %40s %s" % (param, os.environ[param]))
+            value = os.environ[param]
+            if sensitive_var_pattern.match(param):
+                value = f"SECRET[{param}]"
+            logging.debug("ENV %40s %s" % (param, value))
         self.base_path = base_path
         self.base_dir = p.dirname(base_path)
         self.name = name if name is not None else extract_test_name(base_path)

--- a/tests/queries/0_stateless/04033_tpc_ds_q01.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q01.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q02.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q02.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q03.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q03.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q04.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q04.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q05.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q05.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q06.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q06.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q07.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q07.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q08.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q08.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q09.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q09.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q10.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q10.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q11.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q11.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q12.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q12.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q13.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q13.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q14.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q14.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q15.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q15.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q16.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q16.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q17.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q17.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 # Known issue: `stddev_samp` returns nan instead of NULL on single value (https://github.com/ClickHouse/ClickHouse/issues/94683).
 # Once the issue is fixed, update the .reference file.
 

--- a/tests/queries/0_stateless/04033_tpc_ds_q18.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q18.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q19.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q19.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q20.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q20.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q21.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q21.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q22.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q22.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q23.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q23.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q24.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q24.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q25.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q25.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q26.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q26.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q27.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q27.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q28.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q28.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q29.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q29.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q30.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q30.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q31.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q31.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q32.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q32.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q33.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q33.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q34.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q34.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q35.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q35.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 # Known issue: Memory Limit Exceeded with reasonable amount of memory. Enable the test once the issue is resolved or memory is optimised.
 
 echo "SKIP"

--- a/tests/queries/0_stateless/04033_tpc_ds_q36.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q36.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q37.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q37.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q38.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q38.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q39.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q39.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q40.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q40.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q41.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q41.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q42.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q42.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q43.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q43.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q44.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q44.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q45.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q45.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q46.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q46.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q47.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q47.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 # Known issue: the original query doesn't work, uses alternative formulation (https://github.com/ClickHouse/ClickHouse/issues/94858).
 # Once the issue is fixed, switch to the original query from tests/benchmarks/tpc-ds/README.md.
 

--- a/tests/queries/0_stateless/04033_tpc_ds_q48.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q48.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q49.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q49.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q50.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q50.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q51.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q51.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q52.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q52.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q53.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q53.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q54.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q54.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q55.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q55.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q56.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q56.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q57.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q57.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 # Known issue: the original query doesn't work, uses alternative formulation (https://github.com/ClickHouse/ClickHouse/issues/94858).
 # Once the issue is fixed, switch to the original query from tests/benchmarks/tpc-ds/README.md.
 

--- a/tests/queries/0_stateless/04033_tpc_ds_q58.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q58.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 # Known issue: the original query doesn't work, uses alternative formulation (https://github.com/ClickHouse/ClickHouse/issues/94976).
 # Once the issue is fixed, switch to the original query from tests/benchmarks/tpc-ds/README.md.
 

--- a/tests/queries/0_stateless/04033_tpc_ds_q59.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q59.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q60.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q60.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q61.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q61.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q62.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q62.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q63.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q63.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q64.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q64.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q65.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q65.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q66.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q66.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q67.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q67.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q68.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q68.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q69.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q69.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q70.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q70.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q71.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q71.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q72.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q72.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q73.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q73.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q74.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q74.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q75.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q75.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 # Known issue: the original query doesn't work, uses alternative formulation (https://github.com/ClickHouse/ClickHouse/issues/106707).
 # Once the issue is fixed, switch to the original query from tests/benchmarks/tpc-ds/README.md.
 

--- a/tests/queries/0_stateless/04033_tpc_ds_q76.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q76.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q77.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q77.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q78.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q78.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q79.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q79.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q80.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q80.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q81.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q81.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q82.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q82.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q83.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q83.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q84.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q84.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q85.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q85.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q86.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q86.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q87.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q87.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q88.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q88.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q89.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q89.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q90.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q90.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q91.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q91.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q92.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q92.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q93.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q93.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q94.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q94.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q95.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q95.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q96.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q96.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q97.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q97.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q98.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q98.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04033_tpc_ds_q99.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q99.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check, no-parallel
+# Tags: no-fasttest, no-random-settings, no-replicated-database, no-flaky-check
 # no-fasttest: TPC-DS tables use web disk (S3) which is not available in fasttest.
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# no-parallel: heavy queries contend on the shared server under parallel FT jobs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Reuse the dockerhub proxy to mirror test datasets (test.hits, tpc-ds, etc).
This will reduce latency to runners from Hetzner and Scalway.
May have an adverse impact on aws runners, but those are not currently in use.

Resolves #2227

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
