### PR TITLE
Antalya-26.6 - Fix test_storage_iceberg_with_spark/test_writes.py::test_writes_decimal_wide_minmax_pruning

### DIFF
--- a/tests/integration/test_storage_iceberg_with_spark/test_writes.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_writes.py
@@ -704,12 +704,15 @@ def test_writes_decimal_partition_same_shape(started_cluster_iceberg_with_spark,
 
 @pytest.mark.parametrize("storage_type", ["s3", "local"])
 def test_writes_decimal_wide_minmax_pruning(started_cluster_iceberg_with_spark, storage_type):
-    """Min/max statistics of `Decimal128` and `Decimal256` columns must be consumable by the reader.
+    """Min/max statistics of `Decimal128` columns must be consumable by the reader.
 
     The bounds are longer than 8 bytes, which the bound deserializer used to reject, silently
     disabling `IcebergMinMaxIndexPrunedFiles` for these widths. `control` carries the same
     magnitudes in a type whose bounds are known to prune, to tell a decimal-specific gap apart
     from a table that simply cannot be pruned.
+
+    Upstream covers `Decimal256` here too; this branch refuses a decimal wider than the Iceberg
+    spec limit of precision 38, so such a column cannot be written through this path.
     """
     instance = started_cluster_iceberg_with_spark.instances["node1"]
     TABLE_NAME = "test_writes_decimal_wide_minmax_" + storage_type + "_" + get_uuid_str()
@@ -719,18 +722,18 @@ def test_writes_decimal_wide_minmax_pruning(started_cluster_iceberg_with_spark, 
         instance,
         TABLE_NAME,
         started_cluster_iceberg_with_spark,
-        "(d128 Decimal(38, 10), d256 Decimal(76, 20), control Int64)",
+        "(d128 Decimal(38, 10), control Int64)",
         2,
     )
 
     # One file per insert, so the min/max bounds of every file cover exactly one row.
-    for d128, d256, control in [
-        ("1.5", "1.5", "1"),
-        ("9999999999999999999999999999.5", "99999999999999999999999999999999999999999999999999999999.5", "500"),
-        ("-9999999999999999999999999999.5", "-99999999999999999999999999999999999999999999999999999999.5", "-500"),
+    for d128, control in [
+        ("1.5", "1"),
+        ("9999999999999999999999999999.5", "500"),
+        ("-9999999999999999999999999999.5", "-500"),
     ]:
         instance.query(
-            f"INSERT INTO {TABLE_NAME} VALUES ({d128}, {d256}, {control})",
+            f"INSERT INTO {TABLE_NAME} VALUES ({d128}, {control})",
             settings={"allow_insert_into_iceberg": 1},
         )
 
@@ -763,8 +766,6 @@ def test_writes_decimal_wide_minmax_pruning(started_cluster_iceberg_with_spark, 
         "WHERE control < -100",
         "WHERE d128 > 1000000",
         "WHERE d128 < -1000000",
-        "WHERE d256 > 1000000",
-        "WHERE d256 < -1000000",
     ]
     measured = {
         predicate: measure(predicate, index) for index, predicate in enumerate(predicates)
@@ -778,5 +779,3 @@ def test_writes_decimal_wide_minmax_pruning(started_cluster_iceberg_with_spark, 
     assert measured["WHERE control < -100"][2] == 2
     assert measured["WHERE d128 > 1000000"][2] == 2
     assert measured["WHERE d128 < -1000000"][2] == 2
-    assert measured["WHERE d256 > 1000000"][2] == 2
-    assert measured["WHERE d256 < -1000000"][2] == 2


### PR DESCRIPTION
#2320 backported the upstream test, which creates a `Decimal(76, 20)` column, and in the same PR restored the guard that refuses precision above the Iceberg spec limit of 38.

No integration job ran between the two commits, so it only broke after the merge — the test now fails 100% of the time in every `antalya-26.6` PR, and passes on `26.8`, which has no guard.

**Test-only fix:** the guard is correct and asserted elsewhere, so the `Decimal256` column is dropped. `d128 Decimal(38, 10)` keeps what the test is for — a min/max bound longer than 8 bytes.

Related: #2320

### Changelog category (leave one):

- Build/Testing/Packaging Improvement

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [x] <!---ci_exclude_stateless--> Stateless tests
- [x] <!---ci_exclude_stateful--> Stateful tests
- [x] <!---ci_exclude_unit--> Unit tests
- [x] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [x] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
