### PR TITLE
Antalya 26.6 Backport of #115832: Support decimal types for writing in data lakes

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergFieldParseHelpers.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergFieldParseHelpers.cpp
@@ -101,65 +101,73 @@ std::vector<Int64> fieldToInt64Array(const Field & value, std::string_view conte
     return result;
 }
 
+/// Iceberg store decimal values as unscaled value with two's-complement big-endian binary
+/// using the minimum number of bytes for the value
+/// Our decimal binary representation is little endian
+/// so we cannot reuse our default code for parsing it.
+///
+/// NOTE: It's very weird, but Decimal values for lower bound and upper bound
+/// are stored rounded, without fractional part. What is more strange
+/// the integer part is rounded mathematically correctly according to fractional part.
+/// Example: 17.22 -> 17, 8888.999 -> 8889, 1423.77 -> 1424.
+/// I've checked two implementations: Spark and Amazon Athena and both of them
+/// do this.
+///
+/// The problem is -- we cannot use rounded values for lower bounds and upper bounds.
+/// Example: upper_bound(x) = 17.22, but it's rounded 17.00, now condition WHERE x >= 17.21 will
+/// check rounded value and say: "Oh largest value is 17, so values bigger than 17.21 cannot be in this file,
+/// let's skip it". But it will produce incorrect result since actual value (17.22 >= 17.21) is stored in this file.
+///
+/// To handle this issue we subtract 1 from the integral part for lower_bound and add 1 to integral
+/// part of upper_bound. This produces: 17.22 -> [16.0, 18.0]. So this is more rough boundary,
+/// but at least it doesn't lead to incorrect results.
+template <typename DecimalType>
+static std::optional<Field> deserializeDecimalBound(const std::string & str, UInt32 scale, bool lower_bound)
+{
+    using NativeType = typename DecimalType::NativeType;
+    using UnsignedType = make_unsigned_t<NativeType>;
+
+    if (str.size() > sizeof(NativeType))
+        return std::nullopt;
+
+    /// Accumulate into the unsigned counterpart, pre-filled with the sign bits,
+    /// so that the sign extension comes out of the shifts themselves.
+    UnsignedType unscaled = (str[0] & 0x80) ? ~UnsignedType(0) : UnsignedType(0);
+    for (const auto byte : str)
+        unscaled = (unscaled << 8) | static_cast<UInt8>(byte);
+
+    NativeType unscaled_value = static_cast<NativeType>(unscaled);
+
+    if (scale)
+    {
+        NativeType scaler = lower_bound ? -10 : 10;
+        for (UInt32 i = 1; i < scale; ++i)
+            scaler *= 10;
+
+        unscaled_value += scaler;
+    }
+
+    return DecimalField<DecimalType>(unscaled_value, scale);
+}
+
 std::optional<Field> deserializeFieldFromBinaryRepr(const std::string & str, DataTypePtr expected_type, bool lower_bound)
 {
     auto non_nullable_type = removeNullable(expected_type);
     auto column = non_nullable_type->createColumn();
     if (WhichDataType(non_nullable_type).isDecimal())
     {
-        /// Iceberg store decimal values as unscaled value with two's-complement big-endian binary
-        /// using the minimum number of bytes for the value
-        /// Our decimal binary representation is little endian
-        /// so we cannot reuse our default code for parsing it.
-        int64_t unscaled_value = 0;
+        if (str.empty())
+            return std::nullopt;
 
-        // Convert from big-endian to signed int
-        for (const auto byte : str)
-            unscaled_value = (unscaled_value << 8) | static_cast<uint8_t>(byte);
-
-        /// Add sign
-        if (str[0] & 0x80)
-        {
-            int64_t sign_extension = -1;
-            sign_extension <<= (str.size() * 8);
-            unscaled_value |= sign_extension;
-        }
-
-        /// NOTE: It's very weird, but Decimal values for lower bound and upper bound
-        /// are stored rounded, without fractional part. What is more strange
-        /// the integer part is rounded mathematically correctly according to fractional part.
-        /// Example: 17.22 -> 17, 8888.999 -> 8889, 1423.77 -> 1424.
-        /// I've checked two implementations: Spark and Amazon Athena and both of them
-        /// do this.
-        ///
-        /// The problem is -- we cannot use rounded values for lower bounds and upper bounds.
-        /// Example: upper_bound(x) = 17.22, but it's rounded 17.00, now condition WHERE x >= 17.21 will
-        /// check rounded value and say: "Oh largest value is 17, so values bigger than 17.21 cannot be in this file,
-        /// let's skip it". But it will produce incorrect result since actual value (17.22 >= 17.21) is stored in this file.
-        ///
-        /// To handle this issue we subtract 1 from the integral part for lower_bound and add 1 to integral
-        /// part of upper_bound. This produces: 17.22 -> [16.0, 18.0]. So this is more rough boundary,
-        /// but at least it doesn't lead to incorrect results.
-        if (int32_t scale = getDecimalScale(*non_nullable_type))
-        {
-            int64_t scaler = lower_bound ? -10 : 10;
-            while (--scale)
-                scaler *= 10;
-
-            unscaled_value += scaler;
-        }
-
-        if (const auto * decimal_type = checkDecimal<Decimal32>(*non_nullable_type))
-        {
-            DecimalField<Decimal32> result(static_cast<Int32>(unscaled_value), decimal_type->getScale());
-            return result;
-        }
-        if (const auto * decimal_type = checkDecimal<Decimal64>(*non_nullable_type))
-        {
-            DecimalField<Decimal64> result(unscaled_value, decimal_type->getScale());
-            return result;
-        }
-
+        const UInt32 scale = getDecimalScale(*non_nullable_type);
+        if (checkDecimal<Decimal32>(*non_nullable_type))
+            return deserializeDecimalBound<Decimal32>(str, scale, lower_bound);
+        if (checkDecimal<Decimal64>(*non_nullable_type))
+            return deserializeDecimalBound<Decimal64>(str, scale, lower_bound);
+        if (checkDecimal<Decimal128>(*non_nullable_type))
+            return deserializeDecimalBound<Decimal128>(str, scale, lower_bound);
+        if (checkDecimal<Decimal256>(*non_nullable_type))
+            return deserializeDecimalBound<Decimal256>(str, scale, lower_bound);
         return std::nullopt;
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -135,6 +135,10 @@ bool canDumpIcebergStats(const Field & field, DataTypePtr type)
         case TypeIndex::Time:
         case TypeIndex::Time64:
         case TypeIndex::String:
+        case TypeIndex::Decimal32:
+        case TypeIndex::Decimal64:
+        case TypeIndex::Decimal128:
+        case TypeIndex::Decimal256:
             return true;
         default:
             return false;
@@ -189,10 +193,96 @@ Int64 getTimeValueInMicroseconds(const Field & field, DataTypePtr type)
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected Time or Time64, got {}", type->getName());
 }
 
+template <typename DecimalType>
+std::vector<uint8_t> dumpDecimalValue(const Field & field)
+{
+    using NativeType = typename DecimalType::NativeType;
+
+    std::vector<uint8_t> bytes;
+    if (field.getType() == Field::Types::String)
+    {
+        /// A decimal read back from an existing manifest during a manifest rewrite: ClickHouse parses
+        /// the Avro `fixed` of a decimal as a `String`, so the value is already the unscaled value in
+        /// two's-complement big-endian form; it only needs re-trimming to the minimum number of bytes.
+        const auto & str = field.safeGet<String>();
+        if (str.empty() || str.size() > sizeof(NativeType))
+            throw Exception(
+                ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
+                "Iceberg decimal value read back from a manifest is {} bytes long, which does not fit into {} bytes of the declared type",
+                str.size(),
+                sizeof(NativeType));
+        bytes.assign(str.begin(), str.end());
+    }
+    else
+    {
+        const NativeType unscaled_value = field.safeGet<DecimalField<DecimalType>>().getValue().value;
+
+        bytes.resize(sizeof(NativeType));
+        for (size_t i = 0; i < sizeof(NativeType); ++i)
+            bytes[sizeof(NativeType) - 1 - i] = static_cast<uint8_t>(static_cast<UInt64>((unscaled_value >> (8 * i)) & NativeType(0xFF)));
+    }
+
+    size_t first = 0;
+    while (first + 1 < bytes.size()
+           && ((bytes[first] == 0x00 && (bytes[first + 1] & 0x80) == 0) || (bytes[first] == 0xFF && (bytes[first + 1] & 0x80) != 0)))
+        ++first;
+
+    return std::vector<uint8_t>(bytes.begin() + first, bytes.end());
+}
+
+template <typename DecimalType>
+avro::GenericDatum makeDecimalFixedDatum(const Field & field, const avro::NodePtr & schema)
+{
+    using NativeType = typename DecimalType::NativeType;
+
+    if (schema->type() != avro::AVRO_FIXED)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Iceberg decimal partition values are written as an Avro `fixed`, but the manifest schema declares {}",
+            avro::toString(schema->type()));
+
+    const size_t size = schema->fixedSize();
+    std::vector<uint8_t> bytes;
+    if (field.getType() == Field::Types::String)
+    {
+        /// A partition value read back from an existing manifest during a manifest rewrite:
+        /// ClickHouse parses an Avro `fixed` as a `String`, so the value is already the unscaled
+        /// value in two's-complement big-endian form; re-pad it to this schema's width.
+        const auto & str = field.safeGet<String>();
+        if (str.empty() || str.size() > size)
+            throw Exception(
+                ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
+                "Iceberg decimal partition value read back from a manifest is {} bytes long, which does not fit into the {}-byte `fixed` of the manifest schema",
+                str.size(),
+                size);
+        bytes.assign(size, (str[0] & 0x80) ? 0xFF : 0x00);
+        std::copy(str.begin(), str.end(), bytes.end() - str.size());
+    }
+    else
+    {
+        const NativeType unscaled_value = field.safeGet<DecimalField<DecimalType>>().getValue().value;
+        bytes.assign(size, unscaled_value < 0 ? 0xFF : 0x00);
+        for (size_t i = 0; i < size && i < sizeof(NativeType); ++i)
+            bytes[size - 1 - i] = static_cast<uint8_t>(static_cast<UInt64>((unscaled_value >> (8 * i)) & NativeType(0xFF)));
+    }
+
+    avro::GenericDatum datum(schema);
+    datum.value<avro::GenericFixed>().value() = std::move(bytes);
+    return datum;
+}
+
 std::vector<uint8_t> dumpFieldToBytes(const Field & field, DataTypePtr type)
 {
     switch (type->getTypeId())
     {
+        case TypeIndex::Decimal32:
+            return dumpDecimalValue<Decimal32>(field);
+        case TypeIndex::Decimal64:
+            return dumpDecimalValue<Decimal64>(field);
+        case TypeIndex::Decimal128:
+            return dumpDecimalValue<Decimal128>(field);
+        case TypeIndex::Decimal256:
+            return dumpDecimalValue<Decimal256>(field);
         case TypeIndex::Nullable:
             return dumpFieldToBytes(field, assert_cast<const DataTypeNullable *>(type.get())->getNestedType());
         case TypeIndex::Int32:
@@ -444,32 +534,34 @@ static void extendSchemaForPartitions(
     /// concrete Avro type, so for a Nullable partition column it goes inside the
     /// `["null", T]` union branch, not on the union itself (an annotated union is not
     /// a valid Avro schema and makes the manifest schema fail to compile).
-    auto make_annotated_type = [](DataTypePtr type) -> Poco::Dynamic::Var
+    auto make_annotated_type = [](DataTypePtr type, Int32 field_id) -> Poco::Dynamic::Var
     {
         auto logical_type = getAvroLogicalType(type);
         if (logical_type.isEmpty())
-            return getAvroType(type);
+            return getAvroType(type, field_id);
 
         Poco::JSON::Object::Ptr type_field = new Poco::JSON::Object;
-        type_field->set(Iceberg::f_type, getAvroType(type));
+        type_field->set(Iceberg::f_type, getAvroType(type, field_id));
         type_field->set(Iceberg::f_logicalType, logical_type);
         return type_field;
     };
 
     for (size_t i = 0; i < partition_columns.size(); ++i)
     {
+        const Int32 field_id = static_cast<Int32>(1000 + i);
+
         Poco::JSON::Object::Ptr field = new Poco::JSON::Object;
-        field->set(Iceberg::f_field_id, 1000 + i);
+        field->set(Iceberg::f_field_id, field_id);
         field->set(Iceberg::f_name, partition_columns[i]);
         if (partition_types[i]->isNullable())
         {
             Poco::JSON::Array::Ptr union_array = new Poco::JSON::Array;
             union_array->add("null");
-            union_array->add(make_annotated_type(removeNullable(partition_types[i])));
+            union_array->add(make_annotated_type(removeNullable(partition_types[i]), field_id));
             field->set(Iceberg::f_type, union_array);
         }
         else
-            field->set(Iceberg::f_type, make_annotated_type(partition_types[i]));
+            field->set(Iceberg::f_type, make_annotated_type(partition_types[i], field_id));
         partition_fields->add(field);
     }
 
@@ -686,13 +778,38 @@ void generateManifestFile(
         avro::GenericRecord & partition_record = data_file.field("partition").value<avro::GenericRecord>();
         for (size_t i = 0; i < partition_columns.size(); ++i)
         {
+            size_t field_index = 0;
+            if (!partition_record.schema()->nameIndex(partition_columns[i], field_index))
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Partition field {} not found in manifest schema",
+                    partition_columns[i]);
+
+            const avro::NodePtr & field_schema = partition_record.schema()->leafAt(static_cast<UInt32>(field_index));
+
             /// Build the Avro datum that holds the actual partition value (without
             /// the surrounding union). Throws on an unsupported value type.
-            auto make_value_datum = [&]() -> avro::GenericDatum
+            auto make_value_datum = [&](const avro::NodePtr & value_schema) -> avro::GenericDatum
             {
                 auto partition_time_type = getTimeTypeOrNull(partition_types[i]);
                 if (partition_time_type)
                     return avro::GenericDatum(getTimeValueInMicroseconds(partition_values[i], partition_types[i]));
+
+                /// Decimals are dispatched on the column type rather than on the `Field` type, because
+                /// `DateTime64` also lives in a `DecimalField` while Iceberg writes it as a plain `long`.
+                switch (removeNullable(partition_types[i])->getTypeId())
+                {
+                    case TypeIndex::Decimal32:
+                        return makeDecimalFixedDatum<Decimal32>(partition_values[i], value_schema);
+                    case TypeIndex::Decimal64:
+                        return makeDecimalFixedDatum<Decimal64>(partition_values[i], value_schema);
+                    case TypeIndex::Decimal128:
+                        return makeDecimalFixedDatum<Decimal128>(partition_values[i], value_schema);
+                    case TypeIndex::Decimal256:
+                        return makeDecimalFixedDatum<Decimal256>(partition_values[i], value_schema);
+                    default:
+                        break;
+                }
 
                 switch (partition_values[i].getType())
                 {
@@ -724,14 +841,7 @@ void generateManifestFile(
                 /// unions. NULL selects branch 0; a concrete value selects branch 1.
                 /// See issue #105852: before this change, NULL partition values were
                 /// silently written as 0 because the schema was non-nullable.
-                size_t field_index = 0;
-                if (!partition_record.schema()->nameIndex(partition_columns[i], field_index))
-                    throw Exception(
-                        ErrorCodes::LOGICAL_ERROR,
-                        "Partition field {} not found in manifest schema",
-                        partition_columns[i]);
-
-                const avro::NodePtr & union_schema = partition_record.schema()->leafAt(static_cast<UInt32>(field_index));
+                const avro::NodePtr & union_schema = field_schema;
 
                 avro::GenericUnion union_field(union_schema);
                 if (is_null_value)
@@ -741,7 +851,7 @@ void generateManifestFile(
                 else
                 {
                     union_field.selectBranch(1);
-                    union_field.datum() = make_value_datum();
+                    union_field.datum() = make_value_datum(union_schema->leafAt(1));
                 }
                 partition_record.field(partition_columns[i]) = avro::GenericDatum(union_schema, union_field);
             }
@@ -752,7 +862,7 @@ void generateManifestFile(
                         ErrorCodes::LOGICAL_ERROR,
                         "Got NULL partition value for non-nullable partition column {}",
                         partition_columns[i]);
-                partition_record.field(partition_columns[i]) = make_value_datum();
+                partition_record.field(partition_columns[i]) = make_value_datum(field_schema);
             }
         }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.cpp
@@ -192,6 +192,20 @@ Field decodePartitionDecimalByType(const String & bytes, const IDataType & type)
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected decimal type {} of an Iceberg partition column", type.getName());
 }
 
+/// ClickHouse writes a `DateTime64` partition value into the manifest as a bare Avro `long`, without the
+/// `timestamp-micros` annotation that other engines put there, so it arrives here as a plain integer while
+/// the partition key column, taken from the Iceberg schema, is a `DateTime64`. Comparing that raw count
+/// against the scaled decimal bounds of the key condition is off by the scale multiplier, so reinterpret
+/// the integer at the key's own scale: an Iceberg `timestamp` holds microseconds and maps to
+/// `DateTime64(6)`, a `timestamp_ns` holds nanoseconds and maps to `DateTime64(9)`.
+Field reinterpretPartitionDateTime64(const Field & field, const IDataType & type)
+{
+    const Int64 value = field.getType() == Field::Types::UInt64
+        ? static_cast<Int64>(field.safeGet<UInt64>())
+        : field.safeGet<Int64>();
+    return DecimalField<DateTime64>(value, getDecimalScale(type));
+}
+
 }
 
 PruningReturnStatus ManifestFilesPruner::canBePruned(
@@ -210,6 +224,9 @@ PruningReturnStatus ManifestFilesPruner::canBePruned(
                 field = POSITIVE_INFINITY;
             else if (field.getType() == Field::Types::String && WhichDataType(type).isDecimal())
                 field = decodePartitionDecimalByType(field.safeGet<String>(), *type);
+            else if (WhichDataType(type).isDateTime64()
+                && (field.getType() == Field::Types::Int64 || field.getType() == Field::Types::UInt64))
+                field = reinterpretPartitionDateTime64(field, *type);
         }
 
         bool can_be_true = partition_key_condition->mayBeTrueInRange(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.cpp
@@ -7,6 +7,7 @@
 #include <Columns/ColumnsDateTime.h>
 #include <Common/DateLUTImpl.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesDecimal.h>
 #include <Common/logger_useful.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
@@ -23,6 +24,12 @@
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Utils.h>
 
 using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int ICEBERG_SPECIFICATION_VIOLATION;
+    extern const int LOGICAL_ERROR;
+}
 
 namespace DB::Iceberg
 {
@@ -144,6 +151,49 @@ ManifestFilesPruner::ManifestFilesPruner(
     }
 }
 
+namespace
+{
+
+/// Iceberg keeps a decimal partition value as an Avro `fixed`: the unscaled value in two's-complement
+/// big-endian form, using the minimum number of bytes. ClickHouse reads such a `fixed` as a `String`,
+/// so restore the decimal here. Accumulate into the unsigned counterpart, pre-filled with the sign
+/// bits, so that the sign extension comes out of the shifts themselves.
+template <typename DecimalType>
+Field decodePartitionDecimal(const String & bytes, const IDataType & type)
+{
+    using NativeType = typename DecimalType::NativeType;
+    using UnsignedType = make_unsigned_t<NativeType>;
+
+    if (bytes.empty() || bytes.size() > sizeof(NativeType))
+        throw Exception(
+            ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
+            "Iceberg partition value of a decimal column is {} bytes long, which does not fit into {} bytes of {}",
+            bytes.size(),
+            sizeof(NativeType),
+            type.getName());
+
+    UnsignedType unscaled_value = (bytes[0] & 0x80) ? ~UnsignedType(0) : UnsignedType(0);
+    for (const auto byte : bytes)
+        unscaled_value = (unscaled_value << 8) | static_cast<UInt8>(byte);
+
+    return DecimalField<DecimalType>(static_cast<NativeType>(unscaled_value), getDecimalScale(type));
+}
+
+Field decodePartitionDecimalByType(const String & bytes, const IDataType & type)
+{
+    if (checkDecimal<Decimal32>(type))
+        return decodePartitionDecimal<Decimal32>(bytes, type);
+    if (checkDecimal<Decimal64>(type))
+        return decodePartitionDecimal<Decimal64>(bytes, type);
+    if (checkDecimal<Decimal128>(type))
+        return decodePartitionDecimal<Decimal128>(bytes, type);
+    if (checkDecimal<Decimal256>(type))
+        return decodePartitionDecimal<Decimal256>(bytes, type);
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected decimal type {} of an Iceberg partition column", type.getName());
+}
+
+}
+
 PruningReturnStatus ManifestFilesPruner::canBePruned(
     const ProcessedManifestFileEntryPtr & entry, const std::unordered_map<Int32, DB::Range> & entry_hyperrectangles) const
 {
@@ -151,11 +201,15 @@ PruningReturnStatus ManifestFilesPruner::canBePruned(
     {
         const auto & partition_value = entry->parsed_entry->partition_key_value;
         std::vector<FieldRef> index_value(partition_value.begin(), partition_value.end());
-        for (auto & field : index_value)
+        for (size_t i = 0; i < index_value.size(); ++i)
         {
+            auto & field = index_value[i];
+            const auto & type = partition_key->data_types.at(i);
             // NULL_LAST
             if (field.isNull())
                 field = POSITIVE_INFINITY;
+            else if (field.getType() == Field::Types::String && WhichDataType(type).isDecimal())
+                field = decodePartitionDecimalByType(field.safeGet<String>(), *type);
         }
 
         bool can_be_true = partition_key_condition->mayBeTrueInRange(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -576,7 +576,16 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
         case TypeIndex::Decimal64:
         case TypeIndex::Decimal128:
         case TypeIndex::Decimal256:
-            return {fmt::format("decimal({}, {})", getDecimalPrecision(*type), getDecimalScale(*type)), true};
+        {
+            /// The Iceberg spec caps `decimal(P, S)` at precision 38, while ClickHouse `Decimal256` goes up to 76.
+            /// A wider precision has no Iceberg representation, so refuse it instead of writing metadata that
+            /// other engines reject.
+            const UInt32 precision = getDecimalPrecision(*type);
+            if (precision > 38)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Iceberg decimal type supports precision up to 38, got {}", precision);
+            return {fmt::format("decimal({}, {})", precision, getDecimalScale(*type)), true};
+        }
         case TypeIndex::Tuple:
         {
             auto type_tuple = std::static_pointer_cast<const DataTypeTuple>(type);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -516,6 +516,22 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
     return json.extract<Poco::JSON::Object::Ptr>();
 }
 
+/// Iceberg stores a decimal as its unscaled value in two's-complement big-endian form, in the
+/// minimum number of bytes that can hold every value of the declared precision. One bit of that
+/// space is taken by the sign, hence `8 * bytes - 1`.
+static size_t icebergDecimalRequiredBytes(UInt32 precision)
+{
+    UInt256 max_value = 1;
+    for (UInt32 i = 0; i < precision; ++i)
+        max_value *= 10;
+    max_value -= 1;
+
+    size_t bytes = 1;
+    while (bytes < sizeof(UInt256) && (max_value >> (8 * bytes - 1)) != 0)
+        ++bytes;
+    return bytes;
+}
+
 /// Returns type and required
 std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter)
 {
@@ -560,13 +576,7 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
         case TypeIndex::Decimal64:
         case TypeIndex::Decimal128:
         case TypeIndex::Decimal256:
-        {
-            auto precision = getDecimalPrecision(*type);
-            if (precision > 38)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                    "Iceberg decimal type supports precision up to 38, got {}", precision);
-            return {"decimal(" + std::to_string(precision) + ", " + std::to_string(getDecimalScale(*type)) + ")", true};
-        }
+            return {fmt::format("decimal({}, {})", getDecimalPrecision(*type), getDecimalScale(*type)), true};
         case TypeIndex::Tuple:
         {
             auto type_tuple = std::static_pointer_cast<const DataTypeTuple>(type);
@@ -634,7 +644,7 @@ std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & ite
     }
 }
 
-Poco::Dynamic::Var getAvroType(DataTypePtr type)
+Poco::Dynamic::Var getAvroType(DataTypePtr type, Int32 field_id)
 {
     switch (type->getTypeId())
     {
@@ -668,6 +678,25 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
         case TypeIndex::String:
         case TypeIndex::UUID:
             return "string";
+        case TypeIndex::Decimal32:
+        case TypeIndex::Decimal64:
+        case TypeIndex::Decimal128:
+        case TypeIndex::Decimal256:
+        {
+            const UInt32 precision = getDecimalPrecision(*type);
+            const UInt32 scale = getDecimalScale(*type);
+
+            Poco::JSON::Object::Ptr decimal_type = new Poco::JSON::Object;
+            decimal_type->set("type", "fixed");
+            decimal_type->set("size", icebergDecimalRequiredBytes(precision));
+            /// `fixed` is a named Avro type, so the name must be unique within the manifest schema:
+            /// two partition fields of the same decimal shape must not both define `decimal_P_S`.
+            decimal_type->set("name", fmt::format("decimal_{}_{}_{}", precision, scale, field_id));
+            decimal_type->set("logicalType", "decimal");
+            decimal_type->set("precision", precision);
+            decimal_type->set("scale", scale);
+            return decimal_type;
+        }
         case TypeIndex::Nullable:
         {
             /// Iceberg manifest partition fields backed by ClickHouse `Nullable(T)`
@@ -676,7 +705,7 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
             auto type_nullable = std::static_pointer_cast<const DataTypeNullable>(type);
             Poco::JSON::Array::Ptr union_array = new Poco::JSON::Array;
             union_array->add("null");
-            union_array->add(getAvroType(type_nullable->getNestedType()));
+            union_array->add(getAvroType(type_nullable->getNestedType(), field_id));
             return union_array;
         }
         default:

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.h
@@ -93,7 +93,7 @@ Poco::JSON::Object::Ptr getMetadataJSONObject(
 
 
 std::pair<Poco::Dynamic::Var, bool> getIcebergType(DataTypePtr type, Int32 & iter);
-Poco::Dynamic::Var getAvroType(DataTypePtr type);
+Poco::Dynamic::Var getAvroType(DataTypePtr type, Int32 field_id);
 Poco::Dynamic::Var getAvroLogicalType(DataTypePtr type);
 
 /// Converts a ClickHouse PARTITION BY AST into the corresponding Iceberg partition-spec JSON object.

--- a/tests/integration/test_storage_iceberg_with_spark/test_writes.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes.py
@@ -5,6 +5,7 @@ import pytest
 import pyarrow.parquet as pq
 
 from helpers.iceberg_utils import (
+    check_validity_and_get_prunned_files_general,
     create_iceberg_table,
     default_upload_directory,
     get_uuid_str,
@@ -351,3 +352,431 @@ def test_writes_restart(started_cluster_iceberg_with_spark, format_version, stor
     instance.query(f"INSERT INTO {TABLE_NAME} VALUES ('after restart');", settings={"allow_experimental_insert_into_iceberg": 1})
     assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == 'after restart\nbefore restart\n'
 
+
+
+DECIMAL_COLUMNS = [
+    ("small", "Decimal(7, 2)", "decimal(7, 2)", ["17.22", "-8888.99", "0.01", "0.00"]),
+    ("medium", "Decimal(18, 4)", "decimal(18, 4)", ["99999999999999.9999", "-99999999999999.9999", "1.0000", "0.0000"]),
+    ("large", "Decimal(38, 10)", "decimal(38, 10)", ["9999999999999999999999999999.9999999999", "-1.0000000001", "0.0000000000", "2.5000000000"]),
+]
+
+
+def read_latest_metadata(local_dir):
+    metadata_files = sorted(
+        glob.glob(os.path.join(local_dir, "metadata", "*.metadata.json")),
+        key=os.path.getmtime,
+    )
+    assert metadata_files
+    with open(metadata_files[-1]) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("format_version", ["1", "2"])
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_decimal(started_cluster_iceberg_with_spark, format_version, storage_type):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    TABLE_NAME = "test_writes_decimal_" + storage_type + "_" + format_version + "_" + get_uuid_str()
+    local_dir = f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}"
+
+    schema = "(" + ", ".join(f"{name} {ch_type}" for name, ch_type, _, _ in DECIMAL_COLUMNS) + ")"
+    create_iceberg_table(
+        storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark, schema, format_version
+    )
+
+    rows = [
+        tuple(values[i] for _, _, _, values in DECIMAL_COLUMNS)
+        for i in range(len(DECIMAL_COLUMNS[0][3]))
+    ]
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES {', '.join('(' + ', '.join(row) + ')' for row in rows)}",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+
+    expected = "".join("\t".join(row) + "\n" for row in sorted(rows, key=lambda row: [float(value) for value in row]))
+    assert (
+        instance.query(
+            f"SELECT * FROM {TABLE_NAME} ORDER BY ALL",
+            settings={"output_format_decimal_trailing_zeros": 1},
+        )
+        == expected
+    )
+
+    type_names = ", ".join(f"toTypeName({name})" for name, _, _, _ in DECIMAL_COLUMNS)
+    assert instance.query(f"SELECT {type_names} FROM {TABLE_NAME} LIMIT 1") == "\t".join(
+        ch_type for _, ch_type, _, _ in DECIMAL_COLUMNS
+    ) + "\n"
+
+    default_download_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"{local_dir}/",
+        f"{local_dir}/",
+    )
+
+    metadata = read_latest_metadata(local_dir)
+    current_schema = next(
+        s for s in metadata["schemas"] if s["schema-id"] == metadata["current-schema-id"]
+    )
+    written_types = {field["name"]: field["type"] for field in current_schema["fields"]}
+    assert written_types == {name: iceberg_type for name, _, iceberg_type, _ in DECIMAL_COLUMNS}
+
+    data_files = [
+        f
+        for f in glob.glob(os.path.join(local_dir, "data", "**", "*.parquet"), recursive=True)
+        if "delete" not in os.path.basename(f)
+    ]
+    assert data_files
+    for path in data_files:
+        parquet_schema = pq.read_schema(path)
+        for name, ch_type, _, _ in DECIMAL_COLUMNS:
+            field_type = parquet_schema.field(name).type
+            precision, scale = ch_type[len("Decimal("):-1].split(", ")
+            assert str(field_type) == f"decimal128({precision}, {scale})", (name, str(field_type))
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_decimal_read_by_spark(started_cluster_iceberg_with_spark, storage_type):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = "test_writes_decimal_spark_" + storage_type + "_" + get_uuid_str()
+    local_dir = f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}"
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_with_spark,
+        "(id Int32, price Decimal(18, 4))",
+        2,
+    )
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES (1, 17.2200), (2, -8888.9900), (3, 99999999999999.9999)",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+
+    default_download_directory(
+        started_cluster_iceberg_with_spark,
+        storage_type,
+        f"{local_dir}/",
+        f"{local_dir}/",
+    )
+
+    metadata_versions = [
+        int(os.path.basename(path).split(".")[0][1:])
+        for path in glob.glob(os.path.join(local_dir, "metadata", "v*.metadata.json"))
+    ]
+    with open(os.path.join(local_dir, "metadata", "version-hint.text"), "wb") as f:
+        f.write(str(max(metadata_versions)).encode())
+
+    spark_rows = spark.read.format("iceberg").load(local_dir).orderBy("id").collect()
+    assert [str(row["price"]) for row in spark_rows] == [
+        "17.2200",
+        "-8888.9900",
+        "99999999999999.9999",
+    ]
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_decimal_minmax_pruning(started_cluster_iceberg_with_spark, storage_type):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    TABLE_NAME = "test_writes_decimal_minmax_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_with_spark,
+        "(small Decimal(7, 2), wide Decimal(18, 4), control Int64)",
+        2,
+    )
+
+    # One file per insert, so the min/max bounds of every file cover exactly one row. `control`
+    # carries the same magnitudes in a type whose bounds are known to prune, to tell a decimal-specific
+    # gap apart from a table that simply cannot be pruned.
+    for small, wide, control in [
+        ("1.00", "1.0000", "1"),
+        ("500.00", "99999999999999.9999", "500"),
+        ("-8888.99", "-99999999999999.9999", "-8888"),
+    ]:
+        instance.query(
+            f"INSERT INTO {TABLE_NAME} VALUES ({small}, {wide}, {control})",
+            settings={"allow_insert_into_iceberg": 1},
+        )
+
+    base_settings = {
+        "input_format_parquet_bloom_filter_push_down": 0,
+        "input_format_parquet_filter_push_down": 0,
+        "output_format_decimal_trailing_zeros": 1,
+    }
+
+    def measure(predicate, index):
+        query = f"SELECT * FROM {TABLE_NAME} {predicate} ORDER BY ALL"
+        without_pruning = instance.query(
+            query, settings={**base_settings, "use_iceberg_partition_pruning": 0}
+        )
+        query_id = f"{TABLE_NAME}-{index}"
+        with_pruning = instance.query(
+            query,
+            query_id=query_id,
+            settings={**base_settings, "use_iceberg_partition_pruning": 1},
+        )
+        instance.query("SYSTEM FLUSH LOGS")
+        pruned = instance.query(
+            f"SELECT ProfileEvents['IcebergMinMaxIndexPrunedFiles'] FROM system.query_log "
+            f"WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
+        ).strip()
+        return without_pruning, with_pruning, int(pruned or 0)
+
+    predicates = [
+        "",
+        "WHERE control < -1000",
+        "WHERE small < -1000",
+        "WHERE small > 100",
+        "WHERE wide > 1000000",
+        "WHERE wide < -1000000",
+    ]
+    measured = {
+        predicate: measure(predicate, index) for index, predicate in enumerate(predicates)
+    }
+
+    # Pruning must never change the result, whatever it manages to skip.
+    for predicate, (without_pruning, with_pruning, _) in measured.items():
+        assert without_pruning == with_pruning, predicate
+
+    assert measured[""][2] == 0
+    assert measured["WHERE control < -1000"][2] == 2
+    assert measured["WHERE small < -1000"][2] == 2
+    assert measured["WHERE small > 100"][2] == 2
+    # The bounds of `wide` take all 8 bytes of the underlying Int64.
+    assert measured["WHERE wide > 1000000"][2] == 2
+    assert measured["WHERE wide < -1000000"][2] == 2
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_decimal_partition(started_cluster_iceberg_with_spark, storage_type):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    TABLE_NAME = "test_writes_decimal_partition_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_with_spark,
+        "(tag Decimal(7, 2), number Int64)",
+        2,
+        partition_by="tag",
+    )
+
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES (1.50, 10), (2.50, 20), (1.50, 30), (-3.25, 40)",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+    assert (
+        instance.query(
+            f"SELECT * FROM {TABLE_NAME} ORDER BY ALL",
+            settings={"output_format_decimal_trailing_zeros": 1},
+        )
+        == "-3.25\t40\n1.50\t10\n1.50\t30\n2.50\t20\n"
+    )
+
+    def prunned_files(select_expression):
+        return check_validity_and_get_prunned_files_general(
+            instance,
+            TABLE_NAME,
+            {"use_iceberg_partition_pruning": 0},
+            {"use_iceberg_partition_pruning": 1},
+            "IcebergPartitionPrunedFiles",
+            select_expression,
+        )
+
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == 0
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} WHERE tag < 0 ORDER BY ALL") == 2
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} WHERE tag > 2 ORDER BY ALL") == 2
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_decimal_partition_not_first(started_cluster_iceberg_with_spark, storage_type):
+    """Every partition field must be serialized against its own Avro node.
+
+    The decimal is deliberately neither the first nor the last partition field, and it is
+    surrounded by fields of other shapes: a plain `long`, a `Nullable` union whose branch has to
+    be picked from the union's own schema, and a `DateTime64`, which shares `DecimalField` with a
+    decimal but goes into the manifest as a `long`.
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    TABLE_NAME = "test_writes_decimal_partition_not_first_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_with_spark,
+        "(id Int64, note Nullable(String), tag Decimal(7, 2), ts DateTime64(6), number Int64)",
+        2,
+        partition_by="(id, note, tag, ts)",
+    )
+
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES "
+        f"(1, 'a', 1.50, '2025-08-27 12:34:56.000000', 10), "
+        f"(1, NULL, -3.25, '2025-08-27 12:34:56.000000', 20), "
+        f"(2, 'a', 1.50, '2026-08-27 12:34:56.000000', 30)",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+    assert (
+        instance.query(
+            f"SELECT * FROM {TABLE_NAME} ORDER BY ALL",
+            settings={"output_format_decimal_trailing_zeros": 1},
+        )
+        # `ORDER BY` puts NULLs last.
+        == "1\ta\t1.50\t2025-08-27 12:34:56.000000\t10\n"
+        "1\t\\N\t-3.25\t2025-08-27 12:34:56.000000\t20\n"
+        "2\ta\t1.50\t2026-08-27 12:34:56.000000\t30\n"
+    )
+
+    def prunned_files(select_expression):
+        return check_validity_and_get_prunned_files_general(
+            instance,
+            TABLE_NAME,
+            {"use_iceberg_partition_pruning": 0},
+            {"use_iceberg_partition_pruning": 1},
+            "IcebergPartitionPrunedFiles",
+            select_expression,
+        )
+
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == 0
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} WHERE tag < 0 ORDER BY ALL") == 2
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} WHERE tag > 1 ORDER BY ALL") == 1
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} WHERE id = 2 ORDER BY ALL") == 2
+    assert (
+        prunned_files(f"SELECT * FROM {TABLE_NAME} WHERE ts > '2026-01-01 00:00:00' ORDER BY ALL")
+        == 2
+    )
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_decimal_partition_same_shape(started_cluster_iceberg_with_spark, storage_type):
+    """Two partition columns of the same decimal shape must not collide on the Avro `fixed` name.
+
+    `fixed` is a named Avro type whose generated name used to depend only on `(precision, scale)`,
+    so a spec like `PARTITION BY (price_a, price_b)` with two `Decimal(18, 4)` columns emitted two
+    definitions of the same name into one manifest schema and failed schema compilation on insert.
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    TABLE_NAME = "test_writes_decimal_partition_same_shape_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_with_spark,
+        "(price_a Decimal(18, 4), price_b Decimal(18, 4), number Int64)",
+        2,
+        partition_by="(price_a, price_b)",
+    )
+
+    instance.query(
+        f"INSERT INTO {TABLE_NAME} VALUES (1.5000, 2.5000, 10), (-3.2500, 4.7500, 20)",
+        settings={"allow_insert_into_iceberg": 1},
+    )
+    assert (
+        instance.query(
+            f"SELECT * FROM {TABLE_NAME} ORDER BY ALL",
+            settings={"output_format_decimal_trailing_zeros": 1},
+        )
+        == "-3.2500\t4.7500\t20\n1.5000\t2.5000\t10\n"
+    )
+
+    def prunned_files(select_expression):
+        return check_validity_and_get_prunned_files_general(
+            instance,
+            TABLE_NAME,
+            {"use_iceberg_partition_pruning": 0},
+            {"use_iceberg_partition_pruning": 1},
+            "IcebergPartitionPrunedFiles",
+            select_expression,
+        )
+
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == 0
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} WHERE price_a < 0 ORDER BY ALL") == 1
+    assert prunned_files(f"SELECT * FROM {TABLE_NAME} WHERE price_b > 3 ORDER BY ALL") == 1
+
+
+@pytest.mark.parametrize("storage_type", ["s3", "local"])
+def test_writes_decimal_wide_minmax_pruning(started_cluster_iceberg_with_spark, storage_type):
+    """Min/max statistics of `Decimal128` and `Decimal256` columns must be consumable by the reader.
+
+    The bounds are longer than 8 bytes, which the bound deserializer used to reject, silently
+    disabling `IcebergMinMaxIndexPrunedFiles` for these widths. `control` carries the same
+    magnitudes in a type whose bounds are known to prune, to tell a decimal-specific gap apart
+    from a table that simply cannot be pruned.
+    """
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    TABLE_NAME = "test_writes_decimal_wide_minmax_" + storage_type + "_" + get_uuid_str()
+
+    create_iceberg_table(
+        storage_type,
+        instance,
+        TABLE_NAME,
+        started_cluster_iceberg_with_spark,
+        "(d128 Decimal(38, 10), d256 Decimal(76, 20), control Int64)",
+        2,
+    )
+
+    # One file per insert, so the min/max bounds of every file cover exactly one row.
+    for d128, d256, control in [
+        ("1.5", "1.5", "1"),
+        ("9999999999999999999999999999.5", "99999999999999999999999999999999999999999999999999999999.5", "500"),
+        ("-9999999999999999999999999999.5", "-99999999999999999999999999999999999999999999999999999999.5", "-500"),
+    ]:
+        instance.query(
+            f"INSERT INTO {TABLE_NAME} VALUES ({d128}, {d256}, {control})",
+            settings={"allow_insert_into_iceberg": 1},
+        )
+
+    base_settings = {
+        "input_format_parquet_bloom_filter_push_down": 0,
+        "input_format_parquet_filter_push_down": 0,
+        "output_format_decimal_trailing_zeros": 1,
+    }
+
+    def measure(predicate, index):
+        query = f"SELECT * FROM {TABLE_NAME} {predicate} ORDER BY ALL"
+        without_pruning = instance.query(
+            query, settings={**base_settings, "use_iceberg_partition_pruning": 0}
+        )
+        query_id = f"{TABLE_NAME}-{index}"
+        with_pruning = instance.query(
+            query,
+            query_id=query_id,
+            settings={**base_settings, "use_iceberg_partition_pruning": 1},
+        )
+        instance.query("SYSTEM FLUSH LOGS")
+        pruned = instance.query(
+            f"SELECT ProfileEvents['IcebergMinMaxIndexPrunedFiles'] FROM system.query_log "
+            f"WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
+        ).strip()
+        return without_pruning, with_pruning, int(pruned or 0)
+
+    predicates = [
+        "",
+        "WHERE control < -100",
+        "WHERE d128 > 1000000",
+        "WHERE d128 < -1000000",
+        "WHERE d256 > 1000000",
+        "WHERE d256 < -1000000",
+    ]
+    measured = {
+        predicate: measure(predicate, index) for index, predicate in enumerate(predicates)
+    }
+
+    # Pruning must never change the result, whatever it manages to skip.
+    for predicate, (without_pruning, with_pruning, _) in measured.items():
+        assert without_pruning == with_pruning, predicate
+
+    assert measured[""][2] == 0
+    assert measured["WHERE control < -100"][2] == 2
+    assert measured["WHERE d128 > 1000000"][2] == 2
+    assert measured["WHERE d128 < -1000000"][2] == 2
+    assert measured["WHERE d256 > 1000000"][2] == 2
+    assert measured["WHERE d256 < -1000000"][2] == 2


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Support `Decimal` types when writing into Iceberg tables, including decimal partition columns and decimal min/max statistics. (https://github.com/ClickHouse/ClickHouse/pull/115832 by @scanhex12)


### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_unit--> Unit tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
