### PR TITLE
Antalya-25.8 - Port workflow report fixes from antalya-26.6

### DIFF
--- a/.github/actions/create_workflow_report/create_workflow_report.py
+++ b/.github/actions/create_workflow_report/create_workflow_report.py
@@ -260,7 +260,7 @@ def _git_log_merge_prs(
         if not m:
             continue
         pr_number, head_owner = int(m.group(1)), m.group(2)
-        if head_owner.lower() != repo.split("/")[0].lower():
+        if head_owner == "ClickHouse":
             continue
         rows.append(
             {
@@ -280,7 +280,9 @@ def _find_release_baseline(
     branch_ref: str, repo: str, cwd: str | None
 ) -> tuple[str | None, str | None, str | None]:
     """Return (tag_name, tag_sha, published_date YYYY-MM-DD) for the latest
-    non-draft release tag that is an ancestor of branch_ref."""
+    non-draft release tag that is an ancestor of branch_ref.
+    Version-tag refs skip the matching release so the range is previous→this tag.
+    """
     if not GITHUB_TOKEN:
         return None, None, None
     headers = {
@@ -295,6 +297,8 @@ def _find_release_baseline(
         raise Exception(
             f"GitHub API request failed: {response.status_code} {response.text}"
         )
+    parsed = _parse_release_ref(branch_ref)
+    skip_current = parsed is not None and parsed[2] is not None
     for rel in response.json():
         if rel.get("draft"):
             continue
@@ -305,6 +309,8 @@ def _find_release_baseline(
         if not tag_sha:
             continue
         if not _git_is_ancestor(tag_sha, branch_ref, cwd):
+            continue
+        if skip_current and _git_is_ancestor(branch_ref, tag_sha, cwd):
             continue
         published_at = rel.get("published_at") or rel.get("created_at") or ""
         published_date = published_at[:10] if published_at else None
@@ -362,8 +368,8 @@ def get_prs_in_release_dataframe(
     f"""
     PRs merged into branch_ref that belong in the next release notes: after the latest GitHub
     Release tag on this history, or after the oldest rebase bootstrap if no such tag exists.
-    Only merge commits whose subject has from <repo_owner>/ (e.g. from Altinity/) are included.
-    Columns: pr_number, pr_name, labels. Omits PRs labeled cicd.
+    Merge commits whose subject is from the upstream repository (ClickHouse/) are omitted.
+    Columns: pr_number, pr_name, labels.
 
     Returns (dataframe, baseline_date YYYY-MM-DD or None).
     """
@@ -387,11 +393,18 @@ def get_prs_in_release_dataframe(
         check=False,
     )
 
+    parsed = _parse_release_ref(branch_ref)
+    fetch_ref = (
+        f"refs/tags/{branch_ref}"
+        if parsed is not None and parsed[2] is not None
+        else branch_ref
+    )
+
     baseline_sha = None
     baseline_date = None
     for _ in range(DEEPEN_CAP // DEEPEN_STEP):
         subprocess.run(
-            ["git", "fetch", f"--deepen={DEEPEN_STEP}", "origin", branch_ref],
+            ["git", "fetch", f"--deepen={DEEPEN_STEP}", "origin", fetch_ref],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -456,9 +469,18 @@ def _prs_in_release_search_url(branch_name: str, baseline_date: str | None) -> s
 
 def _checks_latest_test_status_cte(commit_sha: str, branch_name: str) -> str:
     """
-    Shared filtering for gh-data.checks: anchor time excludes stateless teardown checks
-    (Stateless% + test_name not matching ^[0-9]{5}); keep rows with check_start_time
-    >= anchor so main + teardown phases are included.
+    Shared filtering for gh-data.checks: anchor time selects the latest result batch
+    per check_name.
+
+    Rows that must not set the anchor (but are still kept if their time is >= anchor):
+    - Stateless teardown: check_name LIKE 'Stateless%' AND test_name not matching ^[0-9]{5}
+    - Empty test_name: CIDB job-level parent rows
+    - Pre/Post Hooks: praktika phases with their own stopwatches; Post Hooks always runs
+      after tests and would otherwise become the sole surviving batch, hiding all FAILs
+
+    Keep rows with check_start_time >= anchor so the latest main batch and any later
+    teardown/hook rows are included. Earlier batches (failed attempts before a rerun
+    uploaded a newer uniform timestamp) are dropped.
     """
     return f"""WITH checks_with_anchor AS (
             SELECT
@@ -470,7 +492,12 @@ def _checks_latest_test_status_cte(commit_sha: str, branch_name: str) -> str:
                 check_start_time,
                 maxIf(
                     check_start_time,
-                    NOT (check_name LIKE 'Stateless%' AND NOT match(test_name, '^[0-9]{{5}}'))
+                    test_name != ''
+                    AND test_name NOT IN ('Pre Hooks', 'Post Hooks')
+                    AND NOT (
+                        check_name LIKE 'Stateless%'
+                        AND NOT match(test_name, '^[0-9]{{5}}')
+                    )
                 ) OVER (PARTITION BY check_name) AS latest_check_start_time
             FROM `gh-data`.checks
             WHERE commit_sha = '{commit_sha}' AND head_ref = '{branch_name}'
@@ -1044,11 +1071,12 @@ def backfill_skipped_statuses(
     status_data = response.json()
     skipped_jobs = []
     for job in status_data["results"]:
-        if job["status"] == "skipped" and len(job["links"]) > 0:
+        status = job["status"].lower()
+        if status == "skipped" and len(job["links"]) > 0:
             skipped_jobs.append(
                 {
                     "job_name": job["name"],
-                    "job_status": job["status"],
+                    "job_status": status,
                     "message": job["info"],
                     "results_link": job["links"][0],
                 }


### PR DESCRIPTION
Cached SKIPPED builds, tag-run PR tables, contributor-fork merges, and Post Hooks CIDB anchors were wrong on 25.8 the same way they were on 26.6.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_unit--> Unit tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
