### PR TITLE
Antalya 26.6 - Remove stateless debug dependency in regression on MasterCI workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6574,7 +6574,7 @@ jobs:
         version: ${{ fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.version.string }}
 
   RegressionTestsRelease:
-    needs: [config_workflow, build_amd_binary, stateless_tests_amd_debug_parallel]
+    needs: [config_workflow, build_amd_binary]
     if: ${{  !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'regression')}}
     uses: ./.github/workflows/regression.yml
     secrets: inherit
@@ -6586,7 +6586,7 @@ jobs:
       timeout_minutes: 210
       workflow_config: ${{ needs.config_workflow.outputs.data }}
   RegressionTestsAarch64:
-    needs: [config_workflow, build_arm_binary, stateless_tests_arm_binary_parallel]
+    needs: [config_workflow, build_arm_binary]
     if: ${{  !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'regression') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'aarch64')}}
     uses: ./.github/workflows/regression.yml
     secrets: inherit

--- a/ci/praktika/yaml_additional_templates.py
+++ b/ci/praktika/yaml_additional_templates.py
@@ -60,7 +60,7 @@ class AltinityWorkflowTemplates:
         docker_image: altinityinfra/clickhouse-keeper
         version: ${{ fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.version.string }}
 """,
-        "Regression": r"""
+        "RegressionPR": r"""
   RegressionTestsRelease:
     needs: [config_workflow, build_amd_binary, stateless_tests_amd_debug_parallel]
     if: ${{  !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'regression')}}
@@ -75,6 +75,32 @@ class AltinityWorkflowTemplates:
       workflow_config: ${{ needs.config_workflow.outputs.data }}
   RegressionTestsAarch64:
     needs: [config_workflow, build_arm_binary, stateless_tests_arm_binary_parallel]
+    if: ${{  !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'regression') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'aarch64')}}
+    uses: ./.github/workflows/regression.yml
+    secrets: inherit
+    with:
+      runner_type: altinity-regression-tester-aarch64
+      commit: {REGRESSION_HASH}
+      arch: aarch64
+      build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout_minutes: 210
+      workflow_config: ${{ needs.config_workflow.outputs.data }}
+""",
+        "Regression": r"""
+  RegressionTestsRelease:
+    needs: [config_workflow, build_amd_binary]
+    if: ${{  !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'regression')}}
+    uses: ./.github/workflows/regression.yml
+    secrets: inherit
+    with:
+      runner_type: altinity-regression-tester
+      commit: {REGRESSION_HASH}
+      arch: release
+      build_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout_minutes: 210
+      workflow_config: ${{ needs.config_workflow.outputs.data }}
+  RegressionTestsAarch64:
+    needs: [config_workflow, build_arm_binary]
     if: ${{  !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'regression') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.custom_data.ci_exclude_tags, 'aarch64')}}
     uses: ./.github/workflows/regression.yml
     secrets: inherit

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -610,8 +610,9 @@ class PullRequestPushYamlGen:
         if "GrypeScan" in self.workflow_config.additional_jobs:
             res += AltinityWorkflowTemplates.ALTINITY_JOBS["GrypeScan"]
             ALL_JOBS += "\n      - GrypeScanServer\n      - GrypeScanKeeper"
-        if "Regression" in self.workflow_config.additional_jobs:
-            res += AltinityWorkflowTemplates.ALTINITY_JOBS["Regression"].replace(
+        if "Regression" in self.workflow_config.additional_jobs or "RegressionPR" in self.workflow_config.additional_jobs:
+            regression_template = AltinityWorkflowTemplates.ALTINITY_JOBS["Regression"] if "Regression" in self.workflow_config.additional_jobs else AltinityWorkflowTemplates.ALTINITY_JOBS["RegressionPR"]
+            res += regression_template.replace(
                 "{REGRESSION_HASH}", AltinityWorkflowTemplates.REGRESSION_HASH
             )
             ALL_JOBS += (

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -163,7 +163,7 @@ workflow = Workflow.Config(
         *JobConfigs.toolchain_build_jobs,
         AltinityJobConfigs.source_upload_job,
     ],
-    additional_jobs=["GrypeScan", "Regression", "CIReport"],
+    additional_jobs=["GrypeScan", "RegressionPR", "CIReport"],
     artifacts=[
         *ArtifactConfigs.unittests_binaries,
         *ArtifactConfigs.clickhouse_binaries,


### PR DESCRIPTION
This solution is a bit kludgy, but it's simple and not a hot path

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_unit--> Unit tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
