### PR TITLE
Antalya-26.6 - Fix test_s3_cluster startup failure under db disk (duplicate shard/replica macros)

### DIFF
--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -163,7 +163,8 @@ def started_cluster():
             "c2.s0_0_1",
             main_configs=["configs/cluster.xml", "configs/named_collections.xml", "configs/hidden_clusters.xml"],
             user_configs=["configs/users.xml"],
-            macros={"replica": "replica2", "shard": "shard1"},
+            # Must be unique per instance: the database disk prefix is .../test-{shard}|{replica}
+            macros={"replica": "replica2_c2", "shard": "shard1"},
             with_zookeeper=True,
             stay_alive=True,
         )


### PR DESCRIPTION
`s0_0_1` and `c2.s0_0_1` both used `shard1`/`replica2`. With a remote database disk the endpoint is `.../root-db-disk/test-{shard}|{replica}`, so those two servers shared one S3 metadata prefix and raced each other while loading the `system` database: one starts, the other dies with `Code: 499. Failed to get object info ... HTTP response code: 404`, and the whole module errors out — 30 tests at once, in ~12.6% of `db disk` runs. 
In [this job](https://github.com/Altinity/ClickHouse/actions/runs/32761063417/job/97614150167) `c2.s0_0_1` came up at 07:10:33.699 and `s0_0_1` at 07:10:33.701.
`c2.s0_0_1`'s macros are not referenced by any test, so renaming its replica is enough; `s0_0_1` is left as is because it takes part in the `ReplicatedMergeTree` tests.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
