### PR TITLE
DO NOT MERGE: CAS-S3 test GC interval 120s (CI experiment)

### DIFF
--- a/tests/config/config.d/cas_s3_storage_policy_for_merge_tree_by_default.xml
+++ b/tests/config/config.d/cas_s3_storage_policy_for_merge_tree_by_default.xml
@@ -18,11 +18,10 @@
                 <secret_access_key>clickhouse</secret_access_key>
                 <!-- Real server-local scratch dir for the write-buffer spill. -->
                 <cas_scratch_path>cas_s3_scratch/</cas_scratch_path>
-                <!-- Background GC pacing: the incarnation protocol's fence/recheck handshake
-                     replaces the old grace window (M-W D-W5); a short interval so reclamation
-                     happens during the run. -->
+                <!-- DO NOT MERGE. Experiment: 120s GC interval to compare ASan CAS-S3
+                     stateless wall time vs 5s (timeout), 60s (OOM), and GC off. -->
                 <cas_gc_enabled>1</cas_gc_enabled>
-                <cas_gc_interval_sec>5</cas_gc_interval_sec>
+                <cas_gc_interval_sec>120</cas_gc_interval_sec>
             </cas_s3>
             <!-- Optional local filesystem cache in front of the cacheless CA-S3 disk (mirrors how plain-s3
                  backs its policy with `cached_s3`). Validated: once warm it serves reads from local disk


### PR DESCRIPTION
Throwaway experiment. **Do not merge.**

Third point on the GC-interval curve for ASan CAS-S3 stateless shards. The test-disk override is **5s**; this PR sets `cas_gc_interval_sec` to **120**.

Already measured:

| Setting | PR | ASan 1/2 | ASan 2/2 |
|---|---|---|---|
| 5s (test default) | [MasterCI 32969478793](https://github.com/Altinity/ClickHouse/actions/runs/32969478793) | 6h timeout at 78% | 6h timeout at 78% |
| 60s (product default) | [#2296](https://github.com/Altinity/ClickHouse/pull/2296) | 3h14m, OOM storm | 2h59m, OOM storm |
| GC off | [#2297](https://github.com/Altinity/ClickHouse/pull/2297) | 2h07m, no OOM | 2h51m, pass |

Compare wall time of:
- `Stateless tests (amd_asan_ubsan, cas s3 storage, parallel, 1/2)`
- `Stateless tests (amd_asan_ubsan, cas s3 storage, parallel, 2/2)`

Related: https://github.com/Altinity/ClickHouse/issues/2298
Related: https://github.com/Altinity/ClickHouse/issues/2299
Related: https://github.com/Altinity/ClickHouse/pull/2296
Related: https://github.com/Altinity/ClickHouse/pull/2297

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Not for changelog.

### Documentation entry for user-facing changes
- No

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_unit--> Unit tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache
- [x] <!---ci_exclude_debug--> Debug
- [x] <!---ci_exclude_binary--> Binary
- [x] <!---ci_exclude_distributed--> Distributed plan
- [x] <!---ci_exclude_azure--> Azure
- [x] <!---ci_exclude_sequential--> Sequential
- [x] <!---ci_exclude_fuzz--> Fuzzer
- [x] <!---ci_exclude_buzzhouse--> BuzzHouse
- [x] <!---ci_exclude_stress--> Stress
- [x] <!---ci_exclude_quick--> Quick functional tests
- [x] <!---ci_exclude_install--> Install packages
- [x] <!---ci_exclude_compatibility--> Compatibility check

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_oauth--> OAuth (5m)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
