### PR TITLE
Add dedicated cas suite to regression and split lightweight_delete CAS jobs

### DIFF
--- a/.github/workflows/regression-reusable-suite.yml
+++ b/.github/workflows/regression-reusable-suite.yml
@@ -93,6 +93,7 @@ jobs:
       build_sha: ${{ inputs.build_sha }}
       pr_number: ${{ github.event.number }}
       artifacts: builds
+      regression_args: ${{ inputs.regression_args }}
       # Args
       args: --test-to-end
         --no-colors

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -667,13 +667,10 @@ jobs:
         include:
           - PART: 1
             FILTER: --only "/lightweight delete/disk space/*"
-            TIMEOUT: 360
           - PART: 2
             FILTER: --only "/lightweight delete/hard restart/*"
-            TIMEOUT: 240
           - PART: 3
             FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*"
-            TIMEOUT: 360
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -682,7 +679,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: ${{ matrix.TIMEOUT }}
+      timeout_minutes: 240
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}
@@ -706,13 +703,10 @@ jobs:
         include:
           - PART: 1
             FILTER: --only "/lightweight delete/disk space/*"
-            TIMEOUT: 360
           - PART: 2
             FILTER: --only "/lightweight delete/hard restart/*"
-            TIMEOUT: 240
           - PART: 3
             FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*"
