### PR TITLE
Fix QueryConditionCache OOB write on part-name/layout reuse (#2342)

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -96,6 +96,10 @@
     M(VectorSimilarityIndexCacheWeightLost, "Approximate number of bytes evicted from the vector index cache.", ValueType::Number) \
     M(QueryConditionCacheHits, "Number of times an entry has been found in the query condition cache (and reading of marks can be skipped). Only updated for SELECT queries with SETTING use_query_condition_cache = 1.", ValueType::Number) \
     M(QueryConditionCacheMisses, "Number of times an entry has not been found in the query condition cache (and reading of mark cannot be skipped). Only updated for SELECT queries with SETTING use_query_condition_cache = 1.", ValueType::Number) \
+    M(QueryConditionCacheLayoutMismatch, "Number of times a query condition cache entry was "         \
+      "skipped because its mark layout did not match the current part's layout. Should be 0 after "   \
+      "the Key fix; a non-zero count indicates a residual hazard (see Altinity/ClickHouse#2342).",     \
+      ValueType::Number) \
     M(QueryCacheHits, "Number of times a query result has been found in the query cache (and query computation was avoided). Only updated for SELECT queries with SETTING use_query_cache = 1.", ValueType::Number) \
     M(QueryCacheMisses, "Number of times a query result has not been found in the query cache (and required query computation). Only updated for SELECT queries with SETTING use_query_cache = 1.", ValueType::Number) \
     M(CreatedReadBufferOrdinary, "Number of times ordinary read buffer was created for reading data (while choosing among other read methods).", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -96,9 +96,9 @@
     M(VectorSimilarityIndexCacheWeightLost, "Approximate number of bytes evicted from the vector index cache.", ValueType::Number) \
     M(QueryConditionCacheHits, "Number of times an entry has been found in the query condition cache (and reading of marks can be skipped). Only updated for SELECT queries with SETTING use_query_condition_cache = 1.", ValueType::Number) \
     M(QueryConditionCacheMisses, "Number of times an entry has not been found in the query condition cache (and reading of mark cannot be skipped). Only updated for SELECT queries with SETTING use_query_condition_cache = 1.", ValueType::Number) \
-    M(QueryConditionCacheLayoutMismatch, "Number of times a query condition cache entry was "         \
-      "skipped because its mark layout did not match the current part's layout. Should be 0 after "   \
-      "the Key fix; a non-zero count indicates a residual hazard (see Altinity/ClickHouse#2342).",     \
+    M(QueryConditionCacheLayoutMismatch, "Number of times a query condition cache entry was skipped "  \
+      "on write or read because its mark layout (marks_count/has_final_mark) did not match the "       \
+      "current part's layout (see Altinity/ClickHouse#2342).",                                         \
       ValueType::Number) \
     M(QueryCacheHits, "Number of times a query result has been found in the query cache (and query computation was avoided). Only updated for SELECT queries with SETTING use_query_cache = 1.", ValueType::Number) \
     M(QueryCacheMisses, "Number of times a query result has not been found in the query cache (and required query computation). Only updated for SELECT queries with SETTING use_query_cache = 1.", ValueType::Number) \

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -1,5 +1,4 @@
 #include <Interpreters/Cache/QueryConditionCache.h>
-#include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/SipHash.h>
@@ -21,11 +20,6 @@ namespace CurrentMetrics
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int LOGICAL_ERROR;
-}
 
 bool QueryConditionCache::Key::operator==(const Key & other) const
 {

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -19,13 +19,13 @@ namespace CurrentMetrics
     extern const Metric QueryConditionCacheEntries;
 }
 
+namespace DB
+{
+
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
 }
-
-namespace DB
-{
 
 bool QueryConditionCache::Key::operator==(const Key & other) const
 {
@@ -64,22 +64,33 @@ void QueryConditionCache::write(
     const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark)
 {
     if (has_final_mark && marks_count == 0)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "A part with a final mark must have at least one mark");
+    {
+        ProfileEvents::increment(ProfileEvents::QueryConditionCacheLayoutMismatch);
+        LOG_ERROR(
+            logger,
+            "Query condition cache write for table_id: {}, part_name: {}, condition_hash: {}: "
+            "has_final_mark is set but marks_count is 0, which is not a valid mark layout. "
+            "Skipping cache update for this entry. See Altinity/ClickHouse#2342.",
+            table_id, part_name, condition_hash);
+        return;
+    }
 
-    /// This validates ranges against the *caller-supplied* marks_count, which is a genuine caller
-    /// bug if it fails -- this throw is unchanged from upstream and should stay a throw.
     for (const auto & mark_range : mark_ranges)
     {
         if (mark_range.begin > mark_range.end || mark_range.end > marks_count)
-            throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
-                "Invalid mark range [{}, {}) for query condition cache entry with {} marks",
-                mark_range.begin,
-                mark_range.end,
-                marks_count);
+        {
+            ProfileEvents::increment(ProfileEvents::QueryConditionCacheLayoutMismatch);
+            LOG_ERROR(
+                logger,
+                "Query condition cache write for table_id: {}, part_name: {}, condition_hash: {}: "
+                "invalid mark range [{}, {}) for entry with {} marks. Skipping cache update for this "
+                "entry. See Altinity/ClickHouse#2342.",
+                table_id, part_name, condition_hash, mark_range.begin, mark_range.end, marks_count);
+            return;
+        }
     }
 
-    /// TODO(#2342): marks_count and has_final_mark are now part of Key (see QueryConditionCache.h).
+    /// NOTE(#2342): marks_count and has_final_mark are now part of Key (see QueryConditionCache.h).
     /// Before this change, Key was {table_id, part_name, condition_hash} only. A part_name can be
     /// reused after its underlying data (and therefore its mark layout) has changed -- e.g. after a
     /// mutation, a merge that produces a part with a name collision under certain replay scenarios,
@@ -99,7 +110,7 @@ void QueryConditionCache::write(
     {
         std::shared_lock shared_lock(entry->mutex); /// cheap
 
-        /// TODO(#2342): defense in depth. With marks_count in the Key, this branch should now be
+        /// NOTE(#2342): defense in depth. With marks_count in the Key, this branch should now be
         /// unreachable in normal operation -- cache.getOrSet() cannot return an Entry keyed to a
         /// different marks_count than the one just constructed. If this ever fires, it means either
         /// (a) a hash collision between two distinct Keys (extremely unlikely with SipHash64 over
@@ -111,6 +122,7 @@ void QueryConditionCache::write(
         /// from inside the query pipeline for what may be a caching-layer inconsistency, and do NOT
         /// proceed to index a vector we now know is a mismatched size. This is intentionally the
         /// last line of defense, not the fix: the fix is the Key change above.
+        chassert(entry->matching_marks.size() == marks_count);
         if (entry->matching_marks.size() != marks_count)
         {
             ProfileEvents::increment(ProfileEvents::QueryConditionCacheLayoutMismatch);
@@ -144,11 +156,12 @@ void QueryConditionCache::write(
     {
         std::lock_guard lock(entry->mutex); /// (*)
 
-        /// TODO(#2342): same defense-in-depth check as above, now under the exclusive lock. Kept
+        /// NOTE(#2342): same defense-in-depth check as above, now under the exclusive lock. Kept
         /// deliberately duplicated rather than factored into a helper: the shared_lock check above
         /// is an optimization (avoid taking the exclusive lock), and the entry could theoretically
         /// change between releasing the shared lock and acquiring the exclusive one in some future
         /// refactor. Re-checking here costs nothing and removes that assumption.
+        chassert(entry->matching_marks.size() == marks_count);
         if (entry->matching_marks.size() != marks_count)
         {
             ProfileEvents::increment(ProfileEvents::QueryConditionCacheLayoutMismatch);
@@ -188,11 +201,9 @@ std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(
 
     if (auto entry = cache.get(key))
     {
-        ProfileEvents::increment(ProfileEvents::QueryConditionCacheHits);
-
         std::shared_lock lock(entry->mutex);
 
-        /// TODO(#2342): defense in depth, mirrors the write-path checks above. On the read path a
+        /// NOTE(#2342): defense in depth, mirrors the write-path checks above. On the read path a
         /// mismatch is comparatively low-risk -- the caller only reads matching_marks, it does not
         /// index into it with the *caller's* marks_count anywhere we've audited (see
         /// MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache, which indexes with
@@ -201,6 +212,7 @@ std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(
         /// confirmed every caller across all supported versions respects that invariant, and because
         /// returning a mismatched-size MatchingMarks to a caller that isn't expecting one is exactly
         /// the kind of latent hazard this whole issue is about. Treat as a cache miss on mismatch.
+        chassert(entry->matching_marks.size() == marks_count);
         if (entry->matching_marks.size() != marks_count)
         {
             ProfileEvents::increment(ProfileEvents::QueryConditionCacheLayoutMismatch);
@@ -221,6 +233,7 @@ std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(
             part_name,
             condition_hash);
 
+        ProfileEvents::increment(ProfileEvents::QueryConditionCacheHits);
         return {entry->matching_marks};
     }
     else

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -1,4 +1,5 @@
 #include <Interpreters/Cache/QueryConditionCache.h>
+#include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/SipHash.h>
@@ -9,12 +10,22 @@ namespace ProfileEvents
 {
     extern const Event QueryConditionCacheHits;
     extern const Event QueryConditionCacheMisses;
+    /// TODO(#2342): register this event in src/Common/ProfileEvents.cpp:
+    ///   M(QueryConditionCacheLayoutMismatch, "Number of times a query condition cache entry was skipped "
+    ///     "because its mark layout did not match the current part's layout. A non-zero count here is direct "
+    ///     "evidence of the use-after-free / OOB-write hazard described in Altinity/ClickHouse#2342.", ValueType::Number) \
+    extern const Event QueryConditionCacheLayoutMismatch;
 }
 
 namespace CurrentMetrics
 {
     extern const Metric QueryConditionCacheBytes;
     extern const Metric QueryConditionCacheEntries;
+}
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
 }
 
 namespace DB
@@ -24,7 +35,9 @@ bool QueryConditionCache::Key::operator==(const Key & other) const
 {
     return table_id == other.table_id
         && part_name == other.part_name
-        && condition_hash == other.condition_hash;
+        && condition_hash == other.condition_hash
+        && marks_count == other.marks_count
+        && has_final_mark == other.has_final_mark;
 }
 
 size_t QueryConditionCache::KeyHasher::operator()(const Key & key) const
@@ -33,6 +46,8 @@ size_t QueryConditionCache::KeyHasher::operator()(const Key & key) const
     hash.update(key.table_id);
     hash.update(key.part_name);
     hash.update(key.condition_hash);
+    hash.update(key.marks_count);
+    hash.update(key.has_final_mark);
     return hash.get64();
 }
 
@@ -52,7 +67,34 @@ void QueryConditionCache::write(
     const UUID & table_id, const String & part_name, UInt64 condition_hash, const String & condition,
     const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark)
 {
-    Key key = {table_id, part_name, condition_hash, condition};
+    if (has_final_mark && marks_count == 0)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "A part with a final mark must have at least one mark");
+
+    /// This validates ranges against the *caller-supplied* marks_count, which is a genuine caller
+    /// bug if it fails -- this throw is unchanged from upstream and should stay a throw.
+    for (const auto & mark_range : mark_ranges)
+    {
+        if (mark_range.begin > mark_range.end || mark_range.end > marks_count)
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Invalid mark range [{}, {}) for query condition cache entry with {} marks",
+                mark_range.begin,
+                mark_range.end,
+                marks_count);
+    }
+
+    /// TODO(#2342): marks_count and has_final_mark are now part of Key (see QueryConditionCache.h).
+    /// Before this change, Key was {table_id, part_name, condition_hash} only. A part_name can be
+    /// reused after its underlying data (and therefore its mark layout) has changed -- e.g. after a
+    /// mutation, a merge that produces a part with a name collision under certain replay scenarios,
+    /// or (per the linked issue) some other part-lifecycle path we have not fully identified.
+    /// getOrSet() below could then return a pre-existing Entry sized for the OLD layout, which the
+    /// code proceeded to index using the NEW marks_count/mark_ranges. On std::vector<bool>'s
+    /// bit-packed storage this is an out-of-bounds *write*, not just a read -- see the (*) fill()
+    /// and matching_marks[marks_count - 1] writes below. Keying on the layout as well eliminates the
+    /// possibility of this mismatch entirely; the alternative (validate-before-use, kept as a defense
+    /// in depth below) only stops the write after the mismatched Entry has already been returned.
+    Key key = {table_id, part_name, condition_hash, marks_count, has_final_mark, condition};
 
     auto load_func = [&](){ return std::make_shared<Entry>(marks_count); };
     auto [entry, inserted] = cache.getOrSet(key, load_func);
@@ -60,6 +102,30 @@ void QueryConditionCache::write(
     /// Try to avoid acquiring the RW lock below (*) by early-ing out. Matters for systems with lots of cores.
     {
         std::shared_lock shared_lock(entry->mutex); /// cheap
+
+        /// TODO(#2342): defense in depth. With marks_count in the Key, this branch should now be
+        /// unreachable in normal operation -- cache.getOrSet() cannot return an Entry keyed to a
+        /// different marks_count than the one just constructed. If this ever fires, it means either
+        /// (a) a hash collision between two distinct Keys (extremely unlikely with SipHash64 over
+        ///     table_id + part_name + condition_hash + marks_count + has_final_mark), or
+        /// (b) a residual bug in Key equality/hashing, or
+        /// (c) the underlying corruption in #2342 has already occurred elsewhere and this Entry's
+        ///     bookkeeping is not trustworthy regardless of what the key comparison says.
+        /// Silently returning (skip the cache write) is the only safe response here -- do NOT throw
+        /// from inside the query pipeline for what may be a caching-layer inconsistency, and do NOT
+        /// proceed to index a vector we now know is a mismatched size. This is intentionally the
+        /// last line of defense, not the fix: the fix is the Key change above.
+        if (entry->matching_marks.size() != marks_count)
+        {
+            ProfileEvents::increment(ProfileEvents::QueryConditionCacheLayoutMismatch);
+            LOG_ERROR(
+                logger,
+                "Query condition cache layout mismatch on write for table_id: {}, part_name: {}, "
+                "condition_hash: {}: entry has {} marks, current task has {} marks (has_final_mark: {}). "
+                "Skipping cache update for this entry. See Altinity/ClickHouse#2342.",
+                table_id, part_name, condition_hash, entry->matching_marks.size(), marks_count, has_final_mark);
+            return;
+        }
 
         bool need_not_update_marks = true;
         for (const auto & mark_range : mark_ranges)
@@ -82,7 +148,22 @@ void QueryConditionCache::write(
     {
         std::lock_guard lock(entry->mutex); /// (*)
 
-        chassert(marks_count == entry->matching_marks.size());
+        /// TODO(#2342): same defense-in-depth check as above, now under the exclusive lock. Kept
+        /// deliberately duplicated rather than factored into a helper: the shared_lock check above
+        /// is an optimization (avoid taking the exclusive lock), and the entry could theoretically
+        /// change between releasing the shared lock and acquiring the exclusive one in some future
+        /// refactor. Re-checking here costs nothing and removes that assumption.
+        if (entry->matching_marks.size() != marks_count)
+        {
+            ProfileEvents::increment(ProfileEvents::QueryConditionCacheLayoutMismatch);
+            LOG_ERROR(
+                logger,
+                "Query condition cache layout mismatch on write (exclusive path) for table_id: {}, "
+                "part_name: {}, condition_hash: {}: entry has {} marks, current task has {} marks "
+                "(has_final_mark: {}). Skipping cache update for this entry. See Altinity/ClickHouse#2342.",
+                table_id, part_name, condition_hash, entry->matching_marks.size(), marks_count, has_final_mark);
+            return;
+        }
 
         /// The input mark ranges are the areas which the scan can skip later on.
         for (const auto & mark_range : mark_ranges)
@@ -104,15 +185,38 @@ void QueryConditionCache::write(
         has_final_mark);
 }
 
-std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(const UUID & table_id, const String & part_name, UInt64 condition_hash)
+std::optional<QueryConditionCache::MatchingMarks> QueryConditionCache::read(
+    const UUID & table_id, const String & part_name, UInt64 condition_hash, size_t marks_count, bool has_final_mark)
 {
-    Key key = {table_id, part_name, condition_hash, ""};
+    Key key = {table_id, part_name, condition_hash, marks_count, has_final_mark, ""};
 
     if (auto entry = cache.get(key))
     {
         ProfileEvents::increment(ProfileEvents::QueryConditionCacheHits);
 
         std::shared_lock lock(entry->mutex);
+
+        /// TODO(#2342): defense in depth, mirrors the write-path checks above. On the read path a
+        /// mismatch is comparatively low-risk -- the caller only reads matching_marks, it does not
+        /// index into it with the *caller's* marks_count anywhere we've audited (see
+        /// MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache, which indexes with
+        /// mark_range.begin/end drawn from part_with_ranges.ranges, i.e. the part's own state at scan
+        /// time, not from this returned vector's size). We still guard here because we have NOT
+        /// confirmed every caller across all supported versions respects that invariant, and because
+        /// returning a mismatched-size MatchingMarks to a caller that isn't expecting one is exactly
+        /// the kind of latent hazard this whole issue is about. Treat as a cache miss on mismatch.
+        if (entry->matching_marks.size() != marks_count)
+        {
+            ProfileEvents::increment(ProfileEvents::QueryConditionCacheLayoutMismatch);
+            LOG_ERROR(
+                logger,
+                "Query condition cache layout mismatch on read for table_id: {}, part_name: {}, "
+                "condition_hash: {}: entry has {} marks, requested {} marks (has_final_mark: {}). "
+                "Treating as a cache miss. See Altinity/ClickHouse#2342.",
+                table_id, part_name, condition_hash, entry->matching_marks.size(), marks_count, has_final_mark);
+            ProfileEvents::increment(ProfileEvents::QueryConditionCacheMisses);
+            return {};
+        }
 
         LOG_TEST(
             logger,

--- a/src/Interpreters/Cache/QueryConditionCache.cpp
+++ b/src/Interpreters/Cache/QueryConditionCache.cpp
@@ -10,10 +10,6 @@ namespace ProfileEvents
 {
     extern const Event QueryConditionCacheHits;
     extern const Event QueryConditionCacheMisses;
-    /// TODO(#2342): register this event in src/Common/ProfileEvents.cpp:
-    ///   M(QueryConditionCacheLayoutMismatch, "Number of times a query condition cache entry was skipped "
-    ///     "because its mark layout did not match the current part's layout. A non-zero count here is direct "
-    ///     "evidence of the use-after-free / OOB-write hazard described in Altinity/ClickHouse#2342.", ValueType::Number) \
     extern const Event QueryConditionCacheLayoutMismatch;
 }
 

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -34,6 +34,11 @@ private:
         const String part_name;
         const UInt64 condition_hash;
 
+        /// A part name can be reused after its data has been replaced. The mark layout is
+        /// part of the cached value's shape, so it must be part of the cache identity too.
+        const size_t marks_count;
+        const bool has_final_mark;
+
         /// -- Additional members, conceptually not part of the key. Only included for pretty-printing
         ///    in system.query_condition_cache:
         const String condition;
@@ -80,7 +85,8 @@ public:
         const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
 
     /// Check the cache if it contains an entry for the given table + part id and predicate hash.
-    std::optional<MatchingMarks> read(const UUID & table_id, const String & part_name, UInt64 condition_hash);
+    std::optional<MatchingMarks> read(
+        const UUID & table_id, const String & part_name, UInt64 condition_hash, size_t marks_count, bool has_final_mark);
 
     /// For debugging and system tables
     std::vector<QueryConditionCache::Cache::KeyMapped> dump() const;

--- a/src/Interpreters/Cache/QueryConditionCache.h
+++ b/src/Interpreters/Cache/QueryConditionCache.h
@@ -85,6 +85,10 @@ public:
         const MarkRanges & mark_ranges, size_t marks_count, bool has_final_mark);
 
     /// Check the cache if it contains an entry for the given table + part id and predicate hash.
+    /// marks_count/has_final_mark describe the caller's current mark layout for the part; they are
+    /// part of the cache key and are also checked against the found entry's stored layout, since a
+    /// part_name can be reused with a different layout after the underlying data has changed. On a
+    /// layout mismatch, the entry is treated as a cache miss (see Altinity/ClickHouse#2342).
     std::optional<MatchingMarks> read(
         const UUID & table_id, const String & part_name, UInt64 condition_hash, size_t marks_count, bool has_final_mark);
 

--- a/src/Interpreters/Cache/tests/gtest_query_condition_cache.cpp
+++ b/src/Interpreters/Cache/tests/gtest_query_condition_cache.cpp
@@ -38,5 +38,11 @@ TEST(QueryConditionCache, RejectsRangesOutsideEntryMarkLayout)
     MarkRanges invalid_range;
     invalid_range.emplace_back(0, 2);
 
-    EXPECT_THROW(cache.write(UUID(1), "part", 42, "", invalid_range, 1, false), Exception);
+    /// An invalid mark range (out of bounds for the given marks_count) is a caller bug, but write()
+    /// logs and skips rather than throwing from inside the query pipeline (see Altinity/ClickHouse#2342).
+    EXPECT_NO_THROW(cache.write(UUID(1), "part", 42, "", invalid_range, 1, false));
+
+    /// Nothing should have been cached for this key.
+    auto result = cache.read(UUID(1), "part", 42, 1, false);
+    EXPECT_FALSE(result);
 }

--- a/src/Interpreters/Cache/tests/gtest_query_condition_cache.cpp
+++ b/src/Interpreters/Cache/tests/gtest_query_condition_cache.cpp
@@ -1,0 +1,42 @@
+#include <Interpreters/Cache/QueryConditionCache.h>
+#include <base/UUID.h>
+#include <base/unit.h>
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+TEST(QueryConditionCache, KeepsEntriesWithDifferentMarkLayoutsSeparate)
+{
+    QueryConditionCache cache("LRU", 1_MiB, 0.5);
+    const UUID table_id(1);
+    const String part_name = "part";
+    constexpr UInt64 condition_hash = 42;
+
+    MarkRanges one_mark;
+    one_mark.emplace_back(0, 1);
+    cache.write(table_id, part_name, condition_hash, "", one_mark, 1, false);
+
+    MarkRanges two_marks;
+    two_marks.emplace_back(1, 2);
+    cache.write(table_id, part_name, condition_hash, "", two_marks, 2, false);
+
+    auto first_layout = cache.read(table_id, part_name, condition_hash, 1, false);
+    ASSERT_TRUE(first_layout);
+    ASSERT_EQ(first_layout->size(), 1);
+    EXPECT_FALSE((*first_layout)[0]);
+
+    auto second_layout = cache.read(table_id, part_name, condition_hash, 2, false);
+    ASSERT_TRUE(second_layout);
+    ASSERT_EQ(second_layout->size(), 2);
+    EXPECT_TRUE((*second_layout)[0]);
+    EXPECT_FALSE((*second_layout)[1]);
+}
+
+TEST(QueryConditionCache, RejectsRangesOutsideEntryMarkLayout)
+{
+    QueryConditionCache cache("LRU", 1_MiB, 0.5);
+    MarkRanges invalid_range;
+    invalid_range.emplace_back(0, 2);
+
+    EXPECT_THROW(cache.write(UUID(1), "part", 42, "", invalid_range, 1, false), Exception);
+}

--- a/src/Interpreters/Cache/tests/gtest_query_condition_cache_defense_in_depth.cpp
+++ b/src/Interpreters/Cache/tests/gtest_query_condition_cache_defense_in_depth.cpp
@@ -1,12 +1,10 @@
-/// TODO(#2342): These tests exercise the defense-in-depth paths added in QueryConditionCache.patched.cpp.
-/// They cannot currently trigger a *genuine* Key-hash collision (SipHash64 over table_id + part_name +
-/// condition_hash + marks_count + has_final_mark is not practically collidable in a unit test), so
-/// "mismatch" here is necessarily synthetic. These tests document and lock in the *behavior* (log +
-/// skip, no throw, no OOB access) rather than proving the mismatch is unreachable in production --
-/// that claim rests on the Key change itself, not on these tests.
-///
-/// NOT YET DONE (see package README, "Not completed" section): compiled, linked, or run. Written
-/// against the same gtest/API shape as the provided gtest_query_condition_cache.cpp.
+/// These tests exercise the defense-in-depth paths in QueryConditionCache.cpp (the log-and-skip
+/// checks kept alongside the Key fix). They cannot currently trigger a *genuine* Key-hash collision
+/// (SipHash64 over table_id + part_name + condition_hash + marks_count + has_final_mark is not
+/// practically collidable in a unit test), so "mismatch" here is necessarily synthetic. These tests
+/// document and lock in the *behavior* (log + skip, no throw, no OOB access) rather than proving the
+/// mismatch is unreachable in production -- that claim rests on the Key change itself, not on these
+/// tests.
 
 #include <Interpreters/Cache/QueryConditionCache.h>
 #include <base/UUID.h>
@@ -17,36 +15,6 @@
 #include <vector>
 
 using namespace DB;
-
-/// Baseline from the provided test file, reproduced here so this file is runnable standalone.
-/// This is the primary regression test for the actual fix: two different mark layouts under the
-/// same table_id/part_name/condition_hash must be kept as distinct cache entries.
-TEST(QueryConditionCache, KeepsEntriesWithDifferentMarkLayoutsSeparate_DuplicateFromProvidedFile)
-{
-    QueryConditionCache cache("LRU", 1_MiB, 0.5);
-    const UUID table_id(1);
-    const String part_name = "part";
-    constexpr UInt64 condition_hash = 42;
-
-    MarkRanges one_mark;
-    one_mark.emplace_back(0, 1);
-    cache.write(table_id, part_name, condition_hash, "", one_mark, 1, false);
-
-    MarkRanges two_marks;
-    two_marks.emplace_back(1, 2);
-    cache.write(table_id, part_name, condition_hash, "", two_marks, 2, false);
-
-    auto first_layout = cache.read(table_id, part_name, condition_hash, 1, false);
-    ASSERT_TRUE(first_layout);
-    ASSERT_EQ(first_layout->size(), 1);
-    EXPECT_FALSE((*first_layout)[0]);
-
-    auto second_layout = cache.read(table_id, part_name, condition_hash, 2, false);
-    ASSERT_TRUE(second_layout);
-    ASSERT_EQ(second_layout->size(), 2);
-    EXPECT_TRUE((*second_layout)[0]);
-    EXPECT_FALSE((*second_layout)[1]);
-}
 
 /// A part_name reused with a completely different mark count (simulating the part-lifecycle
 /// scenario this issue hypothesizes -- e.g. a part name recycled after data changed underneath it)
@@ -74,6 +42,12 @@ TEST(QueryConditionCache, ReusedPartNameWithFinalMarkDoesNotThrowOrCorrupt)
     auto small_layout = cache.read(table_id, part_name, condition_hash, 3, false);
     ASSERT_TRUE(small_layout);
     ASSERT_EQ(small_layout->size(), 3);
+    /// small_ranges = [0, 3) covers the whole entry, so every mark must have been forced to false
+    /// ("must scan"); a corrupted entry (e.g. bleeding over from the differently-shaped large write)
+    /// could instead leave marks at their initial true default or some other value.
+    EXPECT_FALSE((*small_layout)[0]);
+    EXPECT_FALSE((*small_layout)[1]);
+    EXPECT_FALSE((*small_layout)[2]);
 
     auto large_layout = cache.read(table_id, part_name, condition_hash, 100, true);
     ASSERT_TRUE(large_layout);

--- a/src/Interpreters/Cache/tests/gtest_query_condition_cache_defense_in_depth.cpp
+++ b/src/Interpreters/Cache/tests/gtest_query_condition_cache_defense_in_depth.cpp
@@ -1,0 +1,116 @@
+/// TODO(#2342): These tests exercise the defense-in-depth paths added in QueryConditionCache.patched.cpp.
+/// They cannot currently trigger a *genuine* Key-hash collision (SipHash64 over table_id + part_name +
+/// condition_hash + marks_count + has_final_mark is not practically collidable in a unit test), so
+/// "mismatch" here is necessarily synthetic. These tests document and lock in the *behavior* (log +
+/// skip, no throw, no OOB access) rather than proving the mismatch is unreachable in production --
+/// that claim rests on the Key change itself, not on these tests.
+///
+/// NOT YET DONE (see package README, "Not completed" section): compiled, linked, or run. Written
+/// against the same gtest/API shape as the provided gtest_query_condition_cache.cpp.
+
+#include <Interpreters/Cache/QueryConditionCache.h>
+#include <base/UUID.h>
+#include <base/unit.h>
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+using namespace DB;
+
+/// Baseline from the provided test file, reproduced here so this file is runnable standalone.
+/// This is the primary regression test for the actual fix: two different mark layouts under the
+/// same table_id/part_name/condition_hash must be kept as distinct cache entries.
+TEST(QueryConditionCache, KeepsEntriesWithDifferentMarkLayoutsSeparate_DuplicateFromProvidedFile)
+{
+    QueryConditionCache cache("LRU", 1_MiB, 0.5);
+    const UUID table_id(1);
+    const String part_name = "part";
+    constexpr UInt64 condition_hash = 42;
+
+    MarkRanges one_mark;
+    one_mark.emplace_back(0, 1);
+    cache.write(table_id, part_name, condition_hash, "", one_mark, 1, false);
+
+    MarkRanges two_marks;
+    two_marks.emplace_back(1, 2);
+    cache.write(table_id, part_name, condition_hash, "", two_marks, 2, false);
+
+    auto first_layout = cache.read(table_id, part_name, condition_hash, 1, false);
+    ASSERT_TRUE(first_layout);
+    ASSERT_EQ(first_layout->size(), 1);
+    EXPECT_FALSE((*first_layout)[0]);
+
+    auto second_layout = cache.read(table_id, part_name, condition_hash, 2, false);
+    ASSERT_TRUE(second_layout);
+    ASSERT_EQ(second_layout->size(), 2);
+    EXPECT_TRUE((*second_layout)[0]);
+    EXPECT_FALSE((*second_layout)[1]);
+}
+
+/// A part_name reused with a completely different mark count (simulating the part-lifecycle
+/// scenario this issue hypothesizes -- e.g. a part name recycled after data changed underneath it)
+/// must not throw and must not corrupt either entry. With the Key fix this is definitionally two
+/// separate keys, so this mostly re-confirms the same property as the test above from a different
+/// angle (larger layout difference, has_final_mark also varied).
+TEST(QueryConditionCache, ReusedPartNameWithFinalMarkDoesNotThrowOrCorrupt)
+{
+    QueryConditionCache cache("LRU", 1_MiB, 0.5);
+    const UUID table_id(1);
+    const String part_name = "reused_part";
+    constexpr UInt64 condition_hash = 7;
+
+    MarkRanges small_ranges;
+    small_ranges.emplace_back(0, 3);
+    EXPECT_NO_THROW(cache.write(table_id, part_name, condition_hash, "", small_ranges, 3, false));
+
+    /// Simulates the same part_name later associated with a much larger, differently-shaped part
+    /// (e.g. after a merge or mutation), including a final mark this time.
+    MarkRanges large_ranges;
+    large_ranges.emplace_back(0, 50);
+    large_ranges.emplace_back(60, 99);
+    EXPECT_NO_THROW(cache.write(table_id, part_name, condition_hash, "", large_ranges, 100, true));
+
+    auto small_layout = cache.read(table_id, part_name, condition_hash, 3, false);
+    ASSERT_TRUE(small_layout);
+    ASSERT_EQ(small_layout->size(), 3);
+
+    auto large_layout = cache.read(table_id, part_name, condition_hash, 100, true);
+    ASSERT_TRUE(large_layout);
+    ASSERT_EQ(large_layout->size(), 100);
+    /// has_final_mark=true means marks_count-1 (index 99) must be forced to false (i.e. "must scan").
+    EXPECT_FALSE((*large_layout)[99]);
+}
+
+/// Concurrent-scan case referenced in the Entry class comment (*): multiple threads writing
+/// overlapping/adjacent ranges for the same key must not race or corrupt the entry. This does not
+/// specifically target #2342, but is adjacent: the ticket raises prefer_localhost_replica's effect
+/// on crash rate as unexplained by the layout-mismatch fix alone, and increased local-read
+/// concurrency against this cache is one candidate mechanism worth having coverage for.
+TEST(QueryConditionCache, ConcurrentWritesToSameKeyDoNotCorruptEntry)
+{
+    QueryConditionCache cache("LRU", 1_MiB, 0.5);
+    const UUID table_id(2);
+    const String part_name = "concurrent_part";
+    constexpr UInt64 condition_hash = 99;
+    constexpr size_t marks_count = 1000;
+
+    std::vector<std::thread> threads;
+    for (size_t t = 0; t < 8; ++t)
+    {
+        threads.emplace_back([&, t]()
+        {
+            MarkRanges ranges;
+            ranges.emplace_back(t * 100, (t + 1) * 100);
+            cache.write(table_id, part_name, condition_hash, "", ranges, marks_count, false);
+        });
+    }
+    for (auto & th : threads)
+        th.join();
+
+    auto result = cache.read(table_id, part_name, condition_hash, marks_count, false);
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->size(), marks_count);
+    for (size_t i = 0; i < 800; ++i)
+        EXPECT_FALSE((*result)[i]) << "mark " << i << " should have been marked non-matching";
+}

--- a/src/Processors/Transforms/FilterTransform.cpp
+++ b/src/Processors/Transforms/FilterTransform.cpp
@@ -296,10 +296,17 @@ void FilterTransform::writeIntoQueryConditionCache(const MarkRangesInfoPtr & mar
     }
     else
     {
-        /// If the current and the buffer mark range info are from the same table/part, append to the buffer.
-        /// Otherwise write to the query condition cache and reset the buffer.
+        /// If the current and the buffer mark range info are from the same table/part and have the
+        /// same mark layout, append to the buffer. Otherwise write to the query condition cache and
+        /// reset the buffer. Comparing only table_uuid/part_name is not enough: a part_name can be
+        /// reused with a different mark layout (marks_count/has_final_mark), and appending ranges
+        /// computed against a different layout into the same buffer would corrupt it (see
+        /// Altinity/ClickHouse#2342).
 
-        if (buffered_mark_ranges_info->table_uuid != mark_ranges_info->table_uuid || buffered_mark_ranges_info->part_name != mark_ranges_info->part_name)
+        if (buffered_mark_ranges_info->table_uuid != mark_ranges_info->table_uuid
+            || buffered_mark_ranges_info->part_name != mark_ranges_info->part_name
+            || buffered_mark_ranges_info->marks_count != mark_ranges_info->marks_count
+            || buffered_mark_ranges_info->has_final_mark != mark_ranges_info->has_final_mark)
         {
             query_condition_cache->write(
                 buffered_mark_ranges_info->table_uuid,

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1092,7 +1092,12 @@ void MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache(
 
             const auto & data_part = part_with_ranges.data_part;
             auto storage_id = data_part->storage.getStorageID();
-            auto matching_marks_opt = query_condition_cache->read(storage_id.uuid, data_part->name, condition_hash);
+            auto matching_marks_opt = query_condition_cache->read(
+                storage_id.uuid,
+                data_part->name,
+                condition_hash,
+                data_part->index_granularity->getMarksCount(),
+                data_part->index_granularity->hasFinalMark());
             if (!matching_marks_opt)
             {
                 ++it;

--- a/src/Storages/System/StorageSystemQueryConditionCache.cpp
+++ b/src/Storages/System/StorageSystemQueryConditionCache.cpp
@@ -19,7 +19,9 @@ ColumnsDescription StorageSystemQueryConditionCache::getColumnsDescription()
         {"condition", std::make_shared<DataTypeString>(), "The hashed filter condition. Only set if setting query_condition_cache_store_conditions_as_plaintext = true."},
         {"condition_hash", std::make_shared<DataTypeUInt64>(), "The hash of the filter condition."},
         {"entry_size", std::make_shared<DataTypeUInt64>(), "The size of the entry in bytes."},
-        {"matching_marks", std::make_shared<DataTypeString>(), "Matching marks."}
+        {"matching_marks", std::make_shared<DataTypeString>(), "Matching marks."},
+        {"marks_count", std::make_shared<DataTypeUInt64>(), "The number of marks in the part this entry was cached for."},
+        {"has_final_mark", std::make_shared<DataTypeUInt8>(), "Whether the part this entry was cached for has a final mark."}
     };
 }
 
@@ -55,6 +57,8 @@ void StorageSystemQueryConditionCache::fillData(MutableColumns & res_columns, Co
 
         std::shared_lock lock(entry->mutex);
         res_columns[5]->insert(to_string(entry->matching_marks));
+        res_columns[6]->insert(key.marks_count);
+        res_columns[7]->insert(key.has_final_mark);
     }
 }
 


### PR DESCRIPTION
**Root-cause fix, validated: `QueryConditionCache` key missing mark layout**

Following up on the crash trace package (708 rows across a 14-node production cluster) and the direct `QueryConditionCache::write` faults reported in #2342.

## Mechanism

`QueryConditionCache::Key` was `{table_id, part_name, condition_hash}`. A part name can be reused after the underlying part's mark layout changes (exact lifecycle path not confirmed — see Open Items). `write()`'s `cache.getOrSet(key, load_func)` can then return a pre-existing `Entry` sized for the *old* layout, which the code proceeds to index using the *current* task's `marks_count`/`mark_ranges`:

```cpp
std::fill(entry->matching_marks.begin() + mark_range.begin,
          entry->matching_marks.begin() + mark_range.end, false);
...
entry->matching_marks[marks_count - 1] = false;
```

On `std::vector<bool>`'s bit-packed storage, this is an out-of-bounds **write**, not a read.

**Note:** this branch was built starting from the actual `v25.8.28.10001.altinitystable` production tag, not a later revision — the Key fix below was not yet present there and had to be derived from scratch as part of this work, alongside the defense-in-depth hardening.

## Fix

1. `Key` now includes `marks_count` and `has_final_mark` — two different layouts are structurally two different cache entries, so `getOrSet()` can no longer return a mismatched `Entry`.
2. The size-mismatch checks (write, shared-lock path; write, exclusive-lock path; read; plus final-mark/zero-marks and mark-range-bounds validation) are `LOG_ERROR` + skip rather than `throw`, so a residual mismatch degrades to "don't use the cache for this entry" instead of failing the user's query — with `chassert` retained alongside each, so debug/CI builds still catch a regression. A new `QueryConditionCacheLayoutMismatch` ProfileEvent surfaces if any of these ever fire.
3. `FilterTransform`'s buffered-write flush comparison now also checks `marks_count`/`has_final_mark` (not just `table_uuid`/`part_name`) — this was a second, independent path where a differently-shaped part could otherwise be merged into a stale buffer before ever reaching `write()`.
4. `system.query_condition_cache` now exposes `marks_count`/`has_final_mark` so entries that previously looked like indistinguishable duplicates are distinguishable.
5. gtest coverage for layout separation, invalid ranges, reused-part-name-with-different-layout, and concurrent writes.

## Validation performed

- **Write-path `marks_count`/`has_final_mark` derivation vs. read path — confirmed matching.** All 4 real `write()` call sites (`FilterTransform.cpp` WHERE path, `MergeTreeSelectProcessor.cpp` PREWHERE path) derive these from the same live `data_part->index_granularity` object the read path (`MergeTreeDataSelectExecutor.cpp`) uses — not a stale copy. Confirmed by static tracing and by a live smoke test: `QueryConditionCacheHits` > 0 on repeated queries, confirming the fix doesn't silently zero out the cache hit rate.
- **gtests: 4/4 pass**, built and run against a real compiled binary.
- **Full release build succeeded** with this commit's own pinned toolchain (clang 19.1.7, rust nightly-2025-07-07) after fixing an unrelated, external issue (a stale LLVM apt signing-key hash that no longer matched what `apt.llvm.org` currently serves — a local build-environment fix, not part of this patch).
- **A working Docker image was built and smoke-tested**: boots, answers queries, cache-hit-rate/no-regression check passes; a best-effort attempt to reproduce the original part-name-reuse trigger via `ALTER ... DELETE` + `ALTER ... UPDATE` was inconclusive (no crash, but the mutation produced a new part name rather than reusing the original in place, so this likely didn't exercise the actual original trigger).
- This PR went through an internal final-review pass (11 findings fixed: a misplaced `namespace ErrorCodes`, two throws this branch had added that should have been log-and-skip like the rest, missing `chassert`s, a metric double-counting bug, the `FilterTransform` gap in item 3 above, stale test comments/duplicate test, file permissions, wording, and doc-comment updates).

## Newly discovered issue — separate from this fix, reported for visibility

While verifying that the write path's cache-population *exclusions* mirror the read path's guard (`!isFinal() && !mutations_snapshot->hasDataMutations()/hasPatchParts() && !vector_search`), a real, independently-verified gap was found: the write path does **not** fully mirror the read path's guard.

- The two PREWHERE write call sites (`MergeTreeSelectProcessor.cpp`) have zero parity with the read-path guard — `isFinal()`, in-flight mutations/patch parts, and vector search are all unchecked before writing.
- The two WHERE write call sites (`FilterTransform.cpp`) correctly guard `isFinal()`, but not mutations/patch parts or vector search.

Consequence: a query the read path would refuse to consult the cache for can still populate a cache entry via these write paths, and a later "plain" query can read back results computed under different semantics — a silent wrong-results correctness bug, not a crash, and orthogonal to the Key fix above. **This is a distinct issue from #2342 and is not fixed by this PR** — flagging for a separate follow-up.

## Still not resolved, flagged honestly

- Does not explain why `prefer_localhost_replica = 0` independently reduced the crash rate ~19x before the cache was touched. Possible secondary factor: local-read concurrency increasing concurrent `write()` calls against the same `Entry` — out of scope for this PR.
- The exact part-lifecycle sequence that reuses a part name with a different mark layout is still not confirmed live. The Key fix makes this class of bug structurally impossible regardless of the exact trigger, but the trigger itself was not reproduced.

Confidence: high that this closes a concrete cache-owned OOB-write path. Not a claim this was the first or only corruption site in the original crash traces, nor that the `prefer_localhost_replica` question or the newly-discovered write-path exclusion gap are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NAYye5ozisLN7WBqzYfAn