### PR TITLE
Antalya 26.6 - Fix PRs in release table missing 3rd party PRs

### DIFF
--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -260,7 +260,7 @@ def _git_log_merge_prs(
         if not m:
             continue
         pr_number, head_owner = int(m.group(1)), m.group(2)
-        if head_owner.lower() != repo.split("/")[0].lower():
+        if head_owner == 'ClickHouse':
             continue
         rows.append(
             {
@@ -362,8 +362,8 @@ def get_prs_in_release_dataframe(
     f"""
     PRs merged into branch_ref that belong in the next release notes: after the latest GitHub
     Release tag on this history, or after the oldest rebase bootstrap if no such tag exists.
-    Only merge commits whose subject has from <repo_owner>/ (e.g. from Altinity/) are included.
-    Columns: pr_number, pr_name, labels. Omits PRs labeled cicd.
+    Merge commits whose subject is from the upstream repository (ClickHouse/) are omitted.
+    Columns: pr_number, pr_name, labels.
 
     Returns (dataframe, baseline_date YYYY-MM-DD or None).
     """

--- a/.github/actions/create_workflow_report/test_report_queries.py
+++ b/.github/actions/create_workflow_report/test_report_queries.py
@@ -29,12 +29,14 @@ To capture ``expect`` for a commit:
 """
 
 import os
+import subprocess
+from unittest.mock import patch
 
 import pandas as pd
 from clickhouse_driver import Client
 from testflows.core import *
 
-from create_workflow_report import get_checks_fails
+from create_workflow_report import _git_log_merge_prs, get_checks_fails
 
 
 def check_result_matches_expect(df: pd.DataFrame, expect: list[str]) -> None:
@@ -149,10 +151,32 @@ def test_checks_fails_query(self, case_id, commit_sha, head_ref, expect):
         check_result_matches_expect(df, list(expect))
 
 
+@TestScenario
+def test_git_log_merge_prs_includes_fork_prs(self):
+    """Test PR merge history includes contributor forks."""
+    stdout = "\n".join(
+        [
+            f"{'e' * 40}\tMerge pull request #2226 from strtgbb/community-pr-failure-artifacts",
+            f"{'a' * 40}\tMerge pull request #113355 from ClickHouse/backport/26.6/112784",
+            f"{'b' * 40}\tMerge pull request #2252 from Altinity/ci/antalya-26.6/container-dns",
+        ]
+    )
+    with When("I collect fork, upstream, and Altinity pull request merges"):
+        with patch(
+            "create_workflow_report.subprocess.run",
+            return_value=subprocess.CompletedProcess([], 0, stdout=stdout),
+        ):
+            df = _git_log_merge_prs("baseline", "branch", None, "Altinity/ClickHouse")
+
+    with Then("fork and Altinity pull requests are included but upstream is omitted"):
+        assert set(df["pr_number"]) == {2226, 2252}
+
+
 @Name("test report queries")
 @TestModule
 def test_report_queries(self):
     Scenario(run=test_checks_fails_query, flags=TE)
+    Scenario(run=test_git_log_merge_prs_includes_fork_prs, flags=TE)
 
 
 if main():


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
