### PR TITLE
Remove references to clickhouse.cloud

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -629,9 +629,6 @@ AuthResult AccessControl::authenticate(const Credentials & credentials, const Po
 
             message << R"(
 
-If you use ClickHouse Cloud, the password can be reset at https://clickhouse.cloud/
-on the settings page for the corresponding service.
-
 If you have installed ClickHouse and forgot password you can reset it in the configuration file.
 The password for default user is typically located at /etc/clickhouse-server/users.d/default-password.xml
 and deleting this file will reset the password.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5183,10 +5183,6 @@ If settings are set to non-default values, then those settings are honored (only
 This setting takes a ClickHouse version number as a string, like `22.3`, `22.8`. An empty value means that this setting is disabled.
 
 Disabled by default.
-
-:::note
-In ClickHouse Cloud the compatibility setting must be set by ClickHouse Cloud support.  Please [open a case](https://clickhouse.cloud/support) to have it set.
-:::
 )", 0) \
     \
     DECLARE(Map, additional_table_filters, "", R"(

--- a/tests/queries/0_stateless/03362_basic_auth_interactive_not_with_authorization_never.reference
+++ b/tests/queries/0_stateless/03362_basic_auth_interactive_not_with_authorization_never.reference
@@ -1,3 +1,2 @@
 1
 < HTTP/1.1 403 Forbidden
-If you use ClickHouse Cloud, the password can be reset at https://clickhouse.cloud/

--- a/tests/queries/0_stateless/03362_basic_auth_interactive_not_with_authorization_never.sh
+++ b/tests/queries/0_stateless/03362_basic_auth_interactive_not_with_authorization_never.sh
@@ -11,4 +11,4 @@ ${CLICKHOUSE_CURL} -H 'Authorization: never' "$URL?query=SELECT%201"
 # If the Authorization is set to "never", and the credentials are provided in URL parameters,
 # the server will return 403 instead of 401 Unauthorized, so there will be no prompt in the browser.
 URL="${CLICKHOUSE_PORT_HTTP_PROTO}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?user=default&password=invalid_password"
-${CLICKHOUSE_CURL} -H 'Authorization: never' -v "$URL?query=SELECT%201" 2>&1 | grep -P '403 Forbidden|ClickHouse Cloud'
+${CLICKHOUSE_CURL} -H 'Authorization: never' -v "$URL?query=SELECT%201" 2>&1 | grep -P '403 Forbidden' | tr -d '\r'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Remove references to Clickhouse cloud.(#1670)

### CI/CD Options
#### Exclude tests:
- [ ] <!---ci_exclude_fast--> Fast test
- [ ] <!---ci_exclude_integration--> Integration Tests
- [ ] <!---ci_exclude_stateless--> Stateless tests
- [ ] <!---ci_exclude_stateful--> Stateful tests
- [ ] <!---ci_exclude_unit--> Unit tests
- [ ] <!---ci_exclude_performance--> Performance tests
- [x] <!---ci_exclude_aarch64|arm-->  Aarch64 tests
- [ ] <!---ci_exclude_asan--> All with ASAN
- [x] <!---ci_exclude_tsan--> All with TSAN
- [x] <!---ci_exclude_msan--> All with MSAN
- [ ] <!---ci_exclude_ubsan--> All with UBSAN
- [x] <!---ci_exclude_coverage--> All with Coverage
- [ ] <!---ci_exclude_regression--> All Regression
- [ ] <!---no_ci_cache--> Disable CI Cache

#### Regression jobs to run:
- [ ] <!---ci_regression_common--> Fast suites (mostly <1h)
- [ ] <!---ci_regression_aggregate_functions--> Aggregate Functions (2h)
- [ ] <!---ci_regression_alter--> Alter (1.5h)
- [ ] <!---ci_regression_benchmark--> Benchmark (30m)
- [ ] <!---ci_regression_cas--> CAS (content-addressed storage; Antalya only)
- [ ] <!---ci_regression_clickhouse_keeper--> ClickHouse Keeper (1h)
- [x] <!---ci_regression_iceberg--> Iceberg (2h)
- [ ] <!---ci_regression_ldap--> LDAP (1h)
- [x] <!---ci_regression_oauth--> OAuth (5m)
- [x] <!---ci_regression_parquet--> Parquet (1.5h)
- [ ] <!---ci_regression_rbac--> RBAC (1.5h)
- [ ] <!---ci_regression_ssl_server--> SSL Server (1h)
- [ ] <!---ci_regression_s3--> S3 (2h)
- [x] <!---ci_regression_s3_export--> S3 Export (2h)
- [x] <!---ci_regression_swarms--> Swarms (30m)
- [ ] <!---ci_regression_tiered_storage--> Tiered Storage (2h)
