### PR TITLE
Antalya 26.6 - Fix Alpine CVEs

### DIFF
--- a/.github/workflows/pull_request_community.yml
+++ b/.github/workflows/pull_request_community.yml
@@ -992,6 +992,13 @@ jobs:
           path: ci/tmp/build/programs/self-extracting/clickhouse
 
 
+      - name: Upload artifact CH_AMD_RELEASE_STRIPPED
+        uses: actions/upload-artifact@v7
+        with:
+          name: CH_AMD_RELEASE_STRIPPED
+          path: ci/tmp/build/programs/self-extracting/clickhouse-stripped
+
+
       - name: Upload artifact DEB_AMD_RELEASE
         uses: actions/upload-artifact@v7
         with:
@@ -1075,6 +1082,13 @@ jobs:
         with:
           name: CH_ARM_RELEASE
           path: ci/tmp/build/programs/self-extracting/clickhouse
+
+
+      - name: Upload artifact CH_ARM_RELEASE_STRIPPED
+        uses: actions/upload-artifact@v7
+        with:
+          name: CH_ARM_RELEASE_STRIPPED
+          path: ci/tmp/build/programs/self-extracting/clickhouse-stripped
 
 
       - name: Upload artifact DEB_ARM_RELEASE

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -416,6 +416,7 @@ class JobConfigs:
             parameter=BuildTypes.AMD_RELEASE,
             provides=[
                 ArtifactNames.CH_AMD_RELEASE,
+                ArtifactNames.CH_AMD_RELEASE_STRIPPED,
                 ArtifactNames.DEB_AMD_RELEASE,
                 ArtifactNames.RPM_AMD_RELEASE,
                 ArtifactNames.TGZ_AMD_RELEASE,
@@ -427,6 +428,7 @@ class JobConfigs:
             parameter=BuildTypes.ARM_RELEASE,
             provides=[
                 ArtifactNames.CH_ARM_RELEASE,
+                ArtifactNames.CH_ARM_RELEASE_STRIPPED,
                 ArtifactNames.DEB_ARM_RELEASE,
                 ArtifactNames.RPM_ARM_RELEASE,
                 ArtifactNames.TGZ_ARM_RELEASE,

--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -107,6 +107,9 @@ RUN mkdir -p \
     && chown root:clickhouse "${DEFAULT_LOG_DIR}" \
     && chmod ugo+Xrw -R "${DEFAULT_DATA_DIR}" "${DEFAULT_LOG_DIR}" "${DEFAULT_CLIENT_CONFIG_DIR}" "${DEFAULT_SERVER_CONFIG_DIR}"
 
+RUN apk update
+RUN apk add --upgrade libssl3 libcrypto3
+
 VOLUME "${DEFAULT_DATA_DIR}"
 EXPOSE 9000 8123 9009
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Update libssl3 and libcrypto3 to fix HIGH CVEs in alpine docker image.

### Documentation entry for user-facing changes
...

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [x] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
