### PR TITLE
Antalya-26.6: Fix test_database_iceberg_lakekeeper_catalog/test.py::test_auth_token_profile_events

### DIFF
--- a/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
+++ b/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
@@ -253,7 +253,7 @@ def test_select(started_cluster):
 
 
 def create_clickhouse_iceberg_database(
-    started_cluster, node, name, additional_settings={}
+    started_cluster, node, name, additional_settings={}, query_id=None
 ):
     settings = {
         "catalog_type": "rest",
@@ -263,14 +263,14 @@ def create_clickhouse_iceberg_database(
 
     settings.update(additional_settings)
 
+    node.query(f"DROP DATABASE IF EXISTS {name}")
     node.query(
-        f"""
-DROP DATABASE IF EXISTS {name};
-SET allow_experimental_database_iceberg=true;
-CREATE DATABASE {name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
-SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
-    """
+        f"CREATE DATABASE {name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')\n"
+        f"SETTINGS {','.join((k+'='+repr(v) for k, v in settings.items()))}",
+        settings={"allow_experimental_database_iceberg": 1},
+        query_id=query_id,
     )
+
     show_result = node.query(f"SHOW DATABASE {name}")
     assert minio_secret_key not in show_result
     assert "HIDDEN" in show_result
@@ -418,11 +418,11 @@ def get_credentials_profile_events(node, query_id):
 def get_auth_token_profile_events(node, query_id):
     node.query("SYSTEM FLUSH LOGS")
     refreshed = int(node.query(
-        f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenRefreshed'] "
+        f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenRetrieve'] "
         f"FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
     ))
     cache_hits = int(node.query(
-        f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenCacheHits'] "
+        f"SELECT ProfileEvents['DataLakeRestCatalogAuthTokenCachedValid'] "
         f"FROM system.query_log WHERE query_id = '{query_id}' AND type = 'QueryFinish'"
     ))
     return refreshed, cache_hits
@@ -450,9 +450,11 @@ def test_auth_token_profile_events(started_cluster):
         properties={"write.metadata.compression-codec": "none"},
     )
 
-    # The catalog client is initialized lazily on the first database access,
-    # not during CREATE DATABASE. OAuth credentials must use client_id:client_secret
-    # format; oauth_server_uri points to a mock token endpoint in docker compose.
+    # On CREATE the catalog is built eagerly, so that query is the one that fetches the
+    # OAuth token; every later query reuses it from the cache. OAuth credentials must use
+    # client_id:client_secret format; oauth_server_uri points to a mock token endpoint in
+    # docker compose.
+    qid_create = f"{test_ref}-create-{uuid.uuid4()}"
     create_clickhouse_iceberg_database(
         started_cluster,
         node,
@@ -461,18 +463,22 @@ def test_auth_token_profile_events(started_cluster):
             "catalog_credential": "test:secret",
             "oauth_server_uri": MOCK_OAUTH_URL,
         },
+        query_id=qid_create,
     )
+
+    retrieved, cached = get_auth_token_profile_events(node, qid_create)
+    assert retrieved >= 1
 
     qid1 = f"{test_ref}-show-1-{uuid.uuid4()}"
     node.query(f"SHOW TABLES FROM {db_name}", query_id=qid1)
     assert table_name in node.query(f"SHOW TABLES FROM {db_name}")
-    refreshed, cache_hits = get_auth_token_profile_events(node, qid1)
-    assert refreshed >= 1
+    retrieved, cached = get_auth_token_profile_events(node, qid1)
+    assert retrieved == 0 and cached >= 1
 
     qid2 = f"{test_ref}-show-2-{uuid.uuid4()}"
     node.query(f"SHOW TABLES FROM {db_name}", query_id=qid2)
-    refreshed, cache_hits = get_auth_token_profile_events(node, qid2)
-    assert refreshed == 0 and cache_hits >= 1
+    retrieved, cached = get_auth_token_profile_events(node, qid2)
+    assert retrieved == 0 and cached >= 1
 
 
 def test_vended_credentials_cache(started_cluster):


### PR DESCRIPTION
Fix #2323

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_unit--> Unit tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
