### PR TITLE
Antalya-25.8 - Mark two integration tests as broken on TSAN

### DIFF
--- a/tests/broken_tests.yaml
+++ b/tests/broken_tests.yaml
@@ -105,6 +105,11 @@
   check_types:
   - tsan
   - asan
+- name: test_log_query_probability/test.py::test_log_quries_probability_two
+  reason: INVESTIGATE - random timeout
+  message: 'Failed: Timeout >900.0s'
+  check_types:
+  - tsan
 - name: test_grpc_protocol/test.py::test_ipv6_select_one
   reason: INVESTIGATE - Internal test timeout
   message: FutureTimeoutError
@@ -176,6 +181,10 @@
   check_types:
   - tsan
 - name: test_storage_s3_queue/test_5.py::test_create_or_replace_table
+  reason: 'INVESTIGATE: Unstable on tsan'
+  check_types:
+  - tsan
+- name: test_storage_s3_queue/test_5.py::test_persistent_processing_failed_commit_retries
   reason: 'INVESTIGATE: Unstable on tsan'
   check_types:
   - tsan


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_unit--> Unit tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
