### PR TITLE
Antalya-26.6: use Cloudflare DNS in containers so lookups don't hang on unroutable IPv6 nameservers

### DIFF
--- a/.github/actions/docker_setup/action.yml
+++ b/.github/actions/docker_setup/action.yml
@@ -20,7 +20,8 @@ runs:
         sudo cat <<EOT > /etc/docker/daemon.json
         {
           "ipv6": true,
-          "fixed-cidr-v6": "${{ env.ipv6_subnet }}"
+          "fixed-cidr-v6": "${{ env.ipv6_subnet }}",
+          "dns": ["1.1.1.1", "1.0.0.1"]
         }
         EOT
         sudo chown root:root /etc/docker/daemon.json


### PR DESCRIPTION
Containers inherit the runner's uplink resolvers, and the first two are IPv6. Container IPv6 uses an unroutable prefix (`2001:3984:3989::/64`, Docker's docs example), so glibc waits out the timeout on each before reaching the IPv4 ones.

Measured on a runner, `getent hosts base.invalid`:

| resolver | time |
|---|---|
| default (4 nameservers, IPv6 first) | **~14s** |
| `185.12.64.1` | ~2.9s |
| `185.12.64.2` | 0.00s |
| `1.1.1.1` | 0.01s |

This is what blocks `04070_url_base_setting` — it does 25 `.invalid` lookups in series and takes ~950s instead of ~8s. Details in #2250.

Cloudflare rather than the Hetzner resolvers so the setting holds on Scaleway and AWS runners too. Neither resolves `dockerhub-proxy.dockerhub-proxy-zone`, so there's no difference there.

Resolves #2250

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
