### PR TITLE
Antalya 26.6 - Add labels column to report for praktika's flaky label

### DIFF
--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -691,6 +691,10 @@ def get_new_fails_this_pr(
 
     # Combine both types of fails and select only desired columns
     desired_columns = ["job_name", "test_name", "test_status", "results_link"]
+    if len(checks_fails) > 0 and "labels" in checks_fails.columns:
+        desired_columns.append("labels")
+        if len(regression_fails) > 0:
+            regression_fails["labels"] = ""
     all_pr_fails = pd.concat([checks_fails, regression_fails], ignore_index=True)[
         desired_columns
     ]
@@ -976,6 +980,77 @@ def format_test_status(text: str) -> str:
     return f'<span style="font-weight: bold; color: {color}">{text}</span>'
 
 
+def _label_names_from_ext(ext: dict) -> list[str]:
+    names = []
+    for item in ext.get("labels") or []:
+        if isinstance(item, str):
+            name = item
+        elif isinstance(item, dict) and item.get("name"):
+            name = item["name"]
+        else:
+            continue
+        if name != "cidb":
+            names.append(name)
+    return names
+
+
+def fetch_workflow_result_json(
+    pr_number: int, branch: str, commit_sha: str
+) -> dict | None:
+    if pr_number == 0:
+        ref_param = f"REF={branch}"
+        workflow_name = "MasterCI"
+    else:
+        ref_param = f"PR={pr_number}"
+        workflow_name = "PR"
+
+    status_file = f"result_{workflow_name.lower()}.json"
+    s3_path = (
+        f"https://{S3_BUCKET}.s3.amazonaws.com/"
+        f"{ref_param.replace('=', 's/')}/{commit_sha}/{status_file}"
+    )
+    try:
+        response = requests.get(s3_path, timeout=30)
+        if response.status_code != 200:
+            return None
+        return response.json()
+    except Exception as e:
+        print(f"WARNING:Failed to fetch workflow result from {s3_path}: {e}")
+        return None
+
+
+def get_failure_labels_from_workflow(workflow_data: dict | None) -> dict:
+    if not workflow_data:
+        return {}
+    labels_map = {}
+    for job in workflow_data.get("results") or []:
+        job_name = job.get("name")
+        if not job_name:
+            continue
+        for leaf in job.get("results") or []:
+            test_name = leaf.get("name")
+            if not test_name:
+                continue
+            names = _label_names_from_ext(leaf.get("ext") or {})
+            if names:
+                labels_map[(job_name, test_name)] = ", ".join(names)
+    return labels_map
+
+
+def add_labels_to_checks_fails(
+    checks_fails: pd.DataFrame, workflow_data: dict | None
+) -> pd.DataFrame:
+    if checks_fails is None or len(checks_fails) == 0:
+        return checks_fails
+    labels_map = get_failure_labels_from_workflow(workflow_data)
+    df = checks_fails.copy()
+    df["labels"] = df.apply(
+        lambda row: labels_map.get((row["job_name"], row["test_name"]), ""),
+        axis=1,
+    )
+    return df
+
+
 def format_results_as_html_table(results, *, branch_name: str = "") -> str:
     if not isinstance(results, pd.DataFrame):
         return results
@@ -1012,42 +1087,30 @@ def format_results_as_html_table(results, *, branch_name: str = "") -> str:
         "PR Labels": lambda labels: format_pr_labels_with_verification(
             labels, branch_name=branch_name
         ),
+        "Labels": lambda labels: html.escape(str(labels), quote=True) if labels else "",
     }
 
-    html = results.to_html(
+    return results.to_html(
         index=False,
         formatters=formatters,
         escape=False,
         border=0,
         classes=["test-results-table"],
     )
-    return html
 
 
 def backfill_skipped_statuses(
-    job_statuses: pd.DataFrame, pr_number: int, branch: str, commit_sha: str
+    job_statuses: pd.DataFrame,
+    workflow_result: dict | None,
 ):
     """
     Fill in the job statuses for skipped jobs.
     """
-
-    if pr_number == 0:
-        ref_param = f"REF={branch}"
-        workflow_name = "MasterCI"
-    else:
-        ref_param = f"PR={pr_number}"
-        workflow_name = "PR"
-
-    status_file = f"result_{workflow_name.lower()}.json"
-    s3_path = f"https://{S3_BUCKET}.s3.amazonaws.com/{ref_param.replace('=', 's/')}/{commit_sha}/{status_file}"
-    response = requests.get(s3_path)
-
-    if response.status_code != 200:
+    if workflow_result is None:
         return job_statuses
 
-    status_data = response.json()
     skipped_jobs = []
-    for job in status_data["results"]:
+    for job in workflow_result["results"]:
         if job["status"] == "skipped" and len(job["links"]) > 0:
             skipped_jobs.append(
                 {
@@ -1192,10 +1255,15 @@ def create_workflow_report(
         settings={"use_numpy": True},
     )
 
+    workflow_result = fetch_workflow_result_json(pr_number, branch_name, commit_sha)
+
     results_dfs = {
         "prs_in_release": [],
         "job_statuses": get_commit_statuses(commit_sha),
-        "checks_fails": get_checks_fails(db_client, commit_sha, branch_name),
+        "checks_fails": add_labels_to_checks_fails(
+            get_checks_fails(db_client, commit_sha, branch_name),
+            workflow_result,
+        ),
         "checks_known_fails": [],
         "pr_new_fails": [],
         "checks_errors": get_checks_errors(db_client, commit_sha, branch_name),
@@ -1257,7 +1325,8 @@ def create_workflow_report(
             pr_info = {}
 
     results_dfs["job_statuses"] = backfill_skipped_statuses(
-        results_dfs["job_statuses"], pr_number, branch_name, commit_sha
+        results_dfs["job_statuses"],
+        workflow_result,
     )
 
     high_cve_count = 0

--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -692,7 +692,7 @@ def get_new_fails_this_pr(
     # Combine both types of fails and select only desired columns
     desired_columns = ["job_name", "test_name", "test_status", "results_link"]
     if len(checks_fails) > 0 and "labels" in checks_fails.columns:
-        desired_columns.append("labels")
+        desired_columns.insert(desired_columns.index("results_link"), "labels")
         if len(regression_fails) > 0:
             regression_fails["labels"] = ""
     all_pr_fails = pd.concat([checks_fails, regression_fails], ignore_index=True)[
@@ -1048,7 +1048,12 @@ def add_labels_to_checks_fails(
         lambda row: labels_map.get((row["job_name"], row["test_name"]), ""),
         axis=1,
     )
-    return df
+    cols = [c for c in df.columns if c != "labels"]
+    if "results_link" in cols:
+        cols.insert(cols.index("results_link"), "labels")
+    else:
+        cols.append("labels")
+    return df[cols]
 
 
 def format_results_as_html_table(results, *, branch_name: str = "") -> str:


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
