### PR TITLE
Antalya-26.6 - Do not build SimSIMD for ARM sanitizer builds

### DIFF
--- a/contrib/SimSIMD-cmake/CMakeLists.txt
+++ b/contrib/SimSIMD-cmake/CMakeLists.txt
@@ -1,5 +1,23 @@
-# See contrib/usearch-cmake/CMakeLists.txt, why only enabled on x86 and ARM
-if (ARCH_AMD64 OR (ARCH_AARCH64 AND NOT NO_ARMV81_OR_HIGHER AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19))
+# See contrib/usearch-cmake/CMakeLists.txt, why only enabled on x86 and ARM.
+#
+# ARM sanitizer builds are excluded: SimSIMD kills the server on ARM CPUs without SVE
+# (Scalable Vector Extension, an optional ARM feature).
+#
+# SimSIMD detects CPU features in `_simsimd_capabilities_arm`. That function sits inside
+# `#pragma GCC target("arch=armv8.5-a+sve")` (contrib/SimSIMD/include/simsimd/simsimd.h:475).
+# The pragma lets the compiler emit SVE instructions there - in the very function that asks
+# whether the CPU supports SVE. Sanitizer codegen emits one. The CPU raises SIGILL and the
+# server dies.
+#
+# Neoverse N1 and Graviton2 have no SVE, and our supported ARM baseline covers both.
+# `Stress test (arm_tsan)` hits this through 03369_l2_distance_transposed_variadic.
+#
+# `SIMSIMD_TARGET_SVE=0` below does not prevent it. That macro gates the SVE kernels, not the
+# pragma.
+#
+# Drop this exclusion once the probe is fixed upstream. Until then the QBit distance functions
+# and USearch use their scalar implementations on these builds.
+if (ARCH_AMD64 OR (ARCH_AARCH64 AND SANITIZE STREQUAL "" AND NOT NO_ARMV81_OR_HIGHER AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19))
     set(SIMSIMD_PROJECT_DIR "${ClickHouse_SOURCE_DIR}/contrib/SimSIMD")
     set(SIMSIMD_SRCS ${SIMSIMD_PROJECT_DIR}/c/lib.c)
     add_library(_simsimd ${SIMSIMD_SRCS})
@@ -11,5 +29,5 @@ if (ARCH_AMD64 OR (ARCH_AARCH64 AND NOT NO_ARMV81_OR_HIGHER AND CMAKE_CXX_COMPIL
     add_library(ch_contrib::simsimd ALIAS _simsimd)
 else()
     # The latter requires Clang 19 because older versions had a buggy bf16 implementation.
-    message(STATUS "SimSIMD library is only supported on x86_64 with SSE or ARM with ARMv8.1 and Clang 19+")
+    message(STATUS "SimSIMD library is only supported on x86_64 with SSE or ARM with ARMv8.1 and Clang 19+, and is disabled for ARM sanitizer builds")
 endif()

--- a/contrib/usearch-cmake/CMakeLists.txt
+++ b/contrib/usearch-cmake/CMakeLists.txt
@@ -8,8 +8,12 @@ target_compile_definitions(_usearch INTERFACE USEARCH_USE_FP16LIB)
 
 # SimSIMD supports x86 and ARM platforms. The latter requires Clang 19 because older versions had a buggy bf16 implementation.
 if (ARCH_AMD64 OR (ARCH_AARCH64 AND NOT NO_ARMV81_OR_HIGHER AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19))
-    target_link_libraries(_usearch INTERFACE _simsimd)
-    target_compile_definitions(_usearch INTERFACE USEARCH_USE_SIMSIMD)
+    # SimSIMD is not built for ARM sanitizer builds. contrib/SimSIMD-cmake/CMakeLists.txt says why.
+    # Test the target rather than repeat that condition here - copies of it drift apart.
+    if (TARGET _simsimd)
+        target_link_libraries(_usearch INTERFACE _simsimd)
+        target_compile_definitions(_usearch INTERFACE USEARCH_USE_SIMSIMD)
+    endif()
 
     target_compile_definitions(_usearch INTERFACE USEARCH_CAN_COMPILE_FLOAT16)
     target_compile_definitions(_usearch INTERFACE USEARCH_CAN_COMPILE_BF16)


### PR DESCRIPTION
Fix #2340

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_unit--> Unit tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [ ] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [ ] <!---ci_exclude_tsan--> All with TSAN
- [ ] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [x] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [ ] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