-            TIMEOUT: 360
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -721,7 +715,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: ${{ matrix.TIMEOUT }}
+      timeout_minutes: 240
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -727,7 +727,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: 180
+      timeout_minutes: 300
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}
@@ -765,7 +765,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: 180
+      timeout_minutes: 300
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -800,6 +800,7 @@ jobs:
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}
+      storage_path: /${{ matrix.ONLY }}_partition
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: cas_alter_${{ matrix.ONLY }}
@@ -835,6 +836,7 @@ jobs:
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}
+      storage_path: /${{ matrix.ONLY }}_partition
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: cas_s3_cache_alter_${{ matrix.ONLY }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -534,10 +534,56 @@ jobs:
     secrets: inherit
 
   # CAS (content-addressed storage) is only available in Antalya builds >= 26.6.
-  # These jobs run the suites that support the `--cas` or `--cas-s3-cache` flag with
-  # a content-addressed disk as the default MergeTree storage. Gated on the Antalya
-  # version so they are never scheduled on upstream release builds where the `cas`
-  # metadata type does not exist.
+  # The dedicated `cas` suite, plus other suites run with `--cas` or `--cas-s3-cache`.
+  # Gated on the Antalya version so they are never scheduled on upstream release
+  # builds where the `cas` metadata type does not exist.
+  CASSuite:
+    if: |
+      contains(fromJson(inputs.workflow_config).workflow_config.custom_data.version.string, 'antalya') &&
+      (
+        fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs[0] == null ||
+        contains(fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs, 'cas')
+      )
+    uses: ./.github/workflows/regression-reusable-suite.yml
+    with:
+      ref: ${{ inputs.commit }}
+      workflow_config: ${{ inputs.workflow_config }}
+      suite_name: cas
+      suite_executable: regression.py
+      output_format: new-fails
+      flags: --with-analyzer
+      timeout_minutes: 180
+      runner_arch: ${{ inputs.arch }}
+      runner_type: ${{ inputs.runner_type }}
+      build_sha: ${{ inputs.build_sha }}
+      set_commit_status: true
+      job_name: cas
+    secrets: inherit
+
+  CASS3CacheSuite:
+    if: |
+      contains(fromJson(inputs.workflow_config).workflow_config.custom_data.version.string, 'antalya') &&
+      (
+        fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs[0] == null ||
+        contains(fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs, 'cas')
+      )
+    uses: ./.github/workflows/regression-reusable-suite.yml
+    with:
+      ref: ${{ inputs.commit }}
+      workflow_config: ${{ inputs.workflow_config }}
+      suite_name: cas
+      suite_executable: regression.py
+      output_format: new-fails
+      flags: --with-analyzer
+      timeout_minutes: 180
+      runner_arch: ${{ inputs.arch }}
+      runner_type: ${{ inputs.runner_type }}
+      build_sha: ${{ inputs.build_sha }}
+      set_commit_status: true
+      job_name: cas_s3_cache
+      regression_args: --cas-s3-cache
+    secrets: inherit
+
   CAS:
     if: |
       contains(fromJson(inputs.workflow_config).workflow_config.custom_data.version.string, 'antalya') &&

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -716,7 +716,9 @@ jobs:
           - PART: 2
             FILTER: --only "/lightweight delete/hard restart/*"
           - PART: 3
-            FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*"
+            FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*" "/lightweight delete/alter after delete/*" "/lightweight delete/concurrent alter and delete/*" "/lightweight delete/concurrent delete/*" "/lightweight delete/basic checks/*" "/lightweight delete/performance/*" "/lightweight delete/ontime tests/*"
+          - PART: 4
+            FILTER: --only "/lightweight delete/alter after delete/*" "/lightweight delete/concurrent alter and delete/*" "/lightweight delete/concurrent delete/*" "/lightweight delete/basic checks/*" "/lightweight delete/performance/*" "/lightweight delete/ontime tests/*"
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -725,7 +727,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: 240
+      timeout_minutes: 180
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}
@@ -752,7 +754,9 @@ jobs:
           - PART: 2
             FILTER: --only "/lightweight delete/hard restart/*"
           - PART: 3
-            FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*"
+            FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*" "/lightweight delete/alter after delete/*" "/lightweight delete/concurrent alter and delete/*" "/lightweight delete/concurrent delete/*" "/lightweight delete/basic checks/*" "/lightweight delete/performance/*" "/lightweight delete/ontime tests/*"
+          - PART: 4
+            FILTER: --only "/lightweight delete/alter after delete/*" "/lightweight delete/concurrent alter and delete/*" "/lightweight delete/concurrent delete/*" "/lightweight delete/basic checks/*" "/lightweight delete/performance/*" "/lightweight delete/ontime tests/*"
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -761,7 +765,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: 240
+      timeout_minutes: 180
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}
@@ -788,6 +792,8 @@ jobs:
             PART: 1
           - ONLY: attach
             PART: 2
+          - ONLY: attach
+            PART: 3
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -823,6 +829,8 @@ jobs:
             PART: 1
           - ONLY: attach
             PART: 2
+          - ONLY: attach
+            PART: 3
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -667,8 +667,13 @@ jobs:
         include:
           - PART: 1
             FILTER: --only "/lightweight delete/disk space/*"
+            TIMEOUT: 360
           - PART: 2
-            FILTER: --skip "/lightweight delete/disk space/*"
+            FILTER: --only "/lightweight delete/hard restart/*"
+            TIMEOUT: 240
+          - PART: 3
+            FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*"
+            TIMEOUT: 360
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -677,7 +682,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: 300
+      timeout_minutes: ${{ matrix.TIMEOUT }}
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}
@@ -701,8 +706,13 @@ jobs:
         include:
           - PART: 1
             FILTER: --only "/lightweight delete/disk space/*"
+            TIMEOUT: 360
           - PART: 2
-            FILTER: --skip "/lightweight delete/disk space/*"
+            FILTER: --only "/lightweight delete/hard restart/*"
+            TIMEOUT: 240
+          - PART: 3
+            FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*"
+            TIMEOUT: 360
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -711,7 +721,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: 300
+      timeout_minutes: ${{ matrix.TIMEOUT }}
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       part: ${{ matrix.PART }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SUITE: [aes_encryption, atomic_insert, attach, base_58, clickhouse_keeper_failover,data_types, datetime64_extended_range, disk_level_encryption, dns, engines, example, extended_precision_data_types, functions, jwt_authentication, kafka, kerberos, key_value, lightweight_delete, memory, part_moves_between_shards, selects, session_timezone, settings, version, window_functions]
+        SUITE: [aes_encryption, atomic_insert, attach, base_58, clickhouse_keeper_failover,data_types, datetime64_extended_range, disk_level_encryption, dns, engines, example, extended_precision_data_types, functions, jwt_authentication, kafka, kerberos, key_value, memory, part_moves_between_shards, selects, session_timezone, settings, version, window_functions]
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -141,6 +141,40 @@ jobs:
       build_sha: ${{ inputs.build_sha }}
       set_commit_status: true
       job_name: ${{ matrix.SUITE }}
+    secrets: inherit
+
+  LightweightDelete:
+    if: |
+      fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs[0] == null ||
+      contains(fromJson(inputs.workflow_config).workflow_config.custom_data.ci_regression_jobs, 'common')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - PART: 1
+            FILTER: --only "/lightweight delete/disk space/*"
+          - PART: 2
+            FILTER: --only "/lightweight delete/hard restart/*"
+          - PART: 3
+            FILTER: --skip "/lightweight delete/disk space/*" "/lightweight delete/hard restart/*" "/lightweight delete/alter after delete/*" "/lightweight delete/concurrent alter and delete/*" "/lightweight delete/concurrent delete/*" "/lightweight delete/basic checks/*" "/lightweight delete/performance/*" "/lightweight delete/ontime tests/*"
+          - PART: 4
+            FILTER: --only "/lightweight delete/alter after delete/*" "/lightweight delete/concurrent alter and delete/*" "/lightweight delete/concurrent delete/*" "/lightweight delete/basic checks/*" "/lightweight delete/performance/*" "/lightweight delete/ontime tests/*"
+    uses: ./.github/workflows/regression-reusable-suite.yml
+    with:
+      ref: ${{ inputs.commit }}
+      workflow_config: ${{ inputs.workflow_config }}
+      suite_name: lightweight_delete
+      suite_executable: regression.py
+      output_format: new-fails
+      flags: --with-analyzer
+      timeout_minutes: 300
+      runner_arch: ${{ inputs.arch }}
+      runner_type: ${{ inputs.runner_type }}
+      part: ${{ matrix.PART }}
+      build_sha: ${{ inputs.build_sha }}
+      set_commit_status: true
+      job_name: lightweight_delete
+      extra_args: ${{ matrix.FILTER }}
     secrets: inherit
 
   AggregateFunctions:
@@ -181,6 +215,8 @@ jobs:
             PART: 1
           - ONLY: attach
             PART: 2
+          - ONLY: attach
+            PART: 3
     uses: ./.github/workflows/regression-reusable-suite.yml
     with:
       ref: ${{ inputs.commit }}
@@ -189,7 +225,7 @@ jobs:
       suite_executable: regression.py
       output_format: new-fails
       flags: --with-analyzer
-      timeout_minutes: ${{ inputs.timeout_minutes }}
+      timeout_minutes: 300
       runner_arch: ${{ inputs.arch }}
       runner_type: ${{ inputs.runner_type }}
       storage_path: /${{ matrix.ONLY }}_partition


### PR DESCRIPTION
Add the dedicated `cas` / `cas_s3_cache` suite from clickhouse-regression to the Antalya 26.6 pipeline, gated on the same `ci_regression_cas` checkbox as the other CAS jobs.

Match the clickhouse-regression `release` CAS job splits:
- `lightweight_delete`: four shards (disk space, hard restart, leftover, and the slow features), each with a 5-hour timeout.
- attach partition: three parts (`part 1`, `part 2`, `part 3`).

Related: https://github.com/Altinity/ClickHouse/pull/2234

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] I will add a documentation PR to [ClickHouse/clickhouse-docs](https://github.com/ClickHouse/clickhouse-docs) right after this PR is merged.
- [ ] I need help to write the documentation.
- [x] No documentation needed.

### CI/CD Options
#### Exclude tests:
- [x] <!---ci_exclude_fast--> Fast test
- [x] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_unit--> Unit tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [x] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [x] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [ ] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [ ] <!---ci_regression_oauth--> OAuth (5m)
- [ ] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [ ] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
